### PR TITLE
Fix dupes hangs from venv scans and path-unaware language detection

### DIFF
--- a/desloppify/detectors/dupes.py
+++ b/desloppify/detectors/dupes.py
@@ -5,6 +5,9 @@ Each entry contains a representative pair for display plus the full cluster memb
 """
 
 import difflib
+import os
+import sys
+import time
 
 
 def _build_clusters(pairs: list[tuple[int, int, float, str]],
@@ -48,6 +51,8 @@ def detect_duplicates(functions, threshold: float = 0.9) -> tuple[list[dict], in
     n = len(functions)
     if not functions:
         return [], 0
+    debug = os.getenv("DESLOPPIFY_DUPES_DEBUG", "").lower() in {"1", "true", "yes", "on"}
+    debug_every = int(os.getenv("DESLOPPIFY_DUPES_DEBUG_EVERY", "100") or "100")
 
     # Phase 1: Exact duplicates (same hash)
     by_hash: dict[str, list[int]] = {}
@@ -70,6 +75,20 @@ def detect_duplicates(functions, threshold: float = 0.9) -> tuple[list[dict], in
     # Phase 2: Near-duplicates (difflib similarity on functions >= 15 LOC)
     large_idx = [(idx, fn) for idx, fn in enumerate(functions) if fn.loc >= 15]
     large_idx.sort(key=lambda x: x[1].loc)
+    normalized_lines = [fn.normalized.splitlines() for fn in functions]
+    normalized_lengths = [len(fn.normalized) for fn in functions]
+
+    near_candidates = 0
+    near_ratio_calls = 0
+    near_pruned_by_length = 0
+    near_start = time.perf_counter()
+
+    if debug:
+        print(
+            f"[dupes] start near pass: total_functions={n} "
+            f"candidates_by_loc={len(large_idx)} threshold={threshold:.2f}",
+            file=sys.stderr,
+        )
 
     for i_pos in range(len(large_idx)):
         for j_pos in range(i_pos + 1, len(large_idx)):
@@ -77,16 +96,58 @@ def detect_duplicates(functions, threshold: float = 0.9) -> tuple[list[dict], in
             idx_b, fb = large_idx[j_pos]
             if fb.loc > fa.loc * 1.5:
                 break
+            near_candidates += 1
             pair_key = (f"{fa.file}:{fa.name}", f"{fb.file}:{fb.name}")
             if pair_key in seen_pairs:
                 continue
             if fa.body_hash == fb.body_hash:
                 continue
 
-            ratio = difflib.SequenceMatcher(None, fa.normalized, fb.normalized).ratio()
+            # Upper bound on SequenceMatcher.ratio based on sequence lengths:
+            # ratio = 2*M/(len_a+len_b) and M <= min(len_a, len_b).
+            len_a = normalized_lengths[idx_a]
+            len_b = normalized_lengths[idx_b]
+            if len_a and len_b:
+                max_possible = (2 * min(len_a, len_b)) / (len_a + len_b)
+                if max_possible < threshold:
+                    near_pruned_by_length += 1
+                    continue
+
+            matcher = difflib.SequenceMatcher(
+                None,
+                normalized_lines[idx_a],
+                normalized_lines[idx_b],
+                autojunk=False,
+            )
+            # Cheap similarity bounds before full ratio().
+            if matcher.real_quick_ratio() < threshold:
+                continue
+            if matcher.quick_ratio() < threshold:
+                continue
+
+            near_ratio_calls += 1
+            ratio = matcher.ratio()
             if ratio >= threshold:
                 seen_pairs.add(pair_key)
                 pairs.append((idx_a, idx_b, ratio, "near-duplicate"))
+
+        if debug and i_pos and i_pos % debug_every == 0:
+            elapsed = time.perf_counter() - near_start
+            print(
+                f"[dupes] progress i={i_pos}/{len(large_idx)} "
+                f"candidate_pairs={near_candidates} ratio_calls={near_ratio_calls} "
+                f"matches={len(pairs)} elapsed={elapsed:.2f}s",
+                file=sys.stderr,
+            )
+
+    if debug:
+        elapsed = time.perf_counter() - near_start
+        print(
+            f"[dupes] done near pass: candidate_pairs={near_candidates} "
+            f"ratio_calls={near_ratio_calls} pruned_by_length={near_pruned_by_length} "
+            f"matches={len(pairs)} elapsed={elapsed:.2f}s",
+            file=sys.stderr,
+        )
 
     # Cluster: group connected functions so N similar → 1 entry (not N^2/2)
     clusters = _build_clusters(pairs, n)

--- a/desloppify/utils.py
+++ b/desloppify/utils.py
@@ -271,6 +271,8 @@ def _is_excluded_dir(name: str, rel_path: str, extra: tuple[str, ...]) -> bool:
     """Check if a directory should be pruned during traversal."""
     if name in DEFAULT_EXCLUSIONS or name.endswith(".egg-info"):
         return True
+    if name.startswith(".venv") or name.startswith("venv"):
+        return True
     if extra and any(matches_exclusion(rel_path, ex) or ex == name for ex in extra):
         return True
     return False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
-from desloppify.commands._helpers import _write_query
+from desloppify.commands._helpers import _write_query, resolve_lang
 from desloppify.cli import (
     DETECTOR_NAMES,
     _apply_persisted_exclusions,
@@ -244,6 +244,57 @@ class TestStatePath:
         args = SimpleNamespace(state="/tmp/override.json", lang="python")
         result = state_path(args)
         assert result == Path("/tmp/override.json")
+
+
+class TestResolveLang:
+    def test_prefers_explicit_lang(self):
+        args = SimpleNamespace(lang="python", path="/tmp/somewhere")
+        lang = resolve_lang(args)
+        assert lang is not None
+        assert lang.name == "python"
+
+    def test_auto_detect_uses_path_when_it_looks_like_project_root(self, tmp_path, monkeypatch):
+        from desloppify.commands import _helpers as helpers_mod
+
+        # CWD-style project root is python.
+        cwd_root = tmp_path / "cwd_project"
+        cwd_root.mkdir()
+        (cwd_root / "pyproject.toml").write_text("[tool.pytest]\n")
+        py_src = cwd_root / "src"
+        py_src.mkdir()
+        (py_src / "main.py").write_text("print('x')\n")
+
+        # Target --path root is typescript.
+        target_root = tmp_path / "target_project"
+        target_root.mkdir()
+        (target_root / "package.json").write_text('{"name": "target"}\n')
+        ts_src = target_root / "src"
+        ts_src.mkdir()
+        (ts_src / "index.ts").write_text("export const x = 1\n")
+
+        monkeypatch.setattr(helpers_mod, "PROJECT_ROOT", cwd_root)
+        monkeypatch.setattr("desloppify.utils.PROJECT_ROOT", cwd_root)
+        args = SimpleNamespace(lang=None, path=str(target_root))
+        lang = resolve_lang(args)
+        assert lang is not None
+        assert lang.name == "typescript"
+
+    def test_auto_detect_falls_back_to_project_root_for_subdir_path(self, tmp_path, monkeypatch):
+        from desloppify.commands import _helpers as helpers_mod
+
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / "pyproject.toml").write_text("[tool.pytest]\n")
+        src = root / "src"
+        src.mkdir()
+        (src / "main.py").write_text("print('x')\n")
+
+        monkeypatch.setattr(helpers_mod, "PROJECT_ROOT", root)
+        monkeypatch.setattr("desloppify.utils.PROJECT_ROOT", root)
+        args = SimpleNamespace(lang=None, path=str(src))
+        lang = resolve_lang(args)
+        assert lang is not None
+        assert lang.name == "python"
 
 
 # ===========================================================================

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -153,6 +153,27 @@ def test_find_source_files_with_explicit_exclusion(tmp_path, monkeypatch):
     assert not any("generated" in f for f in files)
 
 
+def test_find_source_files_excludes_prefixed_virtualenv_dirs(tmp_path, monkeypatch):
+    """Prefixed virtualenv directories (.venv-*, venv-*) are pruned."""
+    monkeypatch.setattr(utils_mod, "PROJECT_ROOT", tmp_path)
+    utils_mod._find_source_files_cached.cache_clear()
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "keep.py").write_text("keep")
+
+    hidden_venv = src / ".venv-custom"
+    hidden_venv.mkdir()
+    (hidden_venv / "skip_hidden.py").write_text("skip")
+
+    named_venv = src / "venv-project"
+    named_venv.mkdir()
+    (named_venv / "skip_named.py").write_text("skip")
+
+    files = find_source_files(str(src), [".py"])
+    assert files == ["src/keep.py"]
+
+
 # ── set_exclusions() ─────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
This PR fixes two root causes behind very slow `dupes` runs and misleading language selection when scanning from outside a target repo.

### 1) Duplicate detection performance
- Added optional debug instrumentation for near-duplicate pass:
  - `DESLOPPIFY_DUPES_DEBUG=1`
  - `DESLOPPIFY_DUPES_DEBUG_EVERY=<N>`
- Added multiple prefilters before full `SequenceMatcher.ratio()`:
  - length-based theoretical max similarity bound
  - `real_quick_ratio()` gate
  - `quick_ratio()` gate
- Switched near-duplicate comparison to line-sequence matching with `autojunk=False`.

### 2) Virtualenv over-scanning
- File discovery now prunes prefixed virtualenv directories such as:
  - `.venv-*`
  - `venv-*`
- This prevents site-packages in custom venv folder names (e.g. `.venv-desloppify`) from polluting scan candidates.

### 3) `--path`-aware language auto-detection
- `resolve_lang()` and `state_path()` now use a shared auto-detection helper that:
  - prefers `--path` when it looks like a project root (contains language config markers)
  - falls back to `PROJECT_ROOT` when `--path` is a subdir like `src/`
- This avoids incorrect language selection when invoking `desloppify` from another checkout while scanning a target repo via `--path`.

## Tests
Added/updated tests:
- `tests/test_dupes.py`
  - validates length-bound pruning skips matcher creation for impossible pairs
- `tests/test_utils.py`
  - validates `.venv-*` and `venv-*` directories are excluded from file discovery
- `tests/test_cli.py`
  - validates `resolve_lang()` path-aware detection and fallback behavior

Ran:
- `pytest tests/test_dupes.py tests/test_utils.py tests/test_cli.py tests/test_cmd_detect.py -q`

## Repro verification (local)
- `desloppify detect dupes --path /Users/peteromalley/Documents/reigh --threshold 0.9`
  - auto-detected TypeScript
  - completed in ~1.3s in this repro
- `desloppify --lang python detect dupes --path /Users/peteromalley/Documents/reigh`
  - no longer crawls `.venv-desloppify` site-packages
