### PR TITLE
fix: dimension_coverage tautology in _compute_batch_quality (always 1.0)

### DIFF
--- a/desloppify/app/commands/review/batch/core.py
+++ b/desloppify/app/commands/review/batch/core.py
@@ -367,11 +367,13 @@ def _compute_batch_quality(
     issues: list[NormalizedBatchIssue],
     dimension_notes: dict[str, BatchDimensionNotePayload],
     high_score_missing_issue_note: float,
+    *,
+    expected_dimension_count: int = 0,
 ) -> BatchQualityPayload:
     """Compute quality metrics for a single batch result."""
     return {
         "dimension_coverage": round(
-            len(assessments) / max(len(assessments), 1),
+            len(assessments) / max(expected_dimension_count, len(assessments), 1),
             3,
         ),
         "evidence_density": round(
@@ -469,6 +471,7 @@ def normalize_batch_result(
         issues,
         dimension_notes,
         high_score_missing_issue_note,
+        expected_dimension_count=len(allowed_dims),
     )
     return (
         assessments,


### PR DESCRIPTION
## Summary

Fixes the bug identified in https://github.com/peteromallet/desloppify/issues/204#issuecomment-4009077704 (@Boehner).

## The Bug

`_compute_batch_quality` in `app/commands/review/batch/core.py` computes `dimension_coverage` as:

```python
len(assessments) / max(len(assessments), 1)  # Always 1.0
```

This is `N / N` for any non-empty batch — always exactly `1.0`. The `max(..., 1)` guard exists to prevent zero-division, but both operands are the same variable. The denominator should represent the **total expected dimensions** in the batch profile, not the number of assessed dimensions.

## The Fix

Pass `expected_dimension_count=len(allowed_dims)` from `normalize_batch_result` (which already has `allowed_dims` in scope) to `_compute_batch_quality`, and use it as the denominator:

```python
len(assessments) / max(expected_dimension_count, len(assessments), 1)
```

## Before / After

| Scenario | Old (buggy) | New (fixed) |
|----------|------------|-------------|
| 3 dims assessed, 10 expected | `1.000` | `0.300` |
| 10 dims assessed, 10 expected | `1.000` | `1.000` |
| 1 dim assessed, 20 expected | `1.000` | `0.050` |

## Why This Matters

`dimension_coverage` is written into every batch's quality telemetry payload, merged into `holistic_issues_merged.json`, and propagated to `review_quality` in the final output. Any downstream logic that gates imports, warns operators, or surfaces quality issues based on low coverage silently never triggers — because coverage is always reported as `1.0` regardless of actual completeness.

## Backward Compatibility

The new parameter `expected_dimension_count` defaults to `0`, which falls back to `len(assessments)` (old behaviour) via `max()`. The call site in `normalize_batch_result` passes `len(allowed_dims)` explicitly, enabling correct behaviour going forward.