### PR TITLE
Fix unused import detection for JS/TS (binding-aware, per-symbol issues)

### DIFF
--- a/desloppify/languages/_framework/treesitter/analysis/unused_imports.py
+++ b/desloppify/languages/_framework/treesitter/analysis/unused_imports.py
@@ -19,6 +19,34 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_ECMASCRIPT_IMPORT_NODE_TYPE = "import_statement"
+
+# Identifier-ish nodes that represent a reference to a binding in JavaScript/TypeScript.
+# JSX tag names are typically represented as `identifier` in tree-sitter-javascript/tsx,
+# but we include `jsx_identifier` as well for compatibility with grammar variants.
+_ECMASCRIPT_REFERENCE_NODE_TYPES = frozenset({
+    "identifier",
+    "jsx_identifier",
+    "type_identifier",
+    "shorthand_property_identifier",
+})
+
+_ECMASCRIPT_ASSIGNMENT_PATTERN_NODE_TYPES = frozenset({
+    "assignment_pattern",
+    "object_assignment_pattern",
+    "array_assignment_pattern",
+})
+
+_ECMASCRIPT_DECLARATION_NAME_NODE_TYPES = frozenset({
+    # JS
+    "function_declaration",
+    "class_declaration",
+    # TS/TSX
+    "type_alias_declaration",
+    "interface_declaration",
+    "enum_declaration",
+})
+
 
 def detect_unused_imports(
     file_list: list[str],
@@ -36,6 +64,11 @@ def detect_unused_imports(
     except PARSE_INIT_ERRORS as exc:
         logger.debug("tree-sitter init failed: %s", exc)
         return []
+
+    # JavaScript/JSX: extract imported *local bindings* and check whether each
+    # binding is referenced in the file body. This avoids module-path heuristics.
+    if spec.grammar in ("javascript", "tsx"):
+        return _detect_unused_imports_ecmascript(file_list, spec, parser, language)
 
     query = _make_query(language, spec.import_query)
     entries: list[dict] = []
@@ -87,6 +120,267 @@ def detect_unused_imports(
                 })
 
     return entries
+
+
+def _detect_unused_imports_ecmascript(
+    file_list: list[str],
+    spec: TreeSitterLangSpec,
+    parser,
+    language,
+) -> list[dict]:
+    """Binding-aware unused import detection for JavaScript/TypeScript (JSX/TSX).
+
+    Emits one entry per unused imported local binding:
+    {file, line, name, symbol}
+
+    Side-effect-only imports (e.g. `import "x"`) are ignored.
+    """
+    query = _make_query(language, f"({_ECMASCRIPT_IMPORT_NODE_TYPE}) @import")
+    entries: list[dict] = []
+
+    for filepath in file_list:
+        cached = get_or_parse_tree(filepath, parser, spec.grammar)
+        if cached is None:
+            continue
+        source, tree = cached
+
+        # Some real-world repos contain stray NUL bytes (e.g. broken fixtures).
+        # Tree-sitter can treat these as parse-stopping errors, leading to false
+        # positives due to missing references. Replace NUL with space (same length)
+        # and re-parse for analysis.
+        if b"\x00" in source:
+            source = source.replace(b"\x00", b" ")
+            tree = parser.parse(source)
+
+        # If the parse is still errorful, be conservative and skip this file to
+        # avoid false positives from incomplete trees.
+        if getattr(tree.root_node, "has_error", False):
+            continue
+
+        matches = _run_query(query, tree.root_node)
+        if not matches:
+            continue
+
+        referenced = _collect_ecmascript_references(tree.root_node)
+
+        for _pattern_idx, captures in matches:
+            import_node = _unwrap_node(captures.get("import"))
+            if not import_node:
+                continue
+
+            bindings = _extract_ecmascript_import_bindings(import_node)
+            if not bindings:
+                # Side-effect import (`import "x"`) or empty named import (`import {} from "x"`).
+                continue
+
+            line = import_node.start_point[0] + 1
+            for symbol in bindings:
+                if symbol not in referenced:
+                    entries.append({
+                        "file": filepath,
+                        "line": line,
+                        "name": symbol,
+                        "symbol": symbol,
+                    })
+
+    return entries
+
+
+def _extract_ecmascript_import_bindings(import_node) -> list[str]:
+    """Extract local binding names from an ECMAScript import_statement node."""
+    import_clause = None
+    for child in import_node.named_children:
+        if child.type == "import_clause":
+            import_clause = child
+            break
+    if import_clause is None:
+        return []
+
+    bindings: list[str] = []
+    seen: set[str] = set()
+
+    def add(name: str | None) -> None:
+        if not name or name in seen:
+            return
+        seen.add(name)
+        bindings.append(name)
+
+    for child in import_clause.named_children:
+        # Default import: `import Foo from "x"`
+        if child.type == "identifier":
+            add(_node_text(child))
+            continue
+
+        # Namespace import: `import * as ns from "x"`
+        if child.type == "namespace_import":
+            for grand in child.named_children:
+                if grand.type == "identifier":
+                    add(_node_text(grand))
+                    break
+            continue
+
+        # Named imports: `import { a, b as c } from "x"`
+        if child.type == "named_imports":
+            for spec in child.named_children:
+                if spec.type != "import_specifier":
+                    continue
+                alias = spec.child_by_field_name("alias")
+                name = spec.child_by_field_name("name")
+                add(_node_text(alias) if alias is not None else _node_text(name))
+            continue
+
+    return bindings
+
+
+def _collect_ecmascript_references(root_node) -> set[str]:
+    """Collect identifier-like references outside ECMAScript import statements."""
+    referenced: set[str] = set()
+    stack = [root_node]
+
+    while stack:
+        node = stack.pop()
+        if node.type in _ECMASCRIPT_REFERENCE_NODE_TYPES and not _has_ancestor_type(
+            node, {_ECMASCRIPT_IMPORT_NODE_TYPE}
+        ):
+            if not _is_ecmascript_declaration_occurrence(node):
+                text = _node_text(node)
+                if text:
+                    referenced.add(text)
+
+        for child in reversed(node.named_children):
+            stack.append(child)
+
+    return referenced
+
+
+def _has_ancestor_type(node, ancestor_types: set[str]) -> bool:
+    parent = node.parent
+    while parent is not None:
+        if parent.type in ancestor_types:
+            return True
+        parent = parent.parent
+    return False
+
+
+def _is_ecmascript_declaration_occurrence(node) -> bool:
+    """Return True when `node` appears in a declaration/binding position.
+
+    This prevents counting declarations as references (e.g. destructuring patterns,
+    parameter names, catch parameters, type names).
+
+    Not a full scope resolver; it is a conservative structural filter.
+    """
+    # If we're on the right side of an assignment pattern, treat as an expression reference.
+    if _is_within_assignment_pattern_right(node):
+        return False
+
+    cur = node
+    while cur is not None:
+        # Variable declarators: `const foo = ...`, `const {a: b} = ...`
+        if cur.type == "variable_declarator":
+            name = cur.child_by_field_name("name")
+            if name is not None and _is_descendant(name, node):
+                return True
+
+        # TS/TSX params: `required_parameter` / `optional_parameter` pattern field.
+        if cur.type in ("required_parameter", "optional_parameter"):
+            pattern = cur.child_by_field_name("pattern")
+            if pattern is not None and _is_descendant(pattern, node):
+                return True
+
+        # JS params: patterns live directly under `formal_parameters`.
+        if cur.type == "formal_parameters":
+            param_root = _direct_child_under(cur, node)
+            if param_root is not None:
+                # TS/TSX wraps params in required/optional_parameter; handled above.
+                if param_root.type not in ("required_parameter", "optional_parameter"):
+                    if _is_param_binding_occurrence(param_root, node):
+                        return True
+
+        # Catch binding: `catch (e) { ... }`
+        if cur.type == "catch_clause":
+            param = cur.child_by_field_name("parameter")
+            if param is not None and _is_descendant(param, node):
+                return True
+
+        # Declaration names (function/class/type/interface/enum)
+        if cur.type in _ECMASCRIPT_DECLARATION_NAME_NODE_TYPES:
+            name = cur.child_by_field_name("name")
+            if name is not None and _is_descendant(name, node):
+                return True
+
+        # `for (const x of xs)` / `for (let x in xs)` binding.
+        if cur.type == "for_in_statement":
+            left = cur.child_by_field_name("left")
+            if left is not None and _is_descendant(left, node):
+                # Only treat as a declaration if preceded by a declaration keyword.
+                prev = left.prev_sibling
+                if prev is not None and prev.type in ("const", "let", "var"):
+                    return True
+
+        cur = cur.parent
+
+    return False
+
+
+def _is_within_assignment_pattern_right(node) -> bool:
+    """Return True if node appears within the `right` field of an assignment pattern."""
+    cur = node
+    while cur is not None:
+        parent = cur.parent
+        if parent is None:
+            return False
+        if parent.type in _ECMASCRIPT_ASSIGNMENT_PATTERN_NODE_TYPES:
+            right = parent.child_by_field_name("right")
+            if right is not None and _is_descendant(right, node):
+                return True
+        cur = parent
+    return False
+
+
+def _is_descendant(ancestor, node) -> bool:
+    cur = node
+    while cur is not None:
+        if cur == ancestor:
+            return True
+        cur = cur.parent
+    return False
+
+
+def _direct_child_under(ancestor, node):
+    """Return the direct child of `ancestor` that contains `node`, if any."""
+    cur = node
+    while cur is not None and cur.parent is not None and cur.parent != ancestor:
+        cur = cur.parent
+    if cur is not None and cur.parent == ancestor:
+        return cur
+    return None
+
+
+def _is_param_binding_occurrence(param_root, node) -> bool:
+    """Return True if `node` is part of the parameter binding pattern.
+
+    `param_root` is the direct child of `formal_parameters` that contains `node`.
+    """
+    if _is_within_assignment_pattern_right(node):
+        return False
+
+    # `x` in `(x)` or `...rest` in `(...rest)` are bindings.
+    if param_root.type in ("identifier", "rest_pattern"):
+        return True
+
+    # `x=Default` binds `x` on the left; right side is an expression.
+    if param_root.type == "assignment_pattern":
+        left = param_root.child_by_field_name("left")
+        if left is not None and _is_descendant(left, node):
+            return True
+        return False
+
+    # Destructuring patterns (object/array) bind identifiers inside them.
+    if param_root.type in ("object_pattern", "array_pattern", "pair_pattern"):
+        return True
+
+    return False
 
 
 def _extract_alias(import_node) -> str | None:

--- a/desloppify/languages/_framework/treesitter/phases.py
+++ b/desloppify/languages/_framework/treesitter/phases.py
@@ -126,8 +126,10 @@ def make_unused_imports_phase(spec: TreeSitterLangSpec) -> DetectorPhase:
 
         entries = detect_unused_imports(file_list, spec)
         for e in entries:
+            symbol = e.get("symbol")
+            issue_name = f"unused_import::{e['line']}" + (f"::{symbol}" if symbol else "")
             issues.append(make_issue(
-                "unused", e["file"], f"unused_import::{e['line']}",
+                "unused", e["file"], issue_name,
                 tier=3, confidence="medium",
                 summary=f"Unused import: {e['name']}",
             ))

--- a/desloppify/tests/lang/common/test_treesitter_complexity_and_integration.py
+++ b/desloppify/tests/lang/common/test_treesitter_complexity_and_integration.py
@@ -737,6 +737,341 @@ func main() {
         entries = detect_unused_imports([], spec)
         assert entries == []
 
+    def test_js_named_imports_all_used_no_issue(self, tmp_path):
+        from desloppify.languages._framework.treesitter import JS_SPEC
+        from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+            detect_unused_imports,
+        )
+
+        code = """\
+import { rateLimit, RateLimitConfig } from "@/lib/rate-limit";
+
+console.log(rateLimit, RateLimitConfig);
+"""
+        f = tmp_path / "main.js"
+        f.write_text(code)
+
+        entries = detect_unused_imports([str(f)], JS_SPEC)
+        assert entries == []
+
+    def test_js_default_import_used_in_jsx_no_issue(self, tmp_path):
+        from desloppify.languages._framework.treesitter import JS_SPEC
+        from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+            detect_unused_imports,
+        )
+
+        code = """\
+import ReactMarkdown from "react-markdown";
+
+export function App() {
+  return <ReactMarkdown />;
+}
+"""
+        f = tmp_path / "main.jsx"
+        f.write_text(code)
+
+        entries = detect_unused_imports([str(f)], JS_SPEC)
+        assert entries == []
+
+    def test_js_aliased_named_import_used_no_issue(self, tmp_path):
+        from desloppify.languages._framework.treesitter import JS_SPEC
+        from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+            detect_unused_imports,
+        )
+
+        code = """\
+import { foo as bar } from "x";
+
+console.log(bar);
+"""
+        f = tmp_path / "main.js"
+        f.write_text(code)
+
+        entries = detect_unused_imports([str(f)], JS_SPEC)
+        assert entries == []
+
+    def test_js_namespace_import_used_no_issue(self, tmp_path):
+        from desloppify.languages._framework.treesitter import JS_SPEC
+        from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+            detect_unused_imports,
+        )
+
+        code = """\
+import * as ns from "x";
+
+console.log(ns.foo);
+"""
+        f = tmp_path / "main.js"
+        f.write_text(code)
+
+        entries = detect_unused_imports([str(f)], JS_SPEC)
+        assert entries == []
+
+    def test_js_partially_unused_import_line_flags_only_unused_symbol(self, tmp_path):
+        from desloppify.languages._framework.treesitter import JS_SPEC
+        from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+            detect_unused_imports,
+        )
+
+        code = """\
+import {
+  used,
+  unused,
+} from "x";
+
+console.log(used);
+"""
+        f = tmp_path / "main.js"
+        f.write_text(code)
+
+        entries = detect_unused_imports([str(f)], JS_SPEC)
+        names = [e["name"] for e in entries]
+        assert "unused" in names
+        assert "used" not in names
+        assert len(entries) == 1
+
+    def test_js_side_effect_import_only_not_flagged(self, tmp_path):
+        from desloppify.languages._framework.treesitter import JS_SPEC
+        from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+            detect_unused_imports,
+        )
+
+        code = """\
+import "x";
+
+console.log("hi");
+"""
+        f = tmp_path / "main.js"
+        f.write_text(code)
+
+        entries = detect_unused_imports([str(f)], JS_SPEC)
+        assert entries == []
+
+    def test_js_unused_import_issue_id_includes_line_and_symbol(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        from desloppify.languages._framework.treesitter import JS_SPEC
+        from desloppify.languages._framework.treesitter.phases import (
+            make_unused_imports_phase,
+        )
+
+        code = """\
+import { used, unused } from "x";
+
+console.log(used);
+"""
+        f = tmp_path / "main.js"
+        f.write_text(code)
+
+        phase = make_unused_imports_phase(JS_SPEC)
+        mock_lang = MagicMock()
+        mock_lang.file_finder.return_value = [str(f)]
+
+        issues, potentials = phase.run(tmp_path, mock_lang)
+
+        assert potentials["unused_imports"] == 1
+        assert len(issues) == 1
+        assert issues[0]["id"].endswith("::unused_import::1::unused")
+        assert issues[0]["summary"] == "Unused import: unused"
+
+    def test_ts_named_imports_all_used_no_issue(self, tmp_path):
+        from desloppify.languages._framework.treesitter import TYPESCRIPT_SPEC
+        from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+            detect_unused_imports,
+        )
+
+        code = """\
+import { rateLimit, RateLimitConfig } from "@/lib/rate-limit";
+
+export const x: RateLimitConfig = rateLimit();
+"""
+        f = tmp_path / "main.ts"
+        f.write_text(code)
+
+        entries = detect_unused_imports([str(f)], TYPESCRIPT_SPEC)
+        assert entries == []
+
+    def test_ts_default_import_used_in_tsx_no_issue(self, tmp_path):
+        from desloppify.languages._framework.treesitter import TYPESCRIPT_SPEC
+        from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+            detect_unused_imports,
+        )
+
+        code = """\
+import ReactMarkdown from "react-markdown";
+
+export function App() {
+  return <ReactMarkdown />;
+}
+"""
+        f = tmp_path / "main.tsx"
+        f.write_text(code)
+
+        entries = detect_unused_imports([str(f)], TYPESCRIPT_SPEC)
+        assert entries == []
+
+    def test_ts_type_only_named_import_used_in_type_position_no_issue(self, tmp_path):
+        from desloppify.languages._framework.treesitter import TYPESCRIPT_SPEC
+        from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+            detect_unused_imports,
+        )
+
+        code = """\
+import type { Foo } from "x";
+
+export type X = Foo;
+"""
+        f = tmp_path / "main.ts"
+        f.write_text(code)
+
+        entries = detect_unused_imports([str(f)], TYPESCRIPT_SPEC)
+        assert entries == []
+
+    def test_ts_partially_unused_import_line_flags_only_unused_symbol(self, tmp_path):
+        from desloppify.languages._framework.treesitter import TYPESCRIPT_SPEC
+        from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+            detect_unused_imports,
+        )
+
+        code = """\
+import {
+  used,
+  unused,
+} from "x";
+
+export const y = used;
+"""
+        f = tmp_path / "main.ts"
+        f.write_text(code)
+
+        entries = detect_unused_imports([str(f)], TYPESCRIPT_SPEC)
+        names = [e["name"] for e in entries]
+        assert "unused" in names
+        assert "used" not in names
+        assert len(entries) == 1
+
+    def test_ts_side_effect_import_only_not_flagged(self, tmp_path):
+        from desloppify.languages._framework.treesitter import TYPESCRIPT_SPEC
+        from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+            detect_unused_imports,
+        )
+
+        code = """\
+import "x";
+
+export const x = 1;
+"""
+        f = tmp_path / "main.ts"
+        f.write_text(code)
+
+        entries = detect_unused_imports([str(f)], TYPESCRIPT_SPEC)
+        assert entries == []
+
+    def test_ts_unused_import_issue_id_includes_line_and_symbol(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        from desloppify.languages._framework.treesitter import TYPESCRIPT_SPEC
+        from desloppify.languages._framework.treesitter.phases import (
+            make_unused_imports_phase,
+        )
+
+        code = """\
+import { used, unused } from "x";
+
+export const z = used;
+"""
+        f = tmp_path / "main.ts"
+        f.write_text(code)
+
+        phase = make_unused_imports_phase(TYPESCRIPT_SPEC)
+        mock_lang = MagicMock()
+        mock_lang.file_finder.return_value = [str(f)]
+
+        issues, potentials = phase.run(tmp_path, mock_lang)
+
+        assert potentials["unused_imports"] == 1
+        assert len(issues) == 1
+        assert issues[0]["id"].endswith("::unused_import::1::unused")
+        assert issues[0]["summary"] == "Unused import: unused"
+
+    def test_js_destructuring_default_value_counts_as_usage(self, tmp_path):
+        """Default values inside destructuring patterns should count as usage."""
+        from desloppify.languages._framework.treesitter import JS_SPEC
+        from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+            detect_unused_imports,
+        )
+
+        code = """\
+import { imported } from "x";
+
+const { x = imported } = obj;
+console.log(x);
+"""
+        f = tmp_path / "main.js"
+        f.write_text(code)
+
+        entries = detect_unused_imports([str(f)], JS_SPEC)
+        assert entries == []
+
+    def test_js_param_default_value_counts_as_usage(self, tmp_path):
+        """Parameter default values should count as usage (JS grammar)."""
+        from desloppify.languages._framework.treesitter import JS_SPEC
+        from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+            detect_unused_imports,
+        )
+
+        code = """\
+import { Bar } from "x";
+
+function f(x = Bar) {
+  return x;
+}
+"""
+        f = tmp_path / "main.js"
+        f.write_text(code)
+
+        entries = detect_unused_imports([str(f)], JS_SPEC)
+        assert entries == []
+
+    def test_ts_param_type_annotation_counts_as_usage(self, tmp_path):
+        """Parameter type annotations should count as usage (TSX grammar)."""
+        from desloppify.languages._framework.treesitter import TYPESCRIPT_SPEC
+        from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+            detect_unused_imports,
+        )
+
+        code = """\
+import type { Foo } from "x";
+
+export function f(x: Foo) {
+  return x;
+}
+"""
+        f = tmp_path / "main.ts"
+        f.write_text(code)
+
+        entries = detect_unused_imports([str(f)], TYPESCRIPT_SPEC)
+        assert entries == []
+
+    def test_ts_file_with_nul_byte_does_not_false_positive(self, tmp_path):
+        """Stray NUL bytes should not cause parse-truncation false positives."""
+        from desloppify.languages._framework.treesitter import TYPESCRIPT_SPEC
+        from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+            detect_unused_imports,
+        )
+
+        code = (
+            b'import { jest } from "@jest/globals";\n'
+            b'jest.spyOn(console, "log");\n'
+            b'\x00\n'
+            b'jest.spyOn(console, "warn");\n'
+        )
+        f = tmp_path / "main.ts"
+        f.write_bytes(code)
+
+        entries = detect_unused_imports([str(f)], TYPESCRIPT_SPEC)
+        assert entries == []
+
 
 # ── Signature variance tests ─────────────────────────────────
 


### PR DESCRIPTION
Closes #430.

This replaces module-path/basename matching with binding-aware unused import detection for JavaScript/JSX and TypeScript/TSX:
- Parses `import_statement` bindings (default, named, aliased, namespace).
- Builds a reference set from AST identifiers outside import declarations (includes JSX tags and TS type identifiers).
- Flags only truly-unused imported local bindings.
- Emits one issue per unused symbol with name format `unused_import::<line>::<symbol>`.
- Keeps side-effect imports (`import "x"`) unflagged.
- Handles multiline imports.

Robustness:
- Some real OSS fixtures contained stray NUL bytes which can cause tree-sitter parse truncation and false positives; we replace NUL with space and re-parse, and skip files that still parse with errors.

Tests:
- Added/extended tests for JS/JSX + TS/TSX (default/named/alias/namespace, partial unused, side-effect imports, issue id format, default-value usages, TS type-only imports, NUL-byte regression).

Evidence:
- Benchmarked on create-react-app, docusaurus, gatsby (scanning up to 1200 files per repo). New detector substantially reduces false positives, and side-effect-import false positives drop to 0 across runs.