### PR TITLE
Pass filename to ast.parse() so SyntaxWarnings show real paths

### DIFF
--- a/desloppify/languages/python/detectors/coupling_contracts.py
+++ b/desloppify/languages/python/detectors/coupling_contracts.py
@@ -79,7 +79,7 @@ def detect_implicit_mixin_contracts(
         full = Path(filepath) if Path(filepath).is_absolute() else PROJECT_ROOT / filepath
         try:
             content = full.read_text()
-            tree = ast.parse(content)
+            tree = ast.parse(content, filename=str(full))
         except (OSError, SyntaxError, UnicodeDecodeError) as exc:
             # Preserve parse/read context while intentionally skipping broken files.
             _ = (full, exc)

--- a/desloppify/languages/python/detectors/deps.py
+++ b/desloppify/languages/python/detectors/deps.py
@@ -44,7 +44,7 @@ def build_dep_graph(
         )
         try:
             content = Path(abs_path).read_text()
-            tree = ast.parse(content)
+            tree = ast.parse(content, filename=abs_path)
         except (OSError, UnicodeDecodeError, SyntaxError) as exc:
             logger.debug(
                 "Skipping unreadable/unparseable python file %s in deps detector: %s",
@@ -255,7 +255,7 @@ def find_python_dynamic_imports(path: Path, extensions: list[str]) -> set[str]:
     targets: set[str] = set()
     for py_file in path.rglob("*.py"):
         try:
-            tree = ast.parse(py_file.read_text())
+            tree = ast.parse(py_file.read_text(), filename=str(py_file))
         except (SyntaxError, UnicodeDecodeError, OSError) as exc:
             logger.debug("Skipping unreadable file %s in dynamic import scan: %s", py_file, exc)
             continue

--- a/desloppify/languages/python/detectors/facade.py
+++ b/desloppify/languages/python/detectors/facade.py
@@ -12,7 +12,7 @@ def is_py_facade(filepath: str) -> dict | None:
     """Check if a Python file is a pure re-export facade."""
     try:
         content = Path(filepath).read_text()
-        tree = ast.parse(content)
+        tree = ast.parse(content, filename=filepath)
     except (OSError, SyntaxError, UnicodeDecodeError):
         return None
 

--- a/desloppify/languages/python/detectors/mutable_state.py
+++ b/desloppify/languages/python/detectors/mutable_state.py
@@ -230,7 +230,7 @@ def _detect_stale_imports(
             continue
 
         try:
-            tree = ast.parse(content)
+            tree = ast.parse(content, filename=filepath)
         except SyntaxError as exc:
             logger.debug(
                 "Skipping unparseable python file %s in stale-import pass: %s",
@@ -301,7 +301,7 @@ def detect_global_mutable_config(path: Path) -> tuple[list[dict], int]:
             continue
 
         try:
-            tree = ast.parse(content)
+            tree = ast.parse(content, filename=filepath)
         except SyntaxError as exc:
             logger.debug(
                 "Skipping unparseable python file %s in mutable-state pass: %s",

--- a/desloppify/languages/python/detectors/responsibility_cohesion.py
+++ b/desloppify/languages/python/detectors/responsibility_cohesion.py
@@ -92,7 +92,7 @@ def detect_responsibility_cohesion(
         full = Path(filepath) if Path(filepath).is_absolute() else PROJECT_ROOT / filepath
         try:
             source = full.read_text()
-            tree = ast.parse(source)
+            tree = ast.parse(source, filename=str(full))
         except (OSError, UnicodeDecodeError, SyntaxError) as exc:
             # Preserve parse/read context while intentionally skipping broken files.
             _ = (full, exc)

--- a/desloppify/languages/python/detectors/smells_ast/_dispatch.py
+++ b/desloppify/languages/python/detectors/smells_ast/_dispatch.py
@@ -194,7 +194,7 @@ TREE_DETECTORS: tuple[_TreeDetectorSpec, ...] = (
 def _detect_ast_smells(filepath: str, content: str, smell_counts: dict[str, list]):
     """Detect AST-based code smells using registry-driven collector dispatch."""
     try:
-        tree = ast.parse(content)
+        tree = ast.parse(content, filename=filepath)
     except SyntaxError:
         return
 

--- a/desloppify/languages/python/detectors/smells_ast/_source_detectors.py
+++ b/desloppify/languages/python/detectors/smells_ast/_source_detectors.py
@@ -30,7 +30,7 @@ def _collect_module_constants(
     (dicts, lists, sets, tuples, numbers, strings).
     """
     try:
-        tree = ast.parse(content)
+        tree = ast.parse(content, filename=filepath)
     except SyntaxError as exc:
         logger.debug(
             "Skipping unparseable python file %s while collecting constants: %s",
@@ -97,7 +97,7 @@ def _detect_star_import_no_all(
     are part of the scanned project (not stdlib/third-party).
     """
     try:
-        tree = ast.parse(content)
+        tree = ast.parse(content, filename=filepath)
     except SyntaxError as exc:
         logger.debug(
             "Skipping unparseable python file %s for star-import analysis: %s",
@@ -207,7 +207,7 @@ def _detect_vestigial_parameter(
     like 'unused', 'legacy', 'deprecated', 'backward compat', etc.
     """
     try:
-        tree = ast.parse(content)
+        tree = ast.parse(content, filename=filepath)
     except SyntaxError as exc:
         logger.debug(
             "Skipping unparseable python file %s for vestigial-param analysis: %s",


### PR DESCRIPTION
## Summary
- Adds `filename=` parameter to all 11 `ast.parse()` calls in Python detectors that were missing it
- SyntaxWarnings (e.g. invalid escape sequences) now show the actual file path instead of `<unknown>`

Fixes #173

## Test plan
- [x] All 3314 existing tests pass
- Scan a Python codebase with invalid escape sequences and verify warnings show real file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)