### PR TITLE
fix: keep skill frontmatter at the top for Codex installs

### DIFF
--- a/desloppify/app/skill_docs.py
+++ b/desloppify/app/skill_docs.py
@@ -9,7 +9,7 @@ from desloppify.base.discovery.paths import get_project_root
 
 # Bump this integer whenever docs/SKILL.md changes in a way that agents
 # should pick up (new commands, changed workflows, removed sections).
-SKILL_VERSION = 4
+SKILL_VERSION = 5
 
 SKILL_VERSION_RE = re.compile(r"<!--\s*desloppify-skill-version:\s*(\d+)\s*-->")
 SKILL_OVERLAY_RE = re.compile(r"<!--\s*desloppify-overlay:\s*(\w+)\s*-->")

--- a/desloppify/tests/commands/test_transitive_modules.py
+++ b/desloppify/tests/commands/test_transitive_modules.py
@@ -842,7 +842,17 @@ class TestUpdateInstalledSkill:
     @patch("desloppify.app.commands.update_skill.colorize", side_effect=lambda t, _c: t)
     @patch("desloppify.app.commands.update_skill._download")
     def test_successful_dedicated_install(self, mock_download, _mock_colorize, capsys, tmp_path):
-        skill_content = "# Skill\n<!-- desloppify-skill-version: 1 -->\nContent"
+        skill_content = (
+            "---\n"
+            "name: desloppify\n"
+            "description: test\n"
+            "allowed-tools: Bash(desloppify *)\n"
+            "---\n\n"
+            "<!-- desloppify-begin -->\n"
+            "<!-- desloppify-skill-version: 1 -->\n"
+            "# Skill\n"
+            "Content\n"
+        )
         mock_download.side_effect = lambda f: {
             "SKILL.md": skill_content,
             "CLAUDE.md": "overlay",
@@ -856,6 +866,7 @@ class TestUpdateInstalledSkill:
 
         assert result is True
         written = (tmp_path / ".claude" / "skills" / "desloppify" / "SKILL.md").read_text()
+        assert written.startswith("---\n")
         assert "desloppify-skill-version" in written
         out = capsys.readouterr().out
         assert "Updated" in out
@@ -864,7 +875,17 @@ class TestUpdateInstalledSkill:
     @patch("desloppify.app.commands.update_skill._download")
     def test_successful_shared_install(self, mock_download, _mock_colorize, capsys, tmp_path):
         """Non-dedicated install (e.g. windsurf) replaces section in existing file."""
-        skill_content = "# Skill\n<!-- desloppify-skill-version: 1 -->\nContent"
+        skill_content = (
+            "---\n"
+            "name: desloppify\n"
+            "description: test\n"
+            "allowed-tools: Bash(desloppify *)\n"
+            "---\n\n"
+            "<!-- desloppify-begin -->\n"
+            "<!-- desloppify-skill-version: 1 -->\n"
+            "# Skill\n"
+            "Content\n"
+        )
         mock_download.side_effect = lambda f: {
             "SKILL.md": skill_content,
             "WINDSURF.md": "windsurf overlay",

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -1,5 +1,3 @@
-<!-- desloppify-begin -->
-<!-- desloppify-skill-version: 4 -->
 ---
 name: desloppify
 description: >
@@ -10,6 +8,9 @@ description: >
   create a cleanup plan. Supports 28 languages.
 allowed-tools: Bash(desloppify *)
 ---
+
+<!-- desloppify-begin -->
+<!-- desloppify-skill-version: 5 -->
 
 # Desloppify
 


### PR DESCRIPTION
Closes #367

## Summary
- move the `desloppify-begin` / `desloppify-skill-version` markers below the YAML frontmatter in `docs/SKILL.md`
- bump `SKILL_VERSION` so existing installs are marked stale and can be refreshed
- add a regression test that asserts dedicated skill installs still start with frontmatter

## Why
Codex skill discovery expects `SKILL.md` to begin with YAML frontmatter. On `wip/triage-runner`, the generated dedicated skill file started with HTML comments, which made the installed skill undiscoverable.

## Validation
- `pytest -q desloppify/tests/commands/test_transitive_modules.py -k "successful_dedicated_install or successful_shared_install"`