### PR TITLE
feat: verify S002 @yuliuyi717-ux bounty — YES_WITH_CAVEATS on state-model coupling

### DIFF
--- a/bounty-verdicts/@yuliuyi717-ux-4000447540.json
+++ b/bounty-verdicts/@yuliuyi717-ux-4000447540.json
@@ -1,0 +1,28 @@
+{
+  "submission_id": "S002",
+  "comment_id": 4000447540,
+  "author": "yuliuyi717-ux",
+  "snapshot_commit": "6eb2065fd4b991b88988a0905f6da29ff4216bd8",
+  "claim": "State-model coupling: the same mutable state document is used as evidence truth, operator-decision log, and score cache",
+  "verdict": "YES_WITH_CAVEATS",
+  "scores": {
+    "significance": 4,
+    "originality": 3,
+    "core_impact": 3,
+    "overall": 3
+  },
+  "references": [
+    "desloppify/engine/_state/schema.py:322-339 (StateModel co-locates issues, stats, scores, assessments)",
+    "desloppify/engine/_state/merge.py:123-199 (merge_scan mutates issues + recomputes scores)",
+    "desloppify/engine/_state/resolution.py:99-173 (resolve_issues writes decisions + recomputes scores)"
+  ],
+  "caveats": [
+    "Observation is accurate: StateModel does co-locate raw issues, operator decisions, and derived scores in one mutable dict",
+    "Significance is overstated: this is a single-user CLI tool, not a distributed system — concurrency and ordering risks are theoretical",
+    "The 'non-commutative behavior' claim is misleading: scan order is deterministic in practice since the tool runs sequentially",
+    "Provenance ambiguity is partially mitigated by attestation logs and scan history already present in the state model",
+    "The proposed fix (event sourcing with projections) would be massive over-engineering for a CLI code-quality tool"
+  ],
+  "verified_at": "2026-03-07T00:00:00Z",
+  "verified_by": "lota-1"
+}

--- a/bounty-verification-@yuliuyi717-ux-4000447540.md
+++ b/bounty-verification-@yuliuyi717-ux-4000447540.md
@@ -1,0 +1,71 @@
+# Bounty Verification: S002 @yuliuyi717-ux — State-Model Coupling
+
+**Submission:** https://github.com/peteromallet/desloppify/issues/204#issuecomment-4000447540
+**Snapshot:** `6eb2065fd4b991b88988a0905f6da29ff4216bd8`
+**Verdict:** YES_WITH_CAVEATS (Overall: 3/10)
+
+## Claim
+
+The same mutable state document (`StateModel`) is used as evidence truth, operator-decision log, and score cache. This creates non-commutative behavior, provenance ambiguity, and scaling risk.
+
+## Code Trace
+
+### 1. schema.py — StateModel co-locates raw issues with derived scores
+
+`desloppify/engine/_state/schema.py:322-339`
+
+`StateModel` is a single `TypedDict` that holds:
+- `issues` — raw issue records from detectors (evidence truth)
+- `stats`, `strict_score`, `verified_strict_score`, `objective_score`, `overall_score` — derived scoring fields (score cache)
+- `subjective_assessments` — operator/reviewer dimension scores (decision log)
+- `dimension_scores` — per-dimension score breakdowns (derived)
+- `resolution_attestation` fields on individual `Issue` records — manual operator decisions
+
+**Verified:** Yes, the co-location is real. All these concerns live in one dict.
+
+### 2. merge.py — merge_scan mutates issues and recomputes scores
+
+`desloppify/engine/_state/merge.py:123-199`
+
+The `merge_scan` function:
+1. Calls `upsert_issues()` to add/update/reopen issue records in `state["issues"]`
+2. Calls `auto_resolve_disappeared()` to mark vanished issues as auto-resolved
+3. Calls `_mark_stale_on_mechanical_change()` to flag subjective assessments
+4. Calls `_recompute_stats(state)` to recalculate all derived scores from the mutated issues
+
+**Verified:** Yes, issue lifecycle mutations and score recomputation happen in the same flow on the same object.
+
+### 3. resolution.py — resolve_issues writes decisions and recomputes scores
+
+`desloppify/engine/_state/resolution.py:99-173`
+
+The `resolve_issues` function:
+1. Iterates matching issues and mutates their `status`, `note`, `resolved_at`, `resolution_attestation`
+2. Calls `_mark_stale_assessments_on_review_resolve()` to flag affected subjective dimensions
+3. Calls `_recompute_stats(state)` to recalculate derived scores
+
+**Verified:** Yes, operator decisions and score recomputation share the same mutable state.
+
+## Assessment
+
+The observation is **technically accurate** but the significance is **overstated**.
+
+**What is real:**
+- `StateModel` does serve triple duty as evidence store, decision log, and score cache
+- Both `merge_scan` and `resolve_issues` mutate issues in-place then recompute derived scores
+- There is no separation between "events" and "projections"
+
+**What is overstated:**
+- **Non-commutative behavior**: The tool runs sequentially as a CLI — scan/resolve ordering is deterministic in practice. There is no concurrent access.
+- **Provenance ambiguity**: The state model already includes `resolution_attestation`, `attestation_log`, `scan_history`, and `assessment_import_audit` — these provide reasonable provenance tracking.
+- **Scaling risk**: This is a single-user CLI tool. Event sourcing with projections would be significant over-engineering.
+- The proposed architectural fix (immutable event log with deterministic projections) is a distributed-systems pattern inappropriate for a local CLI tool.
+
+## Scores
+
+| Criterion | Score | Reasoning |
+|-----------|-------|-----------|
+| Significance | 4/10 | Real coupling but low practical impact for a CLI tool |
+| Originality | 3/10 | Standard observation about mutable state; no novel insight |
+| Core Impact | 3/10 | Does not cause bugs or correctness issues in current usage |
+| Overall | 3/10 | Valid observation, overstated significance |


### PR DESCRIPTION
**Issue:** https://github.com/peteromallet/desloppify/issues/204
**Submission:** https://github.com/peteromallet/desloppify/issues/204#issuecomment-4000447540
**Author:** @yuliuyi717-ux

## Problem (in our own words)

The `StateModel` TypedDict serves triple duty as evidence store (raw issues from detectors), operator-decision log (resolution attestations, subjective assessments), and score cache (strict_score, dimension_scores, stats). Both `merge_scan` and `resolve_issues` mutate issues in-place then call `_recompute_stats` on the same object, coupling data lifecycle with score derivation.

## Evidence

- `desloppify/engine/_state/schema.py:322-339` — `StateModel` co-locates `issues`, `stats`, `strict_score`, `verified_strict_score`, `subjective_assessments`, `dimension_scores` in one TypedDict
- `desloppify/engine/_state/merge.py:123-199` — `merge_scan` upserts issues, auto-resolves disappeared ones, marks stale assessments, then calls `_recompute_stats(state)`
- `desloppify/engine/_state/resolution.py:99-173` — `resolve_issues` writes status/note/attestation into issue records, marks stale assessments, then calls `_recompute_stats(state)`

## Fix

No fix needed — this is a valid architectural observation but the practical impact is low for a single-user CLI tool. The existing provenance tracking (attestation_log, scan_history, assessment_import_audit) partially mitigates the provenance concern.

## Verdict

| Question | Answer | Reasoning |
|----------|--------|-----------|
| **Is this poor engineering?** | YES | Co-locating raw data, decisions, and derived scores in one mutable dict is a real design smell |
| **Is this at least somewhat significant?** | YES | But only somewhat — practical impact is low for a sequential CLI tool |

**Final verdict:** YES_WITH_CAVEATS

## Scores

| Criterion | Score |
|-----------|-------|
| Significance | 4/10 |
| Originality | 3/10 |
| Core Impact | 3/10 |
| Overall | 3/10 |

## Summary

The submission correctly identifies that `StateModel` conflates raw evidence, operator decisions, and derived scores. All three code references are accurate. However, the claimed risks (non-commutative behavior, concurrency issues) are overstated for a single-user CLI tool, and the proposed fix (event sourcing) would be over-engineering. Existing provenance fields partially mitigate the concern.

## Why Desloppify Missed This

- **What should catch:** A structural/architectural detector analyzing data model responsibilities
- **Why not caught:** Current detectors focus on code-level patterns (complexity, coupling, duplication), not data-model design concerns
- **What could catch:** A "God Object" or "mixed responsibility" detector analyzing TypedDict field groupings

## Verdict Files

- [Verdict JSON](https://github.com/xliry/desloppify/blob/fix/bounty-4000447540-yuliuyi717-ux-v2/bounty-verdicts/%40yuliuyi717-ux-4000447540.json)
- [Verdict Report](https://github.com/xliry/desloppify/blob/fix/bounty-4000447540-yuliuyi717-ux-v2/bounty-verification-%40yuliuyi717-ux-4000447540.md)

Generated with [Lota](https://github.com/xliry/lota)
