### PR TITLE
feat: add opencode skill support

### DIFF
--- a/desloppify/app/cli_support/parser_groups_admin.py
+++ b/desloppify/app/cli_support/parser_groups_admin.py
@@ -284,8 +284,7 @@ def _add_review_parser(sub) -> None:
         type=int,
         default=3,
         help=(
-            "Max concurrent subagent batches when --parallel is enabled "
-            "(default: 3)"
+            "Max concurrent subagent batches when --parallel is enabled (default: 3)"
         ),
     )
     p_review.add_argument(
@@ -299,8 +298,7 @@ def _add_review_parser(sub) -> None:
         type=int,
         default=1,
         help=(
-            "Retries per failed batch for transient runner/network errors "
-            "(default: 1)"
+            "Retries per failed batch for transient runner/network errors (default: 1)"
         ),
     )
     p_review.add_argument(
@@ -308,8 +306,7 @@ def _add_review_parser(sub) -> None:
         type=float,
         default=2.0,
         help=(
-            "Base backoff delay for transient batch retries in seconds "
-            "(default: 2.0)"
+            "Base backoff delay for transient batch retries in seconds (default: 2.0)"
         ),
     )
     p_review.add_argument(
@@ -535,7 +532,9 @@ def _add_dev_parser(sub) -> None:
 
 
 def _add_langs_parser(sub) -> None:
-    sub.add_parser("langs", help="List all available language plugins with depth and tools")
+    sub.add_parser(
+        "langs", help="List all available language plugins with depth and tools"
+    )
 
 
 def _add_update_skill_parser(sub) -> None:
@@ -547,6 +546,6 @@ def _add_update_skill_parser(sub) -> None:
         "interface",
         nargs="?",
         default=None,
-        help="Agent interface (claude, codex, cursor, copilot, windsurf, gemini). "
+        help="Agent interface (claude, codex, cursor, copilot, windsurf, gemini, opencode). "
         "Auto-detected on updates if omitted.",
     )

--- a/desloppify/utils.py
+++ b/desloppify/utils.py
@@ -121,6 +121,7 @@ SKILL_TARGETS: dict[str, tuple[str, str, bool]] = {
     "copilot": (".github/copilot-instructions.md", "COPILOT", False),
     "windsurf": ("AGENTS.md", "WINDSURF", False),
     "gemini": ("AGENTS.md", "GEMINI", False),
+    "opencode": (".opencode/skills/desloppify/SKILL.md", "OPENCODE", True),
 }
 
 

--- a/docs/OPENCODE.md
+++ b/docs/OPENCODE.md
@@ -1,0 +1,43 @@
+## OpenCode Overlay
+
+Use the desloppify skill for codebase health scanning and technical debt tracking.
+
+### Running Commands
+
+Execute desloppify commands via the Bash tool:
+
+```bash
+desloppify scan --path .
+desloppify status
+desloppify next --count 5
+desloppify show <pattern>
+desloppify fix <fixer>
+desloppify resolve fixed "<id>"
+```
+
+### Skill Integration
+
+When this skill is installed (via `desloppify update-skill opencode`), OpenCode will automatically load the desloppify skill and use it when you ask about:
+- Code quality issues
+- Technical debt
+- Health scores
+- What to fix next
+- Creating a cleanup plan
+
+### Core Workflow
+
+1. `desloppify scan --path .` — run scan, follow INSTRUCTIONS FOR AGENTS
+2. Fix recommended issues
+3. `desloppify resolve fixed "<id>"`
+4. Rescan to verify
+
+### Subjective Reviews
+
+For subjective scoring, use OpenCode's subagent system:
+1. Read `dimension_prompts` from `query.json`
+2. Delegate to subagent for isolated scoring
+3. Import findings: `desloppify review --import findings.json`
+4. Fix via core loop
+
+<!-- desloppify-overlay: opencode -->
+<!-- desloppify-end -->


### PR DESCRIPTION
## Summary

- Add 'opencode' to SKILL_TARGETS in utils.py for `desloppify update-skill opencode` command
- Add opencode to CLI help text in parser_groups_admin.py  
- Add docs/OPENCODE.md overlay with OpenCode-specific guidance

This enables OpenCode users to install the desloppify skill via:
```bash
desloppify update-skill opencode
```

The skill will be installed to `.opencode/skills/desloppify/SKILL.md` relative to where the command is run (or globally when run from home).