### PR TITLE
fix: rust workspace rustdoc execution

### DIFF
--- a/desloppify/languages/rust/README.md
+++ b/desloppify/languages/rust/README.md
@@ -308,7 +308,7 @@ Current command policy:
 
 - Clippy runs workspace-wide, all targets, all features, JSON output
 - Cargo check runs workspace-wide, all targets, all features, JSON output
-- Rustdoc runs workspace-wide, all features, library target only, JSON output
+- Rustdoc runs once per workspace library package with `cargo rustdoc -p <package> --lib`, all features, JSON output
 
 Current rustdoc warnings enabled:
 

--- a/desloppify/languages/rust/commands.py
+++ b/desloppify/languages/rust/commands.py
@@ -23,6 +23,7 @@ from desloppify.languages._framework.commands_base_registry import (
     make_cmd_dupes,
     make_cmd_orphaned,
 )
+from desloppify.languages._framework.generic_parts.tool_runner import ToolRunResult
 from desloppify.languages._framework.generic_parts.tool_runner import run_tool_result
 from desloppify.languages.rust.detectors import (
     detect_async_locking,
@@ -48,15 +49,15 @@ from desloppify.languages.rust.phases import (
 from desloppify.languages.rust.tools import (
     CARGO_ERROR_CMD as RUST_CHECK_CMD,
     CLIPPY_WARNING_CMD as RUST_CLIPPY_CMD,
-    RUSTDOC_WARNING_CMD as RUST_RUSTDOC_CMD,
     parse_cargo_errors,
     parse_clippy_messages,
     parse_rustdoc_messages,
+    run_rustdoc_result,
 )
 
 DetectCommand = Callable[[argparse.Namespace], None]
 EntryDetector = Callable[[Path], tuple[list[dict[str, Any]], int]]
-ToolOutputParser = Callable[[str, Path], list[dict[str, Any]]]
+ToolResultRunner = Callable[[Path], ToolRunResult]
 
 cmd_large = make_cmd_large(
     find_rust_files,
@@ -102,11 +103,10 @@ cmd_smells = make_cmd_smells(detect_smells, module_name=__name__)
 
 def _make_tool_detect_command(
     label: str,
-    cmd: str,
-    parser: ToolOutputParser,
+    runner: ToolResultRunner,
 ) -> DetectCommand:
     def command(args: argparse.Namespace) -> None:
-        result = run_tool_result(cmd, Path(args.path), parser)
+        result = runner(Path(args.path))
         if result.status == "error":
             payload = {
                 "count": 0,
@@ -175,18 +175,15 @@ def _make_entry_detect_command(
 
 cmd_clippy_warning = _make_tool_detect_command(
     RUST_CLIPPY_LABEL,
-    RUST_CLIPPY_CMD,
-    parse_clippy_messages,
+    lambda path: run_tool_result(RUST_CLIPPY_CMD, path, parse_clippy_messages),
 )
 cmd_cargo_error = _make_tool_detect_command(
     RUST_CHECK_LABEL,
-    RUST_CHECK_CMD,
-    parse_cargo_errors,
+    lambda path: run_tool_result(RUST_CHECK_CMD, path, parse_cargo_errors),
 )
 cmd_rustdoc_warning = _make_tool_detect_command(
     RUST_RUSTDOC_LABEL,
-    RUST_RUSTDOC_CMD,
-    parse_rustdoc_messages,
+    run_rustdoc_result,
 )
 cmd_rust_import_hygiene = _make_entry_detect_command(
     "Rust import hygiene",

--- a/desloppify/languages/rust/phases.py
+++ b/desloppify/languages/rust/phases.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 from desloppify.base.output.terminal import log
@@ -26,6 +27,7 @@ from desloppify.languages._framework.issue_factories import (
 from desloppify.languages._framework.generic_parts.tool_factories import (
     _record_tool_failure_coverage,
 )
+from desloppify.languages._framework.generic_parts.tool_runner import ToolRunResult
 from desloppify.languages._framework.generic_parts.tool_runner import run_tool_result
 from desloppify.languages.rust.detectors import (
     detect_async_locking,
@@ -46,7 +48,7 @@ from desloppify.languages.rust.tools import (
     RUSTDOC_WARNING_CMD as RUST_RUSTDOC_CMD,
     parse_cargo_errors,
     parse_clippy_messages,
-    parse_rustdoc_messages,
+    run_rustdoc_result,
 )
 from desloppify.state import Issue
 from desloppify.state import make_issue
@@ -236,9 +238,12 @@ def phase_signature(path: Path, lang: LangRuntimeContract) -> tuple[list[Issue],
     return issues, {"signature": len(entries)} if entries else {}
 
 
-def _make_rust_tool_phase(label: str, cmd: str, parser, detector: str, tier: int):
+ToolResultRunner = Callable[[Path], ToolRunResult]
+
+
+def _make_rust_tool_phase(label: str, runner: ToolResultRunner, detector: str, tier: int):
     def run(path: Path, lang) -> tuple[list[dict], dict[str, int]]:
-        result = run_tool_result(cmd, path, parser)
+        result = runner(path)
         if result.status == "error":
             _record_tool_failure_coverage(
                 lang,
@@ -268,8 +273,7 @@ def _make_rust_tool_phase(label: str, cmd: str, parser, detector: str, tier: int
 def tool_phase_clippy():
     return _make_rust_tool_phase(
         RUST_CLIPPY_LABEL,
-        RUST_CLIPPY_CMD,
-        parse_clippy_messages,
+        lambda path: run_tool_result(RUST_CLIPPY_CMD, path, parse_clippy_messages),
         "clippy_warning",
         tier=2,
     )
@@ -278,8 +282,7 @@ def tool_phase_clippy():
 def tool_phase_check():
     return _make_rust_tool_phase(
         RUST_CHECK_LABEL,
-        RUST_CHECK_CMD,
-        parse_cargo_errors,
+        lambda path: run_tool_result(RUST_CHECK_CMD, path, parse_cargo_errors),
         "cargo_error",
         tier=3,
     )
@@ -288,8 +291,7 @@ def tool_phase_check():
 def tool_phase_rustdoc():
     return _make_rust_tool_phase(
         RUST_RUSTDOC_LABEL,
-        RUST_RUSTDOC_CMD,
-        parse_rustdoc_messages,
+        run_rustdoc_result,
         "rustdoc_warning",
         tier=2,
     )

--- a/desloppify/languages/rust/tests/test_tools.py
+++ b/desloppify/languages/rust/tests/test_tools.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
-from desloppify.languages.rust.tools import parse_cargo_errors, parse_clippy_messages
+from desloppify.languages.rust.tools import (
+    build_rustdoc_warning_cmd,
+    parse_cargo_errors,
+    parse_clippy_messages,
+    parse_rustdoc_messages,
+    run_rustdoc_result,
+)
 
 
 def test_parse_clippy_messages_ignores_non_json_noise():
@@ -73,3 +80,149 @@ def test_parse_cargo_errors_prefers_primary_span_and_includes_error_code():
             "message": "[E0425] cannot find value `answer` in this scope",
         }
     ]
+
+
+def test_parse_rustdoc_messages_includes_lint_code():
+    message = {
+        "reason": "compiler-message",
+        "message": {
+            "level": "warning",
+            "message": "no documentation found for this crate's top-level module",
+            "code": {"code": "rustdoc::missing_crate_level_docs"},
+            "spans": [
+                {
+                    "is_primary": True,
+                    "file_name": "crates/lib/src/lib.rs",
+                    "line_start": 1,
+                }
+            ],
+        },
+    }
+
+    entries = parse_rustdoc_messages(json.dumps(message), Path("."))
+
+    assert entries == [
+        {
+            "file": "crates/lib/src/lib.rs",
+            "line": 1,
+            "message": (
+                "[rustdoc::missing_crate_level_docs] "
+                "no documentation found for this crate's top-level module"
+            ),
+        }
+    ]
+
+
+def test_build_rustdoc_warning_cmd_targets_one_package():
+    command = build_rustdoc_warning_cmd("demo-crate")
+
+    assert "cargo rustdoc" in command
+    assert "--package demo-crate" in command
+    assert "--workspace" not in command
+    assert "--lib" in command
+
+
+def test_run_rustdoc_result_scans_each_workspace_library_package(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    commands: list[str] = []
+
+    metadata = {
+        "workspace_members": ["pkg-a 0.1.0 (path+file:///workspace/pkg-a)", "pkg-b 0.1.0 (path+file:///workspace/pkg-b)", "pkg-c 0.1.0 (path+file:///workspace/pkg-c)"],
+        "packages": [
+            {
+                "id": "pkg-a 0.1.0 (path+file:///workspace/pkg-a)",
+                "name": "pkg-a",
+                "targets": [{"kind": ["lib"], "crate_types": ["lib"]}],
+            },
+            {
+                "id": "pkg-b 0.1.0 (path+file:///workspace/pkg-b)",
+                "name": "pkg-b",
+                "targets": [{"kind": ["bin"], "crate_types": ["bin"]}],
+            },
+            {
+                "id": "pkg-c 0.1.0 (path+file:///workspace/pkg-c)",
+                "name": "pkg-c",
+                "targets": [{"kind": ["proc-macro"], "crate_types": ["proc-macro"]}],
+            },
+        ],
+    }
+    rustdoc_message = lambda file_name, line_no: json.dumps(
+        {
+            "reason": "compiler-message",
+            "message": {
+                "level": "warning",
+                "message": "missing docs",
+                "spans": [
+                    {
+                        "is_primary": True,
+                        "file_name": file_name,
+                        "line_start": line_no,
+                    }
+                ],
+            },
+        }
+    )
+
+    def runner(args, **kwargs):
+        command = args[2] if args[:2] == ["/bin/sh", "-lc"] else " ".join(args)
+        commands.append(command)
+        if command == "cargo metadata --format-version=1 --no-deps":
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=json.dumps(metadata), stderr="")
+        if "--package pkg-a" in command:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=1,
+                stdout=rustdoc_message("pkg-a/src/lib.rs", 3),
+                stderr="",
+            )
+        if "--package pkg-c" in command:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=1,
+                stdout=rustdoc_message("pkg-c/src/lib.rs", 8),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    result = run_rustdoc_result(workspace, run_subprocess=runner)
+
+    assert result.status == "ok"
+    assert result.entries == [
+        {"file": "pkg-a/src/lib.rs", "line": 3, "message": "missing docs"},
+        {"file": "pkg-c/src/lib.rs", "line": 8, "message": "missing docs"},
+    ]
+    assert commands[0] == "cargo metadata --format-version=1 --no-deps"
+    assert any("--package pkg-a" in command for command in commands)
+    assert not any("--package pkg-b" in command for command in commands)
+    assert any("--package pkg-c" in command for command in commands)
+
+
+def test_run_rustdoc_result_returns_error_for_unparsed_package_failure(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    metadata = {
+        "workspace_members": ["pkg-a 0.1.0 (path+file:///workspace/pkg-a)"],
+        "packages": [
+            {
+                "id": "pkg-a 0.1.0 (path+file:///workspace/pkg-a)",
+                "name": "pkg-a",
+                "targets": [{"kind": ["lib"], "crate_types": ["lib"]}],
+            }
+        ],
+    }
+
+    def runner(args, **kwargs):
+        command = args[2] if args[:2] == ["/bin/sh", "-lc"] else " ".join(args)
+        if command == "cargo metadata --format-version=1 --no-deps":
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=json.dumps(metadata), stderr="")
+        if "--package pkg-a" in command:
+            return subprocess.CompletedProcess(args=args, returncode=2, stdout="not json", stderr="")
+        raise AssertionError(f"unexpected command: {command}")
+
+    result = run_rustdoc_result(workspace, run_subprocess=runner)
+
+    assert result.status == "error"
+    assert result.error_kind == "tool_failed_unparsed_output"
+    assert result.message is not None
+    assert result.message.startswith("pkg-a:")

--- a/desloppify/languages/rust/tools.py
+++ b/desloppify/languages/rust/tools.py
@@ -3,8 +3,19 @@
 from __future__ import annotations
 
 import json
+import shlex
+import subprocess  # nosec B404
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+
+from desloppify.languages._framework.generic_parts.tool_runner import (
+    SubprocessRun,
+    ToolRunResult,
+    resolve_command_argv,
+    run_tool_result,
+)
+from desloppify.languages.rust.support import find_workspace_root
 
 CLIPPY_WARNING_CMD = (
     "cargo clippy --workspace --all-targets --all-features --message-format=json "
@@ -16,11 +27,13 @@ CARGO_ERROR_CMD = (
     "cargo check --workspace --all-targets --all-features --message-format=json 2>&1"
 )
 RUSTDOC_WARNING_CMD = (
-    "cargo rustdoc --workspace --all-features --lib --message-format=json "
+    "cargo rustdoc --package {package} --all-features --lib --message-format=json "
     "-- -D rustdoc::broken_intra_doc_links "
     "-D rustdoc::private_intra_doc_links "
     "-W rustdoc::missing_crate_level_docs 2>&1"
 )
+_CARGO_METADATA_CMD = "cargo metadata --format-version=1 --no-deps"
+_LIB_TARGET_KINDS = {"lib", "rlib", "dylib", "cdylib", "staticlib", "proc-macro"}
 
 
 def _pick_primary_span(spans: list[dict[str, Any]]) -> dict[str, Any] | None:
@@ -101,11 +114,162 @@ def parse_rustdoc_messages(output: str, scan_path: Path) -> list[dict[str, Any]]
     return _parse_cargo_messages(output, scan_path, allowed_levels={"warning", "error"})
 
 
+def build_rustdoc_warning_cmd(package: str) -> str:
+    """Build a `cargo rustdoc` command for one workspace package."""
+    return RUSTDOC_WARNING_CMD.format(package=shlex.quote(package))
+
+
+def _extract_workspace_rustdoc_packages(payload: dict[str, Any]) -> list[str]:
+    workspace_members = set(payload.get("workspace_members") or [])
+    packages: list[str] = []
+    for package in payload.get("packages") or []:
+        if not isinstance(package, dict) or package.get("id") not in workspace_members:
+            continue
+        name = package.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        targets = package.get("targets") or []
+        has_lib_target = False
+        for target in targets:
+            if not isinstance(target, dict):
+                continue
+            kinds = {str(kind) for kind in target.get("kind") or []}
+            crate_types = {str(kind) for kind in target.get("crate_types") or []}
+            if kinds & _LIB_TARGET_KINDS or crate_types & _LIB_TARGET_KINDS:
+                has_lib_target = True
+                break
+        if has_lib_target:
+            packages.append(name.strip())
+    return sorted(dict.fromkeys(packages))
+
+
+def _run_cargo_metadata(
+    scan_path: Path,
+    *,
+    run_subprocess: SubprocessRun | None = None,
+) -> tuple[ToolRunResult | None, list[str]]:
+    runner: Callable[..., subprocess.CompletedProcess[str]] = run_subprocess or subprocess.run
+    workspace_root = find_workspace_root(scan_path)
+    try:
+        result = runner(
+            resolve_command_argv(_CARGO_METADATA_CMD),
+            shell=False,
+            cwd=str(workspace_root),
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except FileNotFoundError as exc:
+        return (
+            ToolRunResult(
+                entries=[],
+                status="error",
+                error_kind="tool_not_found",
+                message=str(exc),
+            ),
+            [],
+        )
+    except subprocess.TimeoutExpired as exc:
+        return (
+            ToolRunResult(
+                entries=[],
+                status="error",
+                error_kind="tool_timeout",
+                message=str(exc),
+            ),
+            [],
+        )
+
+    output = (result.stdout or "") + (result.stderr or "")
+    if result.returncode not in (0, None):
+        preview = " ".join(output.split())
+        return (
+            ToolRunResult(
+                entries=[],
+                status="error",
+                error_kind="tool_failed_unparsed_output",
+                message=(
+                    f"cargo metadata exited with code {result.returncode}"
+                    + (f": {preview[:160].rstrip()}..." if len(preview) > 160 else f": {preview}" if preview else "")
+                ),
+                returncode=result.returncode,
+            ),
+            [],
+        )
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError as exc:
+        return (
+            ToolRunResult(
+                entries=[],
+                status="error",
+                error_kind="parser_error",
+                message=str(exc),
+                returncode=result.returncode,
+            ),
+            [],
+        )
+    if not isinstance(data, dict):
+        return (
+            ToolRunResult(
+                entries=[],
+                status="error",
+                error_kind="parser_shape_error",
+                message="cargo metadata returned non-object JSON",
+                returncode=result.returncode,
+            ),
+            [],
+        )
+    return None, _extract_workspace_rustdoc_packages(data)
+
+
+def run_rustdoc_result(
+    scan_path: Path,
+    *,
+    run_subprocess: SubprocessRun | None = None,
+) -> ToolRunResult:
+    """Run `cargo rustdoc` once per workspace library package."""
+    metadata_error, packages = _run_cargo_metadata(scan_path, run_subprocess=run_subprocess)
+    if metadata_error is not None:
+        return metadata_error
+    if not packages:
+        return ToolRunResult(entries=[], status="empty", returncode=0)
+
+    workspace_root = find_workspace_root(scan_path)
+    entries: list[dict[str, Any]] = []
+    returncode = 0
+    for package in packages:
+        result = run_tool_result(
+            build_rustdoc_warning_cmd(package),
+            workspace_root,
+            parse_rustdoc_messages,
+            run_subprocess=run_subprocess,
+        )
+        if result.status == "error":
+            message = result.message or "cargo rustdoc failed"
+            return ToolRunResult(
+                entries=[],
+                status="error",
+                error_kind=result.error_kind,
+                message=f"{package}: {message}",
+                returncode=result.returncode,
+            )
+        if result.status == "ok":
+            entries.extend(result.entries)
+            if result.returncode not in (0, None):
+                returncode = result.returncode
+    if not entries:
+        return ToolRunResult(entries=[], status="empty", returncode=returncode)
+    return ToolRunResult(entries=entries, status="ok", returncode=returncode)
+
+
 __all__ = [
+    "build_rustdoc_warning_cmd",
     "CARGO_ERROR_CMD",
     "CLIPPY_WARNING_CMD",
     "RUSTDOC_WARNING_CMD",
     "parse_cargo_errors",
     "parse_clippy_messages",
     "parse_rustdoc_messages",
+    "run_rustdoc_result",
 ]


### PR DESCRIPTION
## Context

This is a follow-up fix for a regression introduced in the earlier Rust support PR.

That PR added the Rust `rustdoc_warning` phase, but the command it used was:

```bash
cargo rustdoc --workspace ...
```

`cargo rustdoc` does not accept `--workspace`, so for Cargo workspaces the rustdoc phase never actually ran. The detector degraded, but the intended rustdoc validation was missing.

## What this PR fixes

This PR fixes that regression by keeping the phase on real `cargo rustdoc`, but running it correctly for workspaces:

1. Run `cargo metadata --format-version=1 --no-deps`
2. Find workspace members that expose a library target
3. Run `cargo rustdoc -p <package> --lib ...` for each eligible package
4. Merge rustdoc diagnostics across packages
5. Keep hard failures visible when a package rustdoc run fails without parseable diagnostics

This is a correction to the Rust PR’s execution model, not a new Rust feature.

## Why this fix

- It fixes the actual bug introduced by the Rust PR
- It keeps the semantics correct by using `cargo rustdoc`, not `cargo doc`
- It works for multi-crate workspaces
- It skips binary-only packages that do not have a library rustdoc target
- It does not hide real failures

## Files changed

- `desloppify/languages/rust/tools.py`
  - added workspace package discovery and per-package rustdoc execution
- `desloppify/languages/rust/commands.py`
  - routed the direct detector through the new runner
- `desloppify/languages/rust/phases.py`
  - routed the scan phase through the same runner
- `desloppify/languages/rust/tests/test_tools.py`
  - added regression tests for package selection, per-package execution, merged diagnostics, and failure handling
- `desloppify/languages/rust/README.md`
  - updated docs to describe the real rustdoc policy

## Validation

Targeted Rust tests:

- `python3 -m pytest desloppify/languages/rust/tests/test_tools.py desloppify/languages/rust/tests/test_init.py`
- Result: `12 passed`

Command-layer + Rust coverage:

- `python3 -m pytest desloppify/tests/commands desloppify/languages/rust/tests`
- Result: `1588 passed`

Full repo regression run:

- `python3 -m pytest`
- Result: `5866 passed, 145 skipped`

Open-source workspace verification:

- Verified against the open-source workspace example `Miosso/rust-workspace`
- Ran:

```bash
python3 -m desloppify.cli --lang rust detect rustdoc_warning --path <workspace-root> --json
```

- Result: returned a real rustdoc finding from the workspace library crate and skipped the binary-only members

- Also ran:

```bash
python3 -m desloppify.cli --lang rust scan --path <workspace-root> --force-rescan --attest "I understand this is not the intended workflow and I am intentionally skipping queue completion"
```

- Result: completed successfully and reached the `cargo rustdoc` phase inside the normal scan flow

## Reviewer focus

The main thing to review is whether the per-package `cargo rustdoc` runner is the right correction for the regression introduced by the Rust PR, and whether the failure semantics remain appropriately strict.
