### PR TITLE
Fix scan export and scoring impact crash paths

### DIFF
--- a/desloppify/engine/_scoring/results/impact.py
+++ b/desloppify/engine/_scoring/results/impact.py
@@ -38,7 +38,10 @@ def compute_score_impact(
         return 0.0
 
     old_weighted = det_data["weighted_failures"]
-    avg_weight = old_weighted / max(1, det_data["failing"])
+    failing = det_data.get("failing")
+    if not isinstance(failing, (int, float)) or failing <= 0:
+        failing = det_data.get("count")
+    avg_weight = old_weighted / max(1, int(failing) if isinstance(failing, (int, float)) else 1)
     new_weighted = max(0.0, old_weighted - issues_to_fix * avg_weight)
 
     total_potential = 0

--- a/desloppify/engine/planning/__init__.py
+++ b/desloppify/engine/planning/__init__.py
@@ -36,6 +36,19 @@ def generate_plan_md(state: PlanState, plan: dict | None = None) -> str:
     return _generate_plan_md(state, plan)
 
 
+def generate_issues(
+    path: Path,
+    lang: LangConfig | LangRun | None = None,
+    *,
+    options: PlanScanOptions | None = None,
+) -> tuple[list[Issue], dict[str, int]]:
+    from desloppify.engine.planning.scan import generate_issues as _generate_issues
+
+    if options is None:
+        return _generate_issues(path, lang)
+    return _generate_issues(path, lang, options=options)
+
+
 def get_next_item(
     state: PlanState,
     scan_path: str | None = None,
@@ -67,6 +80,7 @@ def get_next_items(
 
 __all__ = [
     "CONFIDENCE_ORDER",
+    "generate_issues",
     "generate_plan_md",
     "get_next_item",
     "get_next_items",


### PR DESCRIPTION
## Summary

This fixes two internal crash paths:

1. `scan` can crash because `desloppify.engine.planning.generate_issues` is called from the package root, but `generate_issues` was only defined in `desloppify.engine.planning.scan` and not re-exported.
2. `status` / `next` can crash in score impact calculation when a detector row has `weighted_failures` but does not include a `failing` field.

## Changes

- Re-export `generate_issues(...)` from `desloppify.engine.planning.__init__`
- Make `compute_score_impact(...)` fall back from `failing` to `count` before dividing

## Why

### Planning export
`app/commands/scan/workflow.py` imports:

```python
from desloppify.engine import planning as plan_mod
```

and then calls: ```plan_mod.generate_issues(...)```
But `engine/planning/__init__.py` did not expose that symbol, so `scan` failed with:

```AttributeError: module 'desloppify.engine.planning' has no attribute 'generate_issues'```

This change makes the package API match how it is already used internally.

### Score impact fallback
`engine/_scoring/results/impact.py` assumed:

`det_data["failing"]`
always exists. In practice that was not always true, which caused:

`KeyError: 'failing'`
during status / next.

Falling back to count keeps the scoring logic intact while preventing a hard crash when detector metadata is incomplete.

### Validation
I validated the patched files compile under Python 3.11:

```python3.11 -m py_compile \
  desloppify/engine/planning/__init__.py \
  desloppify/engine/_scoring/results/impact.py
  ```
- I also reproduced the failures from an installed copy before applying the fixes.
- I then ran the fixed version of desloppify over the changes I made to desloppify and it agreed, so `nepotism check` complete. 