### PR TITLE
fix(release): resolve full extra drift and prevent recurrence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,8 @@ package-smoke: install-ci-tools
 	. .pkg-smoke/bin/activate && \
 		python -m pip install --upgrade pip && \
 		WHEEL=$$(ls -t dist/desloppify-*.whl | head -n 1) && \
-		python -m pip install "$$WHEEL" && \
+		python -m pip install "$$WHEEL[full]" && \
+		python -c "import importlib.metadata as m,sys; extras=set(m.metadata('desloppify').get_all('Provides-Extra') or []); required={'full','treesitter','python-security','scorecard'}; missing=required-extras; print('missing extras metadata:', sorted(missing)) if missing else None; sys.exit(1 if missing else 0)" && \
 		desloppify --help > /dev/null
 	rm -rf .pkg-smoke
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "desloppify"
-version = "0.7.6"
+version = "0.7.7"
 description = "Multi-language codebase health scanner and technical debt tracker"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- bump package version to `0.7.7`
- harden `package-smoke` to install built wheel with `[full]` and assert extras metadata exists
- add CI contract tests ensuring README extras are defined in `pyproject.toml` and `[full]` remains a superset

## Why
Fixes #149 and adds a guard so README/package extras drift is caught in CI before release.

## Validation
- `pytest -q desloppify/tests/ci/test_ci_contracts.py`
- `make package-smoke`
