### PR TITLE
fix(engine): prevent workflow::create-plan re-injection after resolution

### DIFF
--- a/desloppify/app/commands/review/importing/plan_sync.py
+++ b/desloppify/app/commands/review/importing/plan_sync.py
@@ -27,7 +27,10 @@ from desloppify.engine._plan.sync import (
     reconcile_plan,
 )
 from desloppify.engine._plan.sync.workflow_gates import sync_import_scores_needed
-from desloppify.engine._plan.sync.workflow import clear_score_communicated_sentinel
+from desloppify.engine._plan.sync.workflow import (
+    clear_create_plan_sentinel,
+    clear_score_communicated_sentinel,
+)
 from desloppify.engine._plan.refresh_lifecycle import mark_subjective_review_completed
 from desloppify.engine.plan_triage import (
     TRIAGE_CMD_RUN_STAGES_CLAUDE,
@@ -103,7 +106,7 @@ def _print_new_review_items(state: dict, new_ids: list[str]) -> None:
             "bold",
         )
     )
-    issues = (state.get("work_items") or state.get("issues", {}))
+    issues = state.get("work_items") or state.get("issues", {})
     for finding_id in sorted(new_ids)[:10]:
         finding = issues.get(finding_id, {})
         print(f"    * [{short_issue_id(finding_id)}] {finding.get('summary', '')}")
@@ -140,7 +143,9 @@ def _print_review_import_footer(
     outcome: PlanImportSyncOutcome,
 ) -> None:
     print()
-    status_line = "  Review queue sync completed. Workflow follow-up may be front-loaded."
+    status_line = (
+        "  Review queue sync completed. Workflow follow-up may be front-loaded."
+    )
     status_tone = "dim"
     if outcome.status == "degraded" and outcome.message:
         status_line = f"  Review queue sync degraded: {outcome.message}"
@@ -148,7 +153,9 @@ def _print_review_import_footer(
     print(colorize(status_line, status_tone))
     print()
     print(colorize("  View execution queue:  desloppify plan queue", "dim"))
-    print(colorize("  View newest first:     desloppify plan queue --sort recent", "dim"))
+    print(
+        colorize("  View newest first:     desloppify plan queue --sort recent", "dim")
+    )
     print(colorize("  View broader backlog:  desloppify backlog", "dim"))
     print()
     print(colorize("  NEXT STEP:", "yellow"))
@@ -167,8 +174,7 @@ def _print_review_import_footer(
 
 def _review_delta_present(diff: dict) -> bool:
     return any(
-        int(diff.get(key, 0) or 0) > 0
-        for key in ("new", "reopened", "auto_resolved")
+        int(diff.get(key, 0) or 0) > 0 for key in ("new", "reopened", "auto_resolved")
     )
 
 
@@ -197,8 +203,7 @@ def _build_import_sync_inputs(
         has_review_issue_delta=_review_delta_present(diff),
         assessment_keys=frozenset(assessment_keys),
         covered_ids=tuple(
-            f"subjective::{dim_key}"
-            for dim_key in sorted(assessment_keys)
+            f"subjective::{dim_key}" for dim_key in sorted(assessment_keys)
         ),
     )
 
@@ -232,7 +237,9 @@ def _apply_import_plan_transitions(
     """Apply plan mutations driven by a review import before persistence/output."""
     import_result = _sync_review_delta(plan, state, sync_inputs)
     covered_pruned = (
-        _prune_covered_subjective_ids_from_plan(plan, covered_ids=sync_inputs.covered_ids)
+        _prune_covered_subjective_ids_from_plan(
+            plan, covered_ids=sync_inputs.covered_ids
+        )
         if trusted
         else []
     )
@@ -245,6 +252,7 @@ def _apply_import_plan_transitions(
     )
     if trusted:
         clear_score_communicated_sentinel(plan)
+        clear_create_plan_sentinel(plan)
         if sync_inputs.covered_ids:
             mark_subjective_review_completed(
                 plan,
@@ -346,8 +354,12 @@ def _append_review_import_sync_log(
         actor="system",
         detail={
             "trigger": "review_import",
-            "new_ids": sorted(import_result.new_ids) if import_result is not None else [],
-            "added_to_queue": import_result.added_to_queue if import_result is not None else [],
+            "new_ids": (
+                sorted(import_result.new_ids) if import_result is not None else []
+            ),
+            "added_to_queue": (
+                import_result.added_to_queue if import_result is not None else []
+            ),
             "workflow_injected_ids": pipeline_result.workflow_injected_ids,
             "triage_injected": bool(triage and triage.injected),
             "triage_injected_ids": list(triage.injected) if triage is not None else [],
@@ -356,7 +368,9 @@ def _append_review_import_sync_log(
             "diff_reopened": diff.get("reopened", 0),
             "diff_auto_resolved": diff.get("auto_resolved", 0),
             "stale_pruned_from_queue": (
-                import_result.stale_pruned_from_queue if import_result is not None else []
+                import_result.stale_pruned_from_queue
+                if import_result is not None
+                else []
             ),
             "covered_subjective_pruned_from_queue": (
                 getattr(import_result, "covered_subjective_pruned_from_queue", [])
@@ -364,11 +378,19 @@ def _append_review_import_sync_log(
                 else []
             ),
             "covered_subjective": list(covered_ids),
-            "stale_sync_injected": sorted(subjective.injected) if subjective is not None else [],
-            "stale_sync_pruned": sorted(subjective.pruned) if subjective is not None else [],
+            "stale_sync_injected": (
+                sorted(subjective.injected) if subjective is not None else []
+            ),
+            "stale_sync_pruned": (
+                sorted(subjective.pruned) if subjective is not None else []
+            ),
             "auto_cluster_changes": pipeline_result.auto_cluster_changes,
-            "import_scores_injected": list(getattr(import_scores_result, "injected", []) or []),
-            "import_scores_pruned": list(getattr(import_scores_result, "pruned", []) or []),
+            "import_scores_injected": list(
+                getattr(import_scores_result, "injected", []) or []
+            ),
+            "import_scores_pruned": list(
+                getattr(import_scores_result, "pruned", []) or []
+            ),
             "sync_status": outcome.status,
             "sync_message": outcome.message,
         },

--- a/desloppify/app/commands/scan/plan_reconcile.py
+++ b/desloppify/app/commands/scan/plan_reconcile.py
@@ -27,7 +27,10 @@ from desloppify.engine._plan.sync import (
 )
 from desloppify.engine._plan.sync.dimensions import current_unscored_ids
 from desloppify.engine._plan.sync.context import is_mid_cycle
-from desloppify.engine._plan.sync.workflow import clear_score_communicated_sentinel
+from desloppify.engine._plan.sync.workflow import (
+    clear_create_plan_sentinel,
+    clear_score_communicated_sentinel,
+)
 from desloppify.engine.work_queue import build_deferred_disposition_item
 
 logger = logging.getLogger(__name__)
@@ -43,6 +46,7 @@ def _reset_cycle_for_force_rescan(plan: dict[str, object]) -> bool:
         order.remove(item)
     plan["plan_start_scores"] = {}
     clear_score_communicated_sentinel(plan)
+    clear_create_plan_sentinel(plan)
     plan.pop("scan_count_at_plan_start", None)
     meta = plan.get("epic_triage_meta", {})
     if isinstance(meta, dict):
@@ -68,7 +72,9 @@ def _plan_has_user_content(plan: dict[str, object]) -> bool:
     )
 
 
-def _apply_plan_reconciliation(plan: dict[str, object], state: state_mod.StateModel) -> bool:
+def _apply_plan_reconciliation(
+    plan: dict[str, object], state: state_mod.StateModel
+) -> bool:
     if not _plan_has_user_content(plan):
         return False
     recon = reconcile_plan_after_scan(plan, state)
@@ -82,7 +88,9 @@ def _apply_plan_reconciliation(plan: dict[str, object], state: state_mod.StateMo
     return bool(recon.changes)
 
 
-def _seed_plan_start_scores(plan: dict[str, object], state: state_mod.StateModel) -> bool:
+def _seed_plan_start_scores(
+    plan: dict[str, object], state: state_mod.StateModel
+) -> bool:
     """Set plan_start_scores when beginning a new queue cycle."""
     existing = plan.get("plan_start_scores")
     if existing and not isinstance(existing, dict):
@@ -99,6 +107,7 @@ def _seed_plan_start_scores(plan: dict[str, object], state: state_mod.StateModel
         "verified": scores.verified,
     }
     clear_score_communicated_sentinel(plan)
+    clear_create_plan_sentinel(plan)
     plan["scan_count_at_plan_start"] = int(state.get("scan_count", 0) or 0)
     return True
 
@@ -109,11 +118,15 @@ def _has_objective_cycle(
 ) -> bool | None:
     """Return True when objective queue work exists and a cycle baseline should freeze."""
     try:
-        from desloppify.app.commands.helpers.queue_progress import plan_aware_queue_breakdown
+        from desloppify.app.commands.helpers.queue_progress import (
+            plan_aware_queue_breakdown,
+        )
 
         breakdown = plan_aware_queue_breakdown(state, plan)
     except PLAN_LOAD_EXCEPTIONS as exc:
-        log_best_effort_failure(logger, "compute queue breakdown for plan-start seeding", exc)
+        log_best_effort_failure(
+            logger, "compute queue breakdown for plan-start seeding", exc
+        )
         return None
     return breakdown.objective_actionable > 0
 
@@ -136,7 +149,9 @@ def _clear_plan_start_scores_if_queue_empty(
 
         breakdown = plan_aware_queue_breakdown(state, plan)
         frozen_strict = plan.get("plan_start_scores", {}).get("strict")
-        queue_empty = score_display_mode(breakdown, frozen_strict) is not ScoreDisplayMode.FROZEN
+        queue_empty = (
+            score_display_mode(breakdown, frozen_strict) is not ScoreDisplayMode.FROZEN
+        )
     except PLAN_LOAD_EXCEPTIONS as exc:
         log_best_effort_failure(logger, "run post-scan plan reconciliation", exc)
         return False
@@ -145,6 +160,7 @@ def _clear_plan_start_scores_if_queue_empty(
     state["_plan_start_scores_for_reveal"] = dict(plan["plan_start_scores"])
     plan["plan_start_scores"] = {}
     clear_score_communicated_sentinel(plan)
+    clear_create_plan_sentinel(plan)
     return True
 
 

--- a/desloppify/engine/_plan/sync/workflow.py
+++ b/desloppify/engine/_plan/sync/workflow.py
@@ -62,7 +62,11 @@ class PendingImportScoresMeta:
             normalized_import_file=str(raw.get("normalized_import_file", "")).strip(),
             packet_sha256=str(raw.get("packet_sha256", "")).strip(),
         )
-        return meta if any((meta.timestamp, meta.import_file, meta.packet_sha256)) else None
+        return (
+            meta
+            if any((meta.timestamp, meta.import_file, meta.packet_sha256))
+            else None
+        )
 
     def to_dict(self) -> dict[str, str]:
         return {
@@ -110,9 +114,11 @@ def _build_pending_import_scores_meta(
     recorded_file = (
         str(import_file).strip()
         if isinstance(import_file, str) and import_file.strip()
-        else str(issues_only_audit.get("import_file", "")).strip()
-        if isinstance(issues_only_audit, dict)
-        else ""
+        else (
+            str(issues_only_audit.get("import_file", "")).strip()
+            if isinstance(issues_only_audit, dict)
+            else ""
+        )
     )
     timestamp = ""
     if isinstance(issues_only_audit, dict):
@@ -181,7 +187,10 @@ def import_scores_meta_matches(
     expected_file = normalized_meta.normalized_import_file
     current_file = _normalize_match_path(import_file) or ""
     if expected_file and current_file and current_file != expected_file:
-        return False, f"expected import file {normalized_meta.import_file}, got {import_file}"
+        return (
+            False,
+            f"expected import file {normalized_meta.import_file}, got {import_file}",
+        )
 
     return True, ""
 
@@ -245,7 +254,8 @@ def _no_unscored(
     if policy is not None:
         return not policy.unscored_ids
     return not stale_policy_mod.current_unscored_ids(
-        state, subjective_prefix=SUBJECTIVE_PREFIX,
+        state,
+        subjective_prefix=SUBJECTIVE_PREFIX,
     )
 
 
@@ -303,6 +313,16 @@ def clear_score_communicated_sentinel(plan: PlanModel) -> None:
     plan.pop("previous_plan_start_scores", None)
 
 
+def clear_create_plan_sentinel(plan: PlanModel) -> None:
+    """Clear the ``create_plan_resolved_this_cycle`` sentinel.
+
+    Call this at the same cycle-boundary points as
+    ``clear_score_communicated_sentinel`` so that ``sync_create_plan_needed``
+    can re-inject ``workflow::create-plan`` in the next cycle.
+    """
+    plan.pop("create_plan_resolved_this_cycle", None)
+
+
 _EMPTY = QueueSyncResult
 
 
@@ -343,6 +363,7 @@ def sync_create_plan_needed(
     - At least one objective issue exists
     - ``workflow::create-plan`` is not already in the queue
     - No triage stages are pending
+    - ``workflow::create-plan`` has not already been resolved this cycle
 
     Front-loads it into the workflow prefix so it stays ahead of triage.
     """
@@ -350,6 +371,11 @@ def sync_create_plan_needed(
     order: list[str] = plan["queue_order"]
 
     if WORKFLOW_CREATE_PLAN_ID in order:
+        return _EMPTY()
+    # Already resolved this cycle — sentinel is set when injected and
+    # cleared at cycle boundaries (force-rescan, score seeding, queue
+    # drain, trusted import).
+    if plan.get("create_plan_resolved_this_cycle"):
         return _EMPTY()
     if any(sid in order for sid in TRIAGE_IDS):
         return _EMPTY()
@@ -359,6 +385,7 @@ def sync_create_plan_needed(
     if not has_objective_backlog(state, policy):
         return _EMPTY()
 
+    plan["create_plan_resolved_this_cycle"] = True
     return _inject(plan, WORKFLOW_CREATE_PLAN_ID)
 
 
@@ -503,6 +530,7 @@ def _rebaseline_plan_start_scores(
 __all__ = [
     "PendingImportScoresMeta",
     "ScoreSnapshot",
+    "clear_create_plan_sentinel",
     "clear_score_communicated_sentinel",
     "import_scores_meta_matches",
     "pending_import_scores_meta",


### PR DESCRIPTION
## Summary

`sync_create_plan_needed()` had no sentinel to prevent re-injection after `workflow::create-plan` was resolved. Unlike `sync_communicate_score_needed()` which uses `previous_plan_start_scores`, the create-plan sync only checked whether objective backlog existed — which is always true mid-cycle. After resolving the item, `_reconcile_if_queue_drained()` calls `reconcile_plan()` which calls `sync_create_plan_needed()` again, and re-injects it.

## Fix

Add `create_plan_resolved_this_cycle` sentinel mirroring the existing `previous_plan_start_scores` pattern:

- Set when `workflow::create-plan` is injected
- Cleared at the same cycle boundaries (force-rescan, score seeding, queue drain, trusted review import)
- Checked in `sync_create_plan_needed()` to prevent re-injection within the same cycle

## Files changed

- `desloppify/engine/_plan/sync/workflow.py` — added sentinel check/set in `sync_create_plan_needed()`, added `clear_create_plan_sentinel()`, updated `__all__`
- `desloppify/app/commands/scan/plan_reconcile.py` — wire `clear_create_plan_sentinel()` at 3 cycle-boundary sites
- `desloppify/app/commands/review/importing/plan_sync.py` — wire `clear_create_plan_sentinel()` at trusted import site

## Testing

- 273 PRR tests pass
- 532 plan tests pass
- 5381 broader tests pass (8 pre-existing failures in test_scoring.py from missing imports, unrelated)

Fixes #434
