### PR TITLE
fix: normalize sort key tuple lengths to prevent TypeError

### DIFF
--- a/desloppify/engine/_work_queue/ranking.py
+++ b/desloppify/engine/_work_queue/ranking.py
@@ -223,6 +223,8 @@ def _natural_sort_key(item: WorkQueueItem) -> tuple:
             _RANK_ISSUE,
             -impact,
             subjective_score_value(item),
+            0.0,
+            0,
             item.get("id", ""),
         )
 


### PR DESCRIPTION
## Summary

Fixes a `TypeError` crash in `_natural_sort_key()` where subjective and mechanical work queue items at the same `_RANK_ISSUE` tier produced tuples of different lengths (4 vs 6 elements). When `estimated_impact` values tied, Python compared `str` (id) against `float` (-review_weight) at position [3], raising `TypeError`.

**Bounty issue:** https://github.com/peteromallet/desloppify/issues/204
**Submission by:** @Tib-Gridello
**Claim:** `_natural_sort_key` returns heterogeneous tuples (4-element for subjective, 6-element for mechanical items) that crash with `TypeError` on equal `estimated_impact`.

## What changed

Padded the subjective item tuple from 4 to 6 elements with neutral defaults (`0.0`, `0`), so all `_RANK_ISSUE` items produce comparable 6-tuples.

**File:** `desloppify/engine/_work_queue/ranking.py` lines 221-227

## Verdict scores

| Metric | Score |
|---|---|
| Significance | 7/10 |
| Originality | 8/10 |
| Core Impact | 6/10 |
| Overall | 7/10 |

🤖 Generated with [Lota](https://github.com/xliry/lota-agents) — autonomous bounty verification & fix pipeline