### PR TITLE
fix: restore observe helper call in triage orchestrator

### DIFF
--- a/desloppify/app/commands/plan/triage/runner/orchestrator.py
+++ b/desloppify/app/commands/plan/triage/runner/orchestrator.py
@@ -315,7 +315,7 @@ def _run_codex_pipeline(
         # Parallel observe path
         used_parallel = False
         if stage == "observe":
-            parallel_ok, merged_report = _run_observe_parallel(
+            parallel_ok, merged_report = _run_observe(
                 si=si,
                 repo_root=repo_root,
                 prompts_dir=prompts_dir,


### PR DESCRIPTION
## Summary
- replace the undefined `_run_observe_parallel` call with the existing `_run_observe` helper
- restore the observe-stage execution path for `desloppify plan triage --run-stages --runner codex`

## Validation
- `PATH=/opt/desloppify-venv/bin:$PATH make ci-fast`
- `PATH=/opt/desloppify-venv/bin:$PATH make package-smoke`