### PR TITLE
feat(r): add Jarl as fast R linter with autofix

### DIFF
--- a/desloppify/languages/r/__init__.py
+++ b/desloppify/languages/r/__init__.py
@@ -1,4 +1,4 @@
-"""R language plugin — lintr + tree-sitter."""
+"""R language plugin — Jarl, lintr + tree-sitter."""
 
 from desloppify.languages._framework.generic_support.core import generic_lang
 from desloppify.languages._framework.treesitter import R_SPEC
@@ -8,6 +8,14 @@ generic_lang(
     extensions=[".R", ".r"],
     tools=[
         {
+            "label": "jarl",
+            "cmd": "jarl check .",
+            "fmt": "gnu",
+            "id": "jarl_lint",
+            "tier": 2,
+            "fix_cmd": "jarl check . --fix --allow-dirty",
+        },
+        {
             "label": "lintr",
             "cmd": (
                 'Rscript -e \'cat(paste(capture.output('
@@ -16,7 +24,7 @@ generic_lang(
             ),
             "fmt": "gnu",
             "id": "lintr_lint",
-            "tier": 2,
+            "tier": 3,
             "fix_cmd": None,
         },
     ],


### PR DESCRIPTION
Summary
   Added Jarl (Just Another R Linter) as the fast, modern R linter with
    auto-fix support.

   Changes
   •  Added Jarl as tier 2 linter (becomes primary)
   •  Demoted lintr to tier 3 (fallback for projects without Jarl)
   •  Updated module docstring

   Why Jarl?
   •  Speed: Orders of magnitude faster than lintr (0.131s vs 18.5s on dplyr)
   •  Auto-fix: Supports --fix flag for automatic fixes (lintr has no auto-fix)
   •  Active development: Built on Air (Posit's Rust formatter)
   •  55+ rules: Growing rule set inspired by lintr

   Testing
   •  All 416 tests pass
   •  R import resolver test passes