### PR TITLE
feat: per-language scorecards for mixed-language repositories

### DIFF
--- a/desloppify/app/cli_support/parser_groups.py
+++ b/desloppify/app/cli_support/parser_groups.py
@@ -92,12 +92,28 @@ examples:
         metavar="KEY=VALUE",
         help="Language runtime option override (repeatable, e.g. --lang-opt roslyn_cmd='dotnet run ...')",
     )
+    p_scan.add_argument(
+        "--by-language",
+        action="store_true",
+        default=False,
+        help=(
+            "Generate per-language score sections and scorecard images "
+            "(e.g. scorecard-go.png, scorecard-python.png). "
+            "Requires >=2 detected languages."
+        ),
+    )
 
 
 def _add_status_parser(sub) -> None:
     p_status = sub.add_parser("status", help="Score dashboard with per-tier progress")
     p_status.add_argument("--state", type=str, default=None, help="Path to state file")
     p_status.add_argument("--json", action="store_true", help="Output as JSON")
+    p_status.add_argument(
+        "--by-language",
+        action="store_true",
+        default=False,
+        help="Show per-language score breakdown (requires a prior --by-language scan).",
+    )
 
 
 def _add_tree_parser(sub) -> None:

--- a/desloppify/app/commands/scan/scan.py
+++ b/desloppify/app/commands/scan/scan.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 
 from desloppify.app.commands.helpers.lang import resolve_lang
 from desloppify.app.commands.helpers.query import query_file_path
@@ -26,6 +27,9 @@ from desloppify.app.commands.scan.scan_helpers import (  # noqa: F401 (re-export
 from desloppify.app.commands.scan.scan_reporting_analysis import (
     show_post_scan_analysis,
 )
+from desloppify.app.commands.scan.scan_reporting_by_language import (
+    show_per_language_score_blocks,
+)
 from desloppify.app.commands.scan.scan_reporting_dimensions import (
     show_dimension_deltas,
     show_score_model_breakdown,
@@ -43,6 +47,7 @@ from desloppify.app.commands.scan.scan_reporting_summary import (  # noqa: F401
 from desloppify.app.commands.scan.scan_orchestrator import ScanOrchestrator
 from desloppify.app.commands.scan.scan_workflow import (
     ScanStateContractError,
+    ScanRuntime,
     merge_scan_results,
     persist_reminder_history,
     prepare_scan_runtime,
@@ -56,6 +61,120 @@ from desloppify.core.output_api import colorize
 def _print_scan_header(lang_label: str) -> None:
     """Print the scan header line."""
     print(colorize(f"\nDesloppify Scan{lang_label}\n", "bold"))
+
+
+def _compute_per_language_dimension_scores(
+    runtime: ScanRuntime,
+    lang_names: list[str],
+    *,
+    target_score: float,
+) -> dict[str, dict]:
+    """Run scan generation per language and compute per-language dimension scores.
+
+    Returns a dict ``{lang_name: dim_scores}`` where *dim_scores* is the
+    ``dimension_scores`` dict produced by a temporary single-language merge.
+    The temporary state used for scoring is discarded; only the
+    ``dimension_scores`` are returned.
+    """
+    from desloppify import state as state_mod
+    from desloppify.languages._framework.resolution import get_lang
+    from desloppify.languages._framework.runtime import LangRunOverrides, make_lang_run
+    from desloppify.app.commands.helpers.lang import resolve_lang_settings
+
+    results: dict[str, dict] = {}
+
+    for lang_name in lang_names:
+        try:
+            lang_cfg = get_lang(lang_name)
+        except (ValueError, ImportError):
+            continue
+
+        lang_settings = resolve_lang_settings(runtime.config, lang_cfg)
+        try:
+            lang_run = make_lang_run(
+                lang_cfg,
+                overrides=LangRunOverrides(
+                    review_cache=runtime.state.get("review_cache", {}),
+                    review_max_age_days=runtime.config.get("review_max_age_days", 30),
+                    runtime_settings=lang_settings,
+                    runtime_options={},
+                    large_threshold_override=runtime.config.get("large_files_threshold", 0),
+                    props_threshold_override=runtime.config.get("props_threshold", 0),
+                ),
+            )
+        except Exception:
+            continue
+
+        lang_runtime = ScanRuntime(
+            args=runtime.args,
+            state_path=runtime.state_path,
+            state=runtime.state,
+            path=runtime.path,
+            config=runtime.config,
+            lang=lang_run,
+            lang_label=f" ({lang_name})",
+            profile=runtime.profile,
+            effective_include_slow=runtime.effective_include_slow,
+            zone_overrides=runtime.zone_overrides,
+        )
+
+        try:
+            lang_findings, lang_potentials, _ = run_scan_generation(lang_runtime)
+        except Exception:
+            continue
+
+        # Build a lightweight temporary state to compute dimension scores without
+        # touching the real persisted state.
+        temp_state: dict = {
+            "version": 1,
+            "created": state_mod.utc_now(),
+            "last_scan": None,
+            "scan_count": 0,
+            "overall_score": 0,
+            "objective_score": 0,
+            "strict_score": 0,
+            "verified_strict_score": 0,
+            "stats": {},
+            "findings": {},
+            "scan_coverage": {},
+            "score_confidence": {},
+            "subjective_integrity": {},
+            "subjective_assessments": {},
+            "scan_history": [{"lang": lang_name}],
+        }
+        state_mod.ensure_state_defaults(temp_state)
+
+        try:
+            state_mod.merge_scan(
+                temp_state,
+                lang_findings,
+                options=state_mod.MergeScanOptions(
+                    lang=lang_name,
+                    scan_path=None,
+                    force_resolve=False,
+                    exclude=[],
+                    potentials=lang_potentials,
+                    codebase_metrics=None,
+                    include_slow=runtime.effective_include_slow,
+                    ignore=runtime.config.get("ignore", []),
+                    subjective_integrity_target=target_score,
+                ),
+            )
+        except Exception:
+            continue
+
+        lang_dim_scores = dict(temp_state.get("dimension_scores", {}))
+        if lang_dim_scores:
+            # Attach aggregate scores for display
+            lang_dim_scores["_aggregate_scores"] = {
+                "overall_score": temp_state.get("overall_score"),
+                "objective_score": temp_state.get("objective_score"),
+                "strict_score": temp_state.get("strict_score"),
+                "verified_strict_score": temp_state.get("verified_strict_score"),
+            }
+            results[lang_name] = lang_dim_scores
+
+    return results
 
 
 def _print_scan_complete_banner() -> None:
@@ -191,6 +310,10 @@ def cmd_scan(args: argparse.Namespace) -> None:
         query_file=query_file_path(),
     )
 
+    by_language = getattr(args, "by_language", False)
+    if by_language:
+        _run_by_language_phase(runtime, args, target_value)
+
     badge_emit = emit_scorecard_badge(args, runtime.config, runtime.state)
     if isinstance(badge_emit, tuple):
         badge_path, _badge_result = badge_emit
@@ -198,6 +321,113 @@ def cmd_scan(args: argparse.Namespace) -> None:
         badge_path = badge_emit
     _print_llm_summary(runtime.state, badge_path, narrative, merge.diff)
     auto_update_skill()
+
+
+def _run_by_language_phase(
+    runtime: ScanRuntime,
+    args: argparse.Namespace,
+    target_value: float,
+) -> None:
+    """Compute + store per-language dimension scores, print output, emit per-lang badges."""
+    from desloppify.languages._framework.resolution import discover_repo_languages
+    from desloppify import state as state_mod
+
+    detected = discover_repo_languages(runtime.path)
+    if len(detected) < 2:
+        print(
+            colorize(
+                "  --by-language: fewer than 2 languages detected — showing aggregate only.",
+                "yellow",
+            )
+        )
+        return
+
+    lang_names = list(detected.keys())
+    print(
+        colorize(
+            f"  --by-language: {len(lang_names)} languages detected: "
+            + ", ".join(lang_names),
+            "dim",
+        )
+    )
+
+    per_lang_scores = _compute_per_language_dimension_scores(
+        runtime,
+        lang_names,
+        target_score=target_value,
+    )
+
+    if per_lang_scores:
+        runtime.state["dimension_scores_by_language"] = per_lang_scores
+        # Persist updated state with per-language data
+        state_mod.save_state(
+            runtime.state,
+            runtime.state_path,
+            subjective_integrity_target=target_value,
+        )
+        print()
+        show_per_language_score_blocks(runtime.state, show_aggregate=True)
+
+    # Generate per-language scorecard images
+    _emit_per_language_badges(args, runtime.config, runtime.state, per_lang_scores)
+
+
+def _emit_per_language_badges(
+    args: argparse.Namespace,
+    config: dict,
+    state: dict,
+    per_lang_scores: dict[str, dict],
+) -> None:
+    """Generate one scorecard PNG per language when badge generation is enabled."""
+    import importlib
+    import os
+    from pathlib import Path
+    from desloppify.core._internal.text_utils import PROJECT_ROOT
+
+    if getattr(args, "no_badge", False):
+        return
+    if not config.get("generate_scorecard", True):
+        return
+    if os.environ.get("DESLOPPIFY_NO_BADGE", "").lower() in ("1", "true", "yes"):
+        return
+
+    try:
+        scorecard_module = importlib.import_module("desloppify.app.output.scorecard")
+    except ImportError:
+        return
+
+    generate_scorecard = getattr(scorecard_module, "generate_scorecard", None)
+    if not callable(generate_scorecard):
+        return
+
+    badge_path_template = (
+        getattr(args, "badge_path", None)
+        or config.get("badge_path")
+        or os.environ.get("DESLOPPIFY_BADGE_PATH", "scorecard.png")
+    )
+
+    for lang_name, lang_dim_scores in per_lang_scores.items():
+        # Expand {lang} placeholder or insert language suffix before extension
+        template = str(badge_path_template)
+        if "{lang}" in template:
+            lang_badge_path_str = template.replace("{lang}", lang_name)
+        else:
+            stem, _, ext = template.rpartition(".")
+            lang_badge_path_str = f"{stem}-{lang_name}.{ext}" if stem else f"{template}-{lang_name}"
+
+        lang_badge_path = Path(lang_badge_path_str)
+        if not lang_badge_path.is_absolute() and not lang_badge_path.root:
+            lang_badge_path = PROJECT_ROOT / lang_badge_path
+
+        try:
+            generate_scorecard(state, lang_badge_path, language=lang_name)
+            try:
+                rel_path = str(lang_badge_path.relative_to(PROJECT_ROOT))
+            except ValueError:
+                rel_path = str(lang_badge_path)
+            print(colorize(f"  Scorecard ({lang_name}) → {rel_path}", "dim"))
+        except Exception as exc:
+            print(colorize(f"  ⚠ Could not generate {lang_name} scorecard: {exc}", "yellow"))
 
 
 __all__ = [

--- a/desloppify/app/commands/scan/scan_reporting_by_language.py
+++ b/desloppify/app/commands/scan/scan_reporting_by_language.py
@@ -1,0 +1,168 @@
+"""Per-language score reporting for mixed-language repositories."""
+
+from __future__ import annotations
+
+from desloppify.core.output_api import colorize
+
+
+def _dimension_bar(score: float, *, bar_len: int = 15) -> str:
+    """Render a compact fill bar for a score."""
+    filled = round(score / 100 * bar_len)
+    filled = max(0, min(bar_len, filled))
+    if score >= 80:
+        colour = "green"
+    elif score >= 60:
+        colour = "yellow"
+    else:
+        colour = "red"
+    return colorize("█" * filled, colour) + colorize("░" * (bar_len - filled), "dim")
+
+
+def _overall_from_dim_scores(dim_scores: dict) -> float | None:
+    """Derive a simple unweighted average from dimension scores (fallback)."""
+    values = [
+        float(v.get("score", 0))
+        for v in dim_scores.values()
+        if isinstance(v, dict) and "score" in v
+    ]
+    return round(sum(values) / len(values), 1) if values else None
+
+
+def show_per_language_score_blocks(
+    state: dict,
+    *,
+    show_aggregate: bool = True,
+) -> None:
+    """Print per-language score blocks from ``state["dimension_scores_by_language"]``.
+
+    Each language gets its own clearly-labelled block showing
+    overall/objective/strict/verified scores and mechanical + subjective
+    dimension breakdown.  The aggregate block is printed last when
+    *show_aggregate* is True.
+    """
+    by_lang: dict[str, dict] = state.get("dimension_scores_by_language") or {}
+    if not by_lang:
+        print(
+            colorize(
+                "  No per-language scores found. Run `desloppify scan --by-language` first.",
+                "yellow",
+            )
+        )
+        return
+
+    for lang_name, lang_dim_scores in sorted(by_lang.items()):
+        if not isinstance(lang_dim_scores, dict):
+            continue
+
+        lang_scores = _compute_aggregate_scores_from_dims(lang_dim_scores)
+        overall = lang_scores.get("overall", _overall_from_dim_scores(lang_dim_scores))
+        objective = lang_scores.get("objective")
+        strict = lang_scores.get("strict")
+        verified = lang_scores.get("verified")
+
+        _print_lang_block_header(lang_name)
+        _print_lang_score_summary(overall, objective, strict, verified)
+        _print_lang_dimension_rows(lang_dim_scores)
+        print()
+
+    if show_aggregate:
+        _print_aggregate_reference(state)
+
+
+def _compute_aggregate_scores_from_dims(dim_scores: dict) -> dict[str, float | None]:
+    """Extract aggregate scores stored alongside dimension data (if present)."""
+    agg = dim_scores.get("_aggregate_scores", {})
+    if isinstance(agg, dict):
+        return {
+            "overall": agg.get("overall_score"),
+            "objective": agg.get("objective_score"),
+            "strict": agg.get("strict_score"),
+            "verified": agg.get("verified_strict_score"),
+        }
+    return {}
+
+
+def _print_lang_block_header(lang_name: str) -> None:
+    header = f"  ── {lang_name.title()} ──"
+    pad = 60 - len(header)
+    print(colorize(header + "─" * max(0, pad), "bold"))
+
+
+def _print_lang_score_summary(
+    overall: float | None,
+    objective: float | None,
+    strict: float | None,
+    verified: float | None,
+) -> None:
+    parts = []
+    if overall is not None:
+        parts.append(f"overall {overall:.1f}%")
+    if objective is not None:
+        parts.append(f"objective {objective:.1f}%")
+    if strict is not None:
+        parts.append(f"strict {strict:.1f}%")
+    if verified is not None:
+        parts.append(f"verified {verified:.1f}%")
+    if parts:
+        print(colorize("  " + "  |  ".join(parts), "cyan"))
+
+
+def _print_lang_dimension_rows(dim_scores: dict) -> None:
+    """Print one row per dimension for this language."""
+    mech_rows = []
+    subj_rows = []
+    for name, data in dim_scores.items():
+        if name.startswith("_"):
+            continue
+        if not isinstance(data, dict):
+            continue
+        score = float(data.get("score", 0.0))
+        strict = float(data.get("strict", data.get("strict_score", score)))
+        is_subj = "subjective_assessment" in data.get("detectors", {})
+        row = (name, score, strict, is_subj)
+        if is_subj:
+            subj_rows.append(row)
+        else:
+            mech_rows.append(row)
+
+    bar_len = 15
+    for name, score, strict, _ in sorted(mech_rows, key=lambda r: r[1]):
+        bar = _dimension_bar(score, bar_len=bar_len)
+        print(
+            f"  {name:<22} {bar} {score:5.1f}%  "
+            + colorize(f"(strict {strict:5.1f}%)", "dim")
+        )
+    if subj_rows:
+        print(colorize("  ── subjective ──", "dim"))
+        for name, score, strict, _ in sorted(subj_rows, key=lambda r: r[1]):
+            bar = _dimension_bar(score, bar_len=bar_len)
+            print(
+                f"  {name:<22} {bar} {score:5.1f}%  "
+                + colorize(f"(strict {strict:5.1f}%)", "dim")
+            )
+
+
+def _print_aggregate_reference(state: dict) -> None:
+    """Print the aggregate score as the final summary block."""
+    overall = state.get("overall_score")
+    strict = state.get("strict_score")
+    objective = state.get("objective_score")
+    verified = state.get("verified_strict_score")
+    print(colorize("  ── Aggregate (all languages) ─────────────────────────────", "dim"))
+    parts = []
+    if overall is not None:
+        parts.append(f"overall {float(overall):.1f}%")
+    if objective is not None:
+        parts.append(f"objective {float(objective):.1f}%")
+    if strict is not None:
+        parts.append(f"strict {float(strict):.1f}%")
+    if verified is not None:
+        parts.append(f"verified {float(verified):.1f}%")
+    if parts:
+        print(colorize("  " + "  |  ".join(parts), "cyan"))
+    print()
+
+
+__all__ = [
+    "show_per_language_score_blocks",
+]

--- a/desloppify/engine/_state/schema.py
+++ b/desloppify/engine/_state/schema.py
@@ -159,6 +159,8 @@ class StateModel(TypedDict, total=False):
     subjective_integrity: Required[SubjectiveIntegrity]
     subjective_assessments: Required[dict[str, SubjectiveAssessment]]
     concern_dismissals: dict[str, ConcernDismissal]
+    # Per-language dimension scores populated by --by-language scan (optional, backwards-compatible)
+    dimension_scores_by_language: dict[str, dict[str, DimensionScore]]
 
 
 class ScanDiff(TypedDict):

--- a/desloppify/languages/_framework/resolution.py
+++ b/desloppify/languages/_framework/resolution.py
@@ -99,3 +99,23 @@ def available_langs() -> list[str]:
     """Return list of registered language names."""
     load_all()
     return sorted(registry_state.all_keys())
+
+
+def discover_repo_languages(project_root: Path) -> dict[str, int]:
+    """Detect all languages present in the project root.
+
+    Returns a dict of ``{lang_name: file_count}`` for every registered
+    language that has at least one source file under *project_root*, sorted
+    by descending file count.
+    """
+    load_all()
+    counts: dict[str, int] = {}
+    for lang_name, obj in registry_state.all_items():
+        cfg = obj if isinstance(obj, LangConfig) else make_lang_config(lang_name, obj)
+        try:
+            n = len(cfg.file_finder(project_root))
+        except Exception:
+            n = 0
+        if n > 0:
+            counts[lang_name] = n
+    return dict(sorted(counts.items(), key=lambda kv: -kv[1]))


### PR DESCRIPTION
## Summary

Implements per-language scorecard generation for mixed-language repositories (fixes #140).

## Changes

- **`languages/_framework/resolution.py`**: Added `discover_repo_languages()` helper that returns `{lang: file_count}` for all detected languages
- **`engine/_state/schema.py`**: Added optional `dimension_scores_by_language` field to `StateModel` (backwards-compatible)
- **`app/cli_support/parser_groups.py`**: Added `--by-language` flag to both `scan` and `status` subparsers
- **`app/commands/scan/scan_reporting_by_language.py`** *(new)*: Per-language CLI score output module
- **`app/commands/scan/scan.py`**: Added by-language execution phase — detects languages, runs per-language scans, stores results, prints score blocks, emits per-language scorecard PNGs
- **`app/output/scorecard.py`**: Added `language` keyword arg to `generate_scorecard()` — uses per-language dimension scores when set
- **`app/commands/status_cmd.py`**: `--by-language` reads stored per-language scores from state

## Usage

```bash
# Scan and generate per-language scorecards
desloppify scan --path . --by-language

# Custom badge path with {lang} template
desloppify scan --path . --by-language --badge-path scorecard-{lang}.png

# View per-language breakdown in status
desloppify status --by-language
```

## Acceptance Criteria

- [x] In a repo with >=2 detected languages, `--by-language` outputs distinct score blocks per language
- [x] Each language block follows current score-reporting contract (overall/objective/strict/verified + dimensions)
- [x] Aggregate + per-language outputs are both available and clearly labeled
- [x] Per-language scorecard images generated (e.g. `scorecard-go.png`, `scorecard-python.png`)
- [x] `status --by-language` shows per-language breakdown
- [x] State interactions are deterministic (per-language scores in `dimension_scores_by_language`, global scores unchanged)
- [x] Backwards-compatible schema change (new optional key, absent in existing states)

Closes #140