### PR TITLE
Fix Windows UnicodeDecodeError when reading README in status/next/scan

### DIFF
--- a/desloppify/commands/scan.py
+++ b/desloppify/commands/scan.py
@@ -313,7 +313,9 @@ def cmd_scan(args):
                 readme_path = PROJECT_ROOT / readme_name
                 if readme_path.exists():
                     try:
-                        if rel_path in readme_path.read_text():
+                        if rel_path in readme_path.read_text(
+                            encoding="utf-8", errors="replace"
+                        ):
                             readme_has_badge = True
                     except OSError:
                         pass
@@ -558,5 +560,4 @@ def _show_low_dimension_hints(dim_scores: dict):
     for name, score, hint in low:
         print(colorize(f"    {name} ({score:.0f}%) — {hint}", "yellow"))
     print()
-
 

--- a/desloppify/narrative/core.py
+++ b/desloppify/narrative/core.py
@@ -52,7 +52,9 @@ def _compute_badge_status() -> dict:
             readme_path = PROJECT_ROOT / readme_name
             if readme_path.exists():
                 try:
-                    in_readme = "scorecard.png" in readme_path.read_text()
+                    in_readme = "scorecard.png" in readme_path.read_text(
+                        encoding="utf-8", errors="replace"
+                    )
                 except OSError:
                     pass
                 break


### PR DESCRIPTION
Hey Peter,

I ran the desloppify for fun against a C# / .NET repo of mine which ran into errors on my Windows encoded readme file.

On Windows with a cp1252 default text encoding, reading README.md could raise UnicodeDecodeError and crash `desloppify status`, `desloppify next`, and `desloppify scan` unless PYTHONUTF8=1 was set.

The fixes are pretty straightfoward and only involve 2 command parameters.