### PR TITLE
Fix prepared review packet reuse and runner hang regressions

### DIFF
--- a/desloppify/app/commands/helpers/query.py
+++ b/desloppify/app/commands/helpers/query.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -40,6 +41,16 @@ def query_writer() -> QueryWriter:
     return QueryWriter(query_file=query_file_path())
 
 
+def load_query() -> dict | None:
+    """Load the active query payload, returning ``None`` on read/parse failure."""
+    path = query_file_path()
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
 def write_query(data: dict) -> OutputResult:
     """Write structured query output using default best-effort policy."""
     return write_query_best_effort(data, context="query payload update")
@@ -52,6 +63,7 @@ def write_query_best_effort(data: dict, *, context: str) -> OutputResult:
 
 __all__ = [
     "QueryWriter",
+    "load_query",
     "query_file_path",
     "query_writer",
     "write_query",

--- a/desloppify/app/commands/review/_runner_process_io.py
+++ b/desloppify/app/commands/review/_runner_process_io.py
@@ -187,12 +187,10 @@ def _check_stall(
     except OSError:
         current_signature = None
     if current_signature is None:
-        baseline = prev_stable if isinstance(prev_stable, int | float) else now
-        output_age = now - baseline
-        stream_idle = now - last_activity
-        if output_age >= threshold and stream_idle >= threshold:
-            return True, None, baseline
-        return False, None, baseline
+        # Codex may remain silent until it writes the final output artifact.
+        # Only treat a batch as stalled once an output file exists and then
+        # remains stable without stream activity.
+        return False, None, None
     if current_signature != prev_sig:
         return False, current_signature, now
     if prev_stable is None:

--- a/desloppify/app/commands/review/batch/orchestrator.py
+++ b/desloppify/app/commands/review/batch/orchestrator.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 from typing import cast
 
+from desloppify.app.commands.helpers.query import load_query
 from desloppify.app.commands.helpers.query import write_query_best_effort
 from desloppify.base.coercions import coerce_positive_int
 from desloppify.base.discovery.file_paths import safe_write_text
@@ -101,6 +102,7 @@ def _load_or_prepare_packet(
     stamp: str,
 ) -> tuple[dict, Path, Path]:
     """Load packet override or prepare a fresh packet snapshot."""
+    blind_path = _blind_packet_path(stamp=stamp)
     packet_override = getattr(args, "packet", None)
     if packet_override:
         packet_path = Path(packet_override)
@@ -110,12 +112,25 @@ def _load_or_prepare_packet(
             packet = json.loads(packet_path.read_text())
         except (OSError, json.JSONDecodeError) as exc:
             raise PacketValidationError(f"reading packet: {exc}", exit_code=1) from exc
-        blind_path = _blind_packet_path()
         blind_packet = build_blind_packet(packet)
         safe_write_text(blind_path, json.dumps(blind_packet, indent=2) + "\n")
         print(colorize(f"  Immutable packet: {packet_path}", "dim"))
         print(colorize(f"  Blind packet: {blind_path}", "dim"))
         return packet, packet_path, blind_path
+
+    prepared_query = _load_prepared_query_packet(args)
+    if prepared_query is not None:
+        packet_path, blind_saved = write_packet_snapshot(
+            prepared_query,
+            stamp=stamp,
+            review_packet_dir=_review_packet_dir(),
+            blind_path=blind_path,
+            safe_write_text_fn=safe_write_text,
+        )
+        print(colorize("  Using prepared review packet from query.json", "cyan"))
+        print(colorize(f"  Immutable packet: {packet_path}", "dim"))
+        print(colorize(f"  Blind packet: {blind_saved}", "dim"))
+        return prepared_query, packet_path, blind_saved
 
     path = Path(args.path)
     dims = parse_dimensions(args)
@@ -138,7 +153,6 @@ def _load_or_prepare_packet(
         context=narrative_mod.NarrativeContext(lang=lang_name, command="review"),
     )
 
-    blind_path = _blind_packet_path()
     packet = review_mod.prepare_holistic_review(
         path,
         lang_run,
@@ -176,6 +190,24 @@ def _load_or_prepare_packet(
     print(colorize(f"  Immutable packet: {packet_path}", "dim"))
     print(colorize(f"  Blind packet: {blind_saved}", "dim"))
     return packet, packet_path, blind_saved
+
+
+def _load_prepared_query_packet(args) -> dict | None:
+    """Reuse the prepared holistic review packet when run-batches follows prepare."""
+    if getattr(args, "dimensions", None):
+        return None
+    if getattr(args, "retrospective", False):
+        return None
+    query = load_query()
+    if not isinstance(query, dict):
+        return None
+    if query.get("command") != "review" or query.get("mode") != "holistic":
+        return None
+    if not isinstance(query.get("investigation_batches"), list):
+        return None
+    if not isinstance(query.get("dimensions"), list):
+        return None
+    return query
 
 
 def do_run_batches(args, state, lang, state_file, config: dict | None = None) -> None:

--- a/desloppify/app/commands/review/preflight.py
+++ b/desloppify/app/commands/review/preflight.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import re
 import sys
 
+from desloppify.app.commands.helpers.query import load_query
 from desloppify.base.exception_sets import CommandError
 from desloppify.base.output.terminal import colorize
 from desloppify.engine._work_queue.context import queue_context
@@ -62,6 +63,32 @@ def _normalize_dimension_key(raw: object) -> str:
     """Normalize a dimension key/name to canonical snake_case."""
     text = str(raw or "").strip().lower().replace(" ", "_")
     return re.sub(r"[^a-z0-9_]+", "_", text).strip("_")
+
+
+def _prepared_query_dimensions() -> set[str] | None:
+    """Return prepared review dimensions from query.json when available."""
+    query = load_query()
+    if not isinstance(query, dict):
+        return None
+    if query.get("command") != "review" or query.get("mode") != "holistic":
+        return None
+    if not isinstance(query.get("investigation_batches"), list):
+        return None
+    dims = query.get("dimensions")
+    if not isinstance(dims, list):
+        return None
+    resolved = {dim.strip() for dim in dims if isinstance(dim, str) and dim.strip()}
+    return resolved or None
+
+
+def _target_dimensions(args: object) -> set[str] | None:
+    """Resolve review target dimensions from CLI args or prepared query state."""
+    dimensions = parse_dimensions(args)
+    if dimensions is not None:
+        return dimensions
+    if getattr(args, "run_batches", False) or getattr(args, "external_start", False):
+        return _prepared_query_dimensions()
+    return None
 
 
 
@@ -167,7 +194,7 @@ def review_rerun_preflight(
     not set. On success, clears stale subjective markers for targeted
     dimensions and persists state.
     """
-    dimensions = parse_dimensions(args)
+    dimensions = _target_dimensions(args)
     normalized_dimensions = (
         {_normalize_dimension_key(dim) for dim in dimensions}
         if dimensions is not None

--- a/desloppify/engine/detectors/jscpd_adapter.py
+++ b/desloppify/engine/detectors/jscpd_adapter.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -39,6 +40,25 @@ _BASE_IGNORES = (
 
 _ARTIFACT_PREFIXES = ("build/", "dist/", ".desloppify/", ".claude/")
 _BUILD_MIRROR_PREFIX = "build/lib/"
+
+
+def _resolve_jscpd_command(scan_path: Path) -> list[str] | None:
+    """Return a locally available jscpd command, or ``None`` when absent."""
+    candidates = [
+        scan_path / "node_modules" / ".bin" / "jscpd",
+        Path.cwd() / "node_modules" / ".bin" / "jscpd",
+    ]
+    for candidate in candidates:
+        try:
+            if candidate.is_file():
+                return [str(candidate)]
+        except OSError:
+            continue
+
+    global_jscpd = shutil.which("jscpd")
+    if global_jscpd:
+        return [global_jscpd]
+    return None
 
 
 def _to_scan_relative(path_resolved: Path, name: str) -> str | None:
@@ -167,15 +187,21 @@ def _parse_jscpd_report(report: dict, scan_path: Path) -> list[dict]:
 
 def detect_with_jscpd(path: Path) -> list[dict] | None:
     """Run jscpd on *path* and return duplication entries, or None on failure."""
+    command = _resolve_jscpd_command(path)
+    if command is None:
+        warn_best_effort(
+            "Boilerplate duplication detection skipped: jscpd not installed locally. "
+            "Install `jscpd` globally or under node_modules/.bin to enable it."
+        )
+        logger.debug("jscpd: no local executable found — skipping boilerplate duplication detection")
+        return None
+
     with tempfile.TemporaryDirectory() as tmpdir:
         try:
             # Use explicit argv (no shell), a bounded timeout, and check=True so
             # non-zero exits are surfaced and handled below.
             subprocess.run(
-                [
-                    "npx",
-                    "--yes",
-                    "jscpd",
+                command + [
                     str(path),
                     "--reporters",
                     "json",
@@ -196,14 +222,13 @@ def detect_with_jscpd(path: Path) -> list[dict] | None:
             )
         except FileNotFoundError:
             warn_best_effort(
-                "Boilerplate duplication detection skipped: npx/jscpd not found. "
-                "Install with `npm install -g jscpd`."
+                "Boilerplate duplication detection skipped: jscpd executable not found."
             )
-            logger.debug("jscpd: npx not found — skipping boilerplate duplication detection")
+            logger.debug("jscpd: executable missing at runtime — skipping boilerplate duplication detection")
             return None
         except subprocess.CalledProcessError as exc:
             warn_best_effort(
-                "Boilerplate duplication detection skipped: npx/jscpd exited with errors."
+                "Boilerplate duplication detection skipped: jscpd exited with errors."
             )
             logger.debug(
                 "jscpd: non-zero exit (%s): %s",
@@ -213,9 +238,9 @@ def detect_with_jscpd(path: Path) -> list[dict] | None:
             return None
         except OSError as exc:
             warn_best_effort(
-                "Boilerplate duplication detection skipped: npx/jscpd failed to run."
+                "Boilerplate duplication detection skipped: jscpd failed to run."
             )
-            logger.debug("jscpd: OS error running npx/jscpd: %s", exc)
+            logger.debug("jscpd: OS error running executable: %s", exc)
             return None
         except subprocess.TimeoutExpired:
             warn_best_effort(

--- a/desloppify/tests/commands/review/test_review_preflight.py
+++ b/desloppify/tests/commands/review/test_review_preflight.py
@@ -17,7 +17,12 @@ from desloppify.base.exception_sets import CommandError
 
 
 def _make_args(**overrides) -> SimpleNamespace:
-    defaults = {"force_review_rerun": False, "dimensions": None}
+    defaults = {
+        "force_review_rerun": False,
+        "dimensions": None,
+        "run_batches": False,
+        "external_start": False,
+    }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
 
@@ -248,6 +253,28 @@ def test_targeting_only_unscored_dims_skips_gate():
     args = _make_args(dimensions="logic_clarity")
     # Gate skipped — no scored dims targeted
     review_rerun_preflight(state, args)
+
+
+def test_run_batches_uses_prepared_query_dimensions_for_gate():
+    """run-batches should honor prepared review dimensions from query.json."""
+    state = {
+        "subjective_assessments": {
+            "naming_quality": {"score": 82.0},
+            "dependency_health": {"score": 0.0},
+        }
+    }
+    args = _make_args(run_batches=True)
+    prepared_query = {
+        "command": "review",
+        "mode": "holistic",
+        "dimensions": ["dependency_health"],
+        "investigation_batches": [{"name": "dependency_health"}],
+    }
+    with (
+        patch("desloppify.app.commands.review.preflight.load_query", return_value=prepared_query),
+        patch(_QUEUE_CONTEXT, return_value=_mock_queue_context(objective_count=3)),
+    ):
+        review_rerun_preflight(state, args)
 
 
 def test_targeting_scored_dim_enforces_gate(capsys):
@@ -650,5 +677,4 @@ def test_merge_skips_preflight():
     ):
         cmd_review(_review_args(merge=True))
         mock_pf.assert_not_called()
-
 

--- a/desloppify/tests/detectors/test_external_adapters.py
+++ b/desloppify/tests/detectors/test_external_adapters.py
@@ -497,8 +497,12 @@ from desloppify.engine.detectors.jscpd_adapter import (  # noqa: E402
 
 class TestJscpdAdapter:
     def test_returns_none_when_jscpd_not_installed(self, tmp_path):
-        with patch("subprocess.run", side_effect=FileNotFoundError("npx not found")):
+        with patch(
+            "desloppify.engine.detectors.jscpd_adapter._resolve_jscpd_command",
+            return_value=None,
+        ), patch("subprocess.run") as mock_run:
             assert detect_with_jscpd(tmp_path) is None
+        mock_run.assert_not_called()
 
     def test_returns_none_on_timeout(self, tmp_path):
         with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("npx", 120)):
@@ -663,6 +667,9 @@ class TestJscpdAdapter:
             return MagicMock(returncode=0, stdout="", stderr="")
 
         with patch("subprocess.run", side_effect=_fake_run), patch(
+            "desloppify.engine.detectors.jscpd_adapter._resolve_jscpd_command",
+            return_value=["/opt/jscpd"],
+        ), patch(
             "desloppify.engine.detectors.jscpd_adapter.collect_exclude_dirs",
             return_value=fake_dirs,
         ), patch(

--- a/desloppify/tests/review/review_commands_cases.py
+++ b/desloppify/tests/review/review_commands_cases.py
@@ -800,8 +800,9 @@ class TestCmdReviewPrepare:
         assert not mock_import.called
         packet_files = sorted(review_packet_dir.glob("holistic_packet_*.json"))
         assert len(packet_files) == 1
-        blind_packet = tmp_path / ".desloppify" / "review_packet_blind.json"
-        assert blind_packet.exists()
+        blind_packets = sorted(review_packet_dir.glob("review_packet_blind_*.json"))
+        assert len(blind_packets) == 1
+        blind_packet = blind_packets[0]
         prompt_files = list(runs_dir.glob("*/prompts/batch-*.md"))
         assert len(prompt_files) == 2
         prompt_text = prompt_files[0].read_text()
@@ -818,6 +819,92 @@ class TestCmdReviewPrepare:
         run_log_text = run_logs[0].read_text()
         assert "run-start" in run_log_text
         assert "run-finished dry-run" in run_log_text
+
+    def test_do_run_batches_reuses_prepared_query_packet(
+        self,
+        mock_lang_with_zones,
+        empty_state,
+        tmp_path,
+    ):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "foo.ts").write_text("export const foo = 1;\n")
+        file_list = [str(src / "foo.ts")]
+        mock_lang_with_zones.file_finder = MagicMock(return_value=file_list)
+
+        args = MagicMock()
+        args.path = str(tmp_path)
+        args.dimensions = None
+        args.runner = "codex"
+        args.parallel = False
+        args.dry_run = True
+        args.packet = None
+        args.only_batches = "1"
+        args.scan_after_import = False
+        args.save_run_log = True
+        args.run_log_file = None
+        args.retrospective = False
+
+        prepared_query = {
+            "command": "review",
+            "mode": "holistic",
+            "language": "typescript",
+            "dimensions": ["dependency_health"],
+            "dimension_prompts": {
+                "dependency_health": {
+                    "description": "Assess coupling and dependency direction.",
+                    "look_for": ["unstable dependencies"],
+                    "skip": ["minor style issues"],
+                }
+            },
+            "system_prompt": "prompt",
+            "investigation_batches": [
+                {
+                    "name": "dependency_health",
+                    "dimensions": ["dependency_health"],
+                    "files_to_read": ["src/foo.ts"],
+                    "why": "prepared",
+                }
+            ],
+            "total_files": 1,
+            "workflow": [],
+        }
+
+        review_packet_dir = tmp_path / ".desloppify" / "review_packets"
+        runs_dir = tmp_path / ".desloppify" / "subagents" / "runs"
+
+        with (
+            patch(
+                "desloppify.app.commands.review.batch.orchestrator.load_query",
+                return_value=prepared_query,
+            ),
+            patch(
+                "desloppify.app.commands.review.runtime_paths.PROJECT_ROOT",
+                tmp_path,
+            ),
+            patch(
+                "desloppify.app.commands.review.runtime_paths.REVIEW_PACKET_DIR",
+                review_packet_dir,
+            ),
+            patch(
+                "desloppify.app.commands.review.runtime_paths.SUBAGENT_RUNS_DIR",
+                runs_dir,
+            ),
+            patch(
+                "desloppify.app.commands.review.batch.orchestrator.review_mod.prepare_holistic_review",
+                side_effect=AssertionError("should not rebuild packet"),
+            ),
+        ):
+            do_run_batches(
+                args, empty_state, mock_lang_with_zones, "fake_sp", config={}
+            )
+
+        prompt_files = list(runs_dir.glob("*/prompts/batch-*.md"))
+        assert len(prompt_files) == 1
+        prompt_text = prompt_files[0].read_text()
+        assert "Batch name: dependency_health" in prompt_text
+        assert "DIMENSION TO EVALUATE:" in prompt_text
+        assert "## dependency_health" in prompt_text
 
     def test_do_run_batches_merges_outputs_and_imports(self, empty_state, tmp_path):
         packet = {
@@ -1883,7 +1970,7 @@ class TestCmdReviewPrepare:
                 output_file=output_file,
                 log_file=log_file,
                 deps=runner_helpers_mod.CodexBatchRunnerDeps(
-                    timeout_seconds=30,
+                    timeout_seconds=1,
                     subprocess_run=subprocess.run,
                     timeout_error=TimeoutError,
                     safe_write_text_fn=lambda p, t: p.write_text(t),
@@ -1896,7 +1983,7 @@ class TestCmdReviewPrepare:
 
         assert code == 124
         log_text = log_file.read_text()
-        assert "STALL RECOVERY" in log_text
+        assert "TIMEOUT after 1s" in log_text
         assert "Recovered stalled batch from JSON output file" not in log_text
 
     def test_collect_batch_results_recovers_execution_failure_with_valid_output(

--- a/desloppify/tests/review/test_runner_internals.py
+++ b/desloppify/tests/review/test_runner_internals.py
@@ -207,7 +207,7 @@ class TestCheckStall:
     """_check_stall: state machine for detecting runner stalls."""
 
     def test_no_output_file_first_call_not_stalled(self, tmp_path):
-        """First call with missing output file: not stalled, baseline set."""
+        """Missing output file alone should not trigger the stall path."""
         output_file = tmp_path / "nope.json"
         now = 1000.0
         stalled, sig, stable = _check_stall(
@@ -215,10 +215,10 @@ class TestCheckStall:
         )
         assert stalled is False
         assert sig is None
-        assert stable == now  # baseline set to now
+        assert stable is None
 
     def test_no_output_file_stalls_after_threshold(self, tmp_path):
-        """Missing output file stalls when both output age and stream idle exceed threshold."""
+        """Missing output file still should not be treated as a stall."""
         output_file = tmp_path / "nope.json"
         baseline = 1000.0
         now = 1050.0  # 50s later
@@ -226,7 +226,9 @@ class TestCheckStall:
         stalled, sig, stable = _check_stall(
             output_file, None, baseline, now, last_activity, threshold=30
         )
-        assert stalled is True
+        assert stalled is False
+        assert sig is None
+        assert stable is None
 
     def test_no_output_file_not_stalled_when_stream_active(self, tmp_path):
         """Missing output but recent stream activity prevents stall."""
@@ -238,6 +240,8 @@ class TestCheckStall:
             output_file, None, baseline, now, last_activity, threshold=30
         )
         assert stalled is False
+        assert sig is None
+        assert stable is None
 
     def test_file_changes_resets_stable_since(self, tmp_path):
         """When the file signature changes, stable_since resets and no stall."""


### PR DESCRIPTION
Fixes #371

## Summary

This fixes a group of review/scan workflow regressions that showed up while validating the Codex-based holistic review path:

- `review --run-batches` now reuses the prepared holistic packet from `.desloppify/query.json` when no new scope is requested
- rerun preflight now derives its target dimensions from the prepared query when appropriate
- blind packet snapshots are run-scoped instead of reusing a single global filename
- silent Codex batches are no longer killed as "stalled" before an output file exists
- `jscpd` duplication analysis now skips quickly when no local/global `jscpd` executable is available

## Why

These issues combined into a pretty confusing workflow:

- a prepared `dependency_health` rerun could generate a stale prompt for another dimension
- `run-batches --parallel` could unexpectedly expand into a full 20-batch run
- every silent batch could then fail with early stall kills
- `scan` could hang at boilerplate duplication in environments without `jscpd`

## Validation

Targeted tests:

- `pytest desloppify/tests/commands/review/test_review_preflight.py desloppify/tests/review/test_runner_internals.py desloppify/tests/detectors/test_external_adapters.py desloppify/tests/review/review_commands_cases.py -q`

Result:

- `249 passed`

## Notes

The prepared-packet reuse path intentionally stays conservative:

- explicit `--packet` still wins
- explicit `--dimensions` still triggers fresh packet preparation
- retrospective runs still prepare a fresh packet
