### PR TITLE
Add Rust inline-test filtering

### DIFF
--- a/desloppify/languages/rust/tests/test_tools.py
+++ b/desloppify/languages/rust/tests/test_tools.py
@@ -49,6 +49,532 @@ def test_parse_clippy_messages_ignores_non_json_noise():
     ]
 
 
+def test_parse_clippy_messages_skips_inline_cfg_test_module_diagnostics(tmp_path):
+    source = tmp_path / "src" / "lib.rs"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """
+pub fn runtime_value() -> usize {
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn inline_test_uses_unwrap() {
+        let _ = Some(1usize).unwrap();
+    }
+}
+""".strip()
+        + "\n"
+    )
+
+    message = {
+        "reason": "compiler-message",
+        "message": {
+            "level": "warning",
+            "message": "used `unwrap()` on an `Option` value",
+            "code": {"code": "clippy::unwrap_used"},
+            "spans": [
+                {
+                    "is_primary": True,
+                    "file_name": "src/lib.rs",
+                    "line_start": 9,
+                }
+            ],
+        },
+    }
+
+    entries = parse_clippy_messages(json.dumps(message), tmp_path)
+
+    assert entries == []
+
+
+def test_parse_clippy_messages_keeps_non_test_diagnostics_in_same_file(tmp_path):
+    source = tmp_path / "src" / "lib.rs"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """
+pub fn runtime_value() -> usize {
+    Some(1usize).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn inline_test_uses_unwrap() {
+        let _ = Some(1usize).unwrap();
+    }
+}
+""".strip()
+        + "\n"
+    )
+
+    message = {
+        "reason": "compiler-message",
+        "message": {
+            "level": "warning",
+            "message": "used `unwrap()` on an `Option` value",
+            "code": {"code": "clippy::unwrap_used"},
+            "spans": [
+                {
+                    "is_primary": True,
+                    "file_name": "src/lib.rs",
+                    "line_start": 2,
+                }
+            ],
+        },
+    }
+
+    entries = parse_clippy_messages(json.dumps(message), tmp_path)
+
+    assert entries == [
+        {
+            "file": "src/lib.rs",
+            "line": 2,
+            "message": "[clippy::unwrap_used] used `unwrap()` on an `Option` value",
+        }
+    ]
+
+
+def test_parse_clippy_messages_keeps_cfg_not_test_inline_module(tmp_path):
+    source = tmp_path / "src" / "lib.rs"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """
+#[cfg(not(test))]
+mod production_only {
+    pub fn value() -> usize {
+        Some(1usize).unwrap()
+    }
+}
+""".strip()
+        + "\n"
+    )
+
+    message = {
+        "reason": "compiler-message",
+        "message": {
+            "level": "warning",
+            "message": "used `unwrap()` on an `Option` value",
+            "code": {"code": "clippy::unwrap_used"},
+            "spans": [
+                {
+                    "is_primary": True,
+                    "file_name": "src/lib.rs",
+                    "line_start": 4,
+                }
+            ],
+        },
+    }
+
+    entries = parse_clippy_messages(json.dumps(message), tmp_path)
+
+    assert entries == [
+        {
+            "file": "src/lib.rs",
+            "line": 4,
+            "message": "[clippy::unwrap_used] used `unwrap()` on an `Option` value",
+        }
+    ]
+
+
+def test_parse_clippy_messages_skips_cfg_all_test_inline_module(tmp_path):
+    source = tmp_path / "src" / "lib.rs"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """
+#[cfg(all(test, feature = "unstable"))]
+mod tests {
+    pub fn helper() {
+        let _ = Some(1usize).unwrap();
+    }
+}
+""".strip()
+        + "\n"
+    )
+
+    message = {
+        "reason": "compiler-message",
+        "message": {
+            "level": "warning",
+            "message": "used `unwrap()` on an `Option` value",
+            "code": {"code": "clippy::unwrap_used"},
+            "spans": [
+                {
+                    "is_primary": True,
+                    "file_name": "src/lib.rs",
+                    "line_start": 4,
+                }
+            ],
+        },
+    }
+
+    entries = parse_clippy_messages(json.dumps(message), tmp_path)
+
+    assert entries == []
+
+
+def test_parse_clippy_messages_keeps_cfg_any_test_or_other_inline_module(tmp_path):
+    source = tmp_path / "src" / "lib.rs"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """
+#[cfg(any(test, feature = "bench"))]
+mod maybe_test {
+    pub fn helper() {
+        let _ = Some(1usize).unwrap();
+    }
+}
+""".strip()
+        + "\n"
+    )
+
+    message = {
+        "reason": "compiler-message",
+        "message": {
+            "level": "warning",
+            "message": "used `unwrap()` on an `Option` value",
+            "code": {"code": "clippy::unwrap_used"},
+            "spans": [
+                {
+                    "is_primary": True,
+                    "file_name": "src/lib.rs",
+                    "line_start": 4,
+                }
+            ],
+        },
+    }
+
+    entries = parse_clippy_messages(json.dumps(message), tmp_path)
+
+    assert entries == [
+        {
+            "file": "src/lib.rs",
+            "line": 4,
+            "message": "[clippy::unwrap_used] used `unwrap()` on an `Option` value",
+        }
+    ]
+
+
+def test_parse_clippy_messages_skips_inline_cfg_test_with_comment_between_attr_and_mod(
+    tmp_path,
+):
+    source = tmp_path / "src" / "lib.rs"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """
+#[cfg(test)]
+// inline tests live below
+mod tests {
+    pub fn helper() {
+        let _ = Some(1usize).unwrap();
+    }
+}
+""".strip()
+        + "\n"
+    )
+
+    message = {
+        "reason": "compiler-message",
+        "message": {
+            "level": "warning",
+            "message": "used `unwrap()` on an `Option` value",
+            "code": {"code": "clippy::unwrap_used"},
+            "spans": [
+                {
+                    "is_primary": True,
+                    "file_name": "src/lib.rs",
+                    "line_start": 5,
+                }
+            ],
+        },
+    }
+
+    entries = parse_clippy_messages(json.dumps(message), tmp_path)
+
+    assert entries == []
+
+
+def test_parse_clippy_messages_ignores_commented_out_cfg_test_marker(tmp_path):
+    source = tmp_path / "src" / "lib.rs"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """
+// #[cfg(test)]
+mod production {
+    pub fn helper() {
+        let _ = Some(1usize).unwrap();
+    }
+}
+""".strip()
+        + "\n"
+    )
+
+    message = {
+        "reason": "compiler-message",
+        "message": {
+            "level": "warning",
+            "message": "used `unwrap()` on an `Option` value",
+            "code": {"code": "clippy::unwrap_used"},
+            "spans": [
+                {
+                    "is_primary": True,
+                    "file_name": "src/lib.rs",
+                    "line_start": 4,
+                }
+            ],
+        },
+    }
+
+    entries = parse_clippy_messages(json.dumps(message), tmp_path)
+
+    assert entries == [
+        {
+            "file": "src/lib.rs",
+            "line": 4,
+            "message": "[clippy::unwrap_used] used `unwrap()` on an `Option` value",
+        }
+    ]
+
+
+def test_parse_clippy_messages_skips_full_inline_module_when_strings_contain_closing_braces(
+    tmp_path,
+):
+    source = tmp_path / "src" / "lib.rs"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """
+#[cfg(test)]
+mod tests {
+    pub fn first() {
+        println!("brace in string: }");
+    }
+
+    pub fn second() {
+        let _ = Some(1usize).unwrap();
+    }
+}
+""".strip()
+        + "\n"
+    )
+
+    message = {
+        "reason": "compiler-message",
+        "message": {
+            "level": "warning",
+            "message": "used `unwrap()` on an `Option` value",
+            "code": {"code": "clippy::unwrap_used"},
+            "spans": [
+                {
+                    "is_primary": True,
+                    "file_name": "src/lib.rs",
+                    "line_start": 8,
+                }
+            ],
+        },
+    }
+
+    entries = parse_clippy_messages(json.dumps(message), tmp_path)
+
+    assert entries == []
+
+
+def test_parse_clippy_messages_skips_inline_module_when_test_contains_url_string(
+    tmp_path,
+):
+    source = tmp_path / "src" / "lib.rs"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """
+#[cfg(test)]
+mod tests {
+    pub fn first() {
+        let _url = "http://example.com";
+    }
+
+    pub fn second() {
+        let _ = Some(1usize).unwrap();
+    }
+}
+""".strip()
+        + "\n"
+    )
+
+    message = {
+        "reason": "compiler-message",
+        "message": {
+            "level": "warning",
+            "message": "used `unwrap()` on an `Option` value",
+            "code": {"code": "clippy::unwrap_used"},
+            "spans": [
+                {
+                    "is_primary": True,
+                    "file_name": "src/lib.rs",
+                    "line_start": 8,
+                }
+            ],
+        },
+    }
+
+    entries = parse_clippy_messages(json.dumps(message), tmp_path)
+
+    assert entries == []
+
+
+def test_parse_clippy_messages_skips_inline_module_when_test_contains_lifetime(
+    tmp_path,
+):
+    source = tmp_path / "src" / "lib.rs"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """
+#[cfg(test)]
+mod tests {
+    pub fn with_lifetime(input: &'static str) -> &'static str {
+        let _ = Some(input).unwrap();
+        input
+    }
+}
+""".strip()
+        + "\n"
+    )
+
+    message = {
+        "reason": "compiler-message",
+        "message": {
+            "level": "warning",
+            "message": "used `unwrap()` on an `Option` value",
+            "code": {"code": "clippy::unwrap_used"},
+            "spans": [
+                {
+                    "is_primary": True,
+                    "file_name": "src/lib.rs",
+                    "line_start": 4,
+                }
+            ],
+        },
+    }
+
+    entries = parse_clippy_messages(json.dumps(message), tmp_path)
+
+    assert entries == []
+
+
+def test_parse_clippy_messages_skips_inline_module_with_raw_identifier_name(tmp_path):
+    source = tmp_path / "src" / "lib.rs"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """
+#[cfg(test)]
+mod r#tests {
+    pub fn helper() {
+        let _ = Some(1usize).unwrap();
+    }
+}
+""".strip()
+        + "\n"
+    )
+
+    message = {
+        "reason": "compiler-message",
+        "message": {
+            "level": "warning",
+            "message": "used `unwrap()` on an `Option` value",
+            "code": {"code": "clippy::unwrap_used"},
+            "spans": [
+                {
+                    "is_primary": True,
+                    "file_name": "src/lib.rs",
+                    "line_start": 4,
+                }
+            ],
+        },
+    }
+
+    entries = parse_clippy_messages(json.dumps(message), tmp_path)
+
+    assert entries == []
+
+
+def test_parse_clippy_messages_skips_inline_module_with_doc_attr_containing_bracket(
+    tmp_path,
+):
+    source = tmp_path / "src" / "lib.rs"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """
+#[cfg(test)]
+#[doc = "]"]
+mod tests {
+    pub fn helper() {
+        let _ = Some(1usize).unwrap();
+    }
+}
+""".strip()
+        + "\n"
+    )
+
+    message = {
+        "reason": "compiler-message",
+        "message": {
+            "level": "warning",
+            "message": "used `unwrap()` on an `Option` value",
+            "code": {"code": "clippy::unwrap_used"},
+            "spans": [
+                {
+                    "is_primary": True,
+                    "file_name": "src/lib.rs",
+                    "line_start": 5,
+                }
+            ],
+        },
+    }
+
+    entries = parse_clippy_messages(json.dumps(message), tmp_path)
+
+    assert entries == []
+
+
+def test_parse_clippy_messages_skips_inline_module_when_block_comment_contains_double_slash(
+    tmp_path,
+):
+    source = tmp_path / "src" / "lib.rs"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        """
+#[cfg(test)]
+/* this comment includes // text that should not terminate scanning */
+mod tests {
+    pub fn helper() {
+        let _ = Some(1usize).unwrap();
+    }
+}
+""".strip()
+        + "\n"
+    )
+
+    message = {
+        "reason": "compiler-message",
+        "message": {
+            "level": "warning",
+            "message": "used `unwrap()` on an `Option` value",
+            "code": {"code": "clippy::unwrap_used"},
+            "spans": [
+                {
+                    "is_primary": True,
+                    "file_name": "src/lib.rs",
+                    "line_start": 5,
+                }
+            ],
+        },
+    }
+
+    entries = parse_clippy_messages(json.dumps(message), tmp_path)
+
+    assert entries == []
+
+
 def test_parse_cargo_errors_prefers_primary_span_and_includes_error_code():
     message = {
         "reason": "compiler-message",
@@ -147,22 +673,23 @@ def test_run_rustdoc_result_scans_each_workspace_library_package(tmp_path):
             },
         ],
     }
-    rustdoc_message = lambda file_name, line_no: json.dumps(
-        {
-            "reason": "compiler-message",
-            "message": {
-                "level": "warning",
-                "message": "missing docs",
-                "spans": [
-                    {
-                        "is_primary": True,
-                        "file_name": file_name,
-                        "line_start": line_no,
-                    }
-                ],
-            },
-        }
-    )
+    def rustdoc_message(file_name: str, line_no: int) -> str:
+        return json.dumps(
+            {
+                "reason": "compiler-message",
+                "message": {
+                    "level": "warning",
+                    "message": "missing docs",
+                    "spans": [
+                        {
+                            "is_primary": True,
+                            "file_name": file_name,
+                            "line_start": line_no,
+                        }
+                    ],
+                },
+            }
+        )
 
     def runner(args, **kwargs):
         command = args[2] if args[:2] == ["/bin/sh", "-lc"] else " ".join(args)

--- a/desloppify/languages/rust/tools.py
+++ b/desloppify/languages/rust/tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shlex
 import subprocess  # nosec B404
 from collections.abc import Callable
@@ -34,6 +35,9 @@ RUSTDOC_WARNING_CMD = (
 )
 _CARGO_METADATA_CMD = "cargo metadata --format-version=1 --no-deps"
 _LIB_TARGET_KINDS = {"lib", "rlib", "dylib", "cdylib", "staticlib", "proc-macro"}
+_INLINE_MOD_RE = re.compile(
+    r"(?:pub(?:\s*\([^)]*\))?\s+)?mod\s+(?:r#)?(?:[^\W\d]|_)\w*\s*\{"
+)
 
 
 def _pick_primary_span(spans: list[dict[str, Any]]) -> dict[str, Any] | None:
@@ -48,9 +52,10 @@ def _parse_cargo_messages(
     scan_path: Path,
     *,
     allowed_levels: set[str],
+    skip_inline_cfg_test_modules: bool = False,
 ) -> list[dict[str, Any]]:
-    del scan_path
     entries: list[dict[str, Any]] = []
+    inline_test_cache: dict[str, tuple[tuple[int, int], ...]] = {}
     for raw_line in output.splitlines():
         line = raw_line.strip()
         if not line:
@@ -70,6 +75,13 @@ def _parse_cargo_messages(
         filename = str(span.get("file_name") or "").strip()
         line_no = span.get("line_start")
         if not filename or not isinstance(line_no, int):
+            continue
+        if skip_inline_cfg_test_modules and _should_skip_inline_cfg_test_module_diagnostic(
+            scan_path,
+            filename,
+            line_no,
+            inline_test_cache,
+        ):
             continue
         code = (message.get("code") or {}).get("code") or ""
         rendered = str(message.get("rendered") or message.get("message") or "").strip()
@@ -101,7 +113,475 @@ def _parse_json_object_line(line: str) -> dict[str, Any] | None:
 
 def parse_clippy_messages(output: str, scan_path: Path) -> list[dict[str, Any]]:
     """Parse cargo-clippy diagnostics, including denied warnings."""
-    return _parse_cargo_messages(output, scan_path, allowed_levels={"warning", "error"})
+    return _parse_cargo_messages(
+        output,
+        scan_path,
+        allowed_levels={"warning", "error"},
+        # Inline `#[cfg(test)] mod ...` blocks live in production files, so
+        # line-level filtering prevents test-only diagnostics from inflating
+        # production debt.
+        skip_inline_cfg_test_modules=True,
+    )
+
+
+def _should_skip_inline_cfg_test_module_diagnostic(
+    scan_path: Path,
+    filename: str,
+    line_no: int,
+    inline_test_cache: dict[str, tuple[tuple[int, int], ...]],
+) -> bool:
+    source_file = _resolve_rust_source_file(scan_path, filename)
+    if source_file is None:
+        return False
+
+    cache_key = str(source_file)
+    ranges = inline_test_cache.get(cache_key)
+    if ranges is None:
+        source_text = _read_source_text(source_file)
+        ranges = (
+            tuple(_inline_cfg_test_module_line_ranges(source_text))
+            if source_text is not None
+            else tuple()
+        )
+        inline_test_cache[cache_key] = ranges
+
+    return any(start <= line_no <= end for start, end in ranges)
+
+
+def _resolve_rust_source_file(scan_path: Path, filename: str) -> Path | None:
+    trimmed = filename.strip()
+    if not trimmed or trimmed.startswith("<"):
+        return None
+
+    candidate = Path(trimmed)
+    resolved = candidate if candidate.is_absolute() else (scan_path / candidate)
+    try:
+        normalized = resolved.resolve()
+    except OSError:
+        return None
+    if normalized.suffix != ".rs" or not normalized.is_file():
+        return None
+    return normalized
+
+
+def _read_source_text(path: Path) -> str | None:
+    try:
+        return path.read_text(errors="replace")
+    except OSError:
+        return None
+
+
+def _inline_cfg_test_module_line_ranges(content: str) -> list[tuple[int, int]]:
+    stripped = _strip_comments_preserve_lines(content)
+    ranges: list[tuple[int, int]] = []
+    cursor = 0
+    while True:
+        cfg_attr = _find_next_cfg_attribute(stripped, cursor)
+        if cfg_attr is None:
+            break
+        attr_start, attr_end, expression = cfg_attr
+        cursor = attr_end
+        if not _cfg_expression_requires_test(expression):
+            continue
+
+        module = _find_following_inline_module(stripped, attr_end)
+        if module is None:
+            continue
+        module_start, open_brace = module
+        close_brace = _find_matching_delimiter(stripped, open_brace, "{", "}")
+        if close_brace is None:
+            continue
+        ranges.append(
+            (
+                _line_number(stripped, module_start),
+                _line_number(stripped, close_brace),
+            )
+        )
+        cursor = close_brace + 1
+
+    return _merge_line_ranges(ranges)
+
+
+def _find_next_cfg_attribute(content: str, start: int) -> tuple[int, int, str] | None:
+    cursor = start
+    while True:
+        attr_start = content.find("#[", cursor)
+        if attr_start == -1:
+            return None
+
+        name_start = _skip_whitespace(content, attr_start + 2)
+        name, after_name = _parse_identifier(content, name_start)
+        if name != "cfg":
+            cursor = attr_start + 2
+            continue
+
+        after_name = _skip_whitespace(content, after_name)
+        if after_name >= len(content) or content[after_name] != "(":
+            cursor = attr_start + 2
+            continue
+
+        expression_end = _find_matching_delimiter(content, after_name, "(", ")")
+        if expression_end is None:
+            return None
+
+        expression = content[after_name + 1 : expression_end]
+        attr_end = _skip_whitespace(content, expression_end + 1)
+        if attr_end >= len(content) or content[attr_end] != "]":
+            cursor = attr_start + 2
+            continue
+
+        return attr_start, attr_end + 1, expression
+
+
+def _find_following_inline_module(content: str, start: int) -> tuple[int, int] | None:
+    cursor = start
+    while cursor < len(content):
+        cursor = _skip_whitespace(content, cursor)
+        if cursor >= len(content):
+            return None
+        if content.startswith("///", cursor) or content.startswith("//!", cursor):
+            cursor = _line_end(content, cursor)
+            continue
+        if content.startswith("#[", cursor):
+            attr_end = _find_attribute_end(content, cursor)
+            if attr_end is None:
+                return None
+            cursor = attr_end
+            continue
+
+        module_match = _INLINE_MOD_RE.match(content, cursor)
+        if module_match is None:
+            return None
+        open_brace = content.find("{", module_match.start(), module_match.end())
+        if open_brace == -1:
+            return None
+        return module_match.start(), open_brace
+    return None
+
+
+def _find_attribute_end(content: str, start: int) -> int | None:
+    if not content.startswith("#[", start):
+        return None
+    depth = 1
+    cursor = start + 2
+    while cursor < len(content):
+        char = content[cursor]
+        if content.startswith("//", cursor):
+            cursor = _line_end(content, cursor)
+            continue
+        if content.startswith("/*", cursor):
+            cursor = _block_comment_end(content, cursor)
+            continue
+        if char == '"':
+            cursor = _quoted_string_end(content, cursor, '"')
+            continue
+        if char == "'" and _looks_like_char_literal_start(content, cursor):
+            cursor = _quoted_string_end(content, cursor, "'")
+            continue
+        if char == "r" and _looks_like_raw_string_start(content, cursor):
+            cursor = _raw_string_end(content, cursor)
+            continue
+        if char == "[":
+            depth += 1
+            cursor += 1
+            continue
+        elif char == "]":
+            depth -= 1
+            cursor += 1
+            if depth == 0:
+                return cursor
+            continue
+        cursor += 1
+    return None
+
+
+def _cfg_expression_requires_test(expression: str) -> bool:
+    requires_test, _ = _parse_cfg_predicate(expression, 0)
+    return requires_test
+
+
+def _parse_cfg_predicate(expression: str, index: int) -> tuple[bool, int]:
+    cursor = _skip_whitespace(expression, index)
+    name, cursor = _parse_identifier(expression, cursor)
+    if name is None:
+        return False, cursor
+
+    cursor = _skip_whitespace(expression, cursor)
+    if cursor < len(expression) and expression[cursor] == "(":
+        close_paren = _find_matching_delimiter(expression, cursor, "(", ")")
+        if close_paren is None:
+            return False, len(expression)
+
+        args_required: list[bool] = []
+        arg_cursor = cursor + 1
+        while arg_cursor < close_paren:
+            arg_cursor = _skip_whitespace(expression, arg_cursor)
+            if arg_cursor >= close_paren:
+                break
+
+            arg_required, next_cursor = _parse_cfg_predicate(expression, arg_cursor)
+            args_required.append(arg_required)
+            if next_cursor <= arg_cursor:
+                next_cursor = arg_cursor + 1
+            arg_cursor = _skip_whitespace(expression, next_cursor)
+
+            if arg_cursor < close_paren and expression[arg_cursor] == ",":
+                arg_cursor += 1
+                continue
+
+            while arg_cursor < close_paren and expression[arg_cursor] != ",":
+                arg_cursor += 1
+            if arg_cursor < close_paren and expression[arg_cursor] == ",":
+                arg_cursor += 1
+
+        next_index = close_paren + 1
+        if name == "all":
+            return any(args_required), next_index
+        if name == "any":
+            return bool(args_required) and all(args_required), next_index
+        if name == "not":
+            return False, next_index
+        return False, next_index
+
+    if cursor < len(expression) and expression[cursor] == "=":
+        return False, _skip_cfg_value(expression, cursor + 1)
+
+    return name == "test", cursor
+
+
+def _skip_cfg_value(expression: str, index: int) -> int:
+    cursor = _skip_whitespace(expression, index)
+    in_string = False
+    while cursor < len(expression):
+        char = expression[cursor]
+        if in_string:
+            if char == "\\" and cursor + 1 < len(expression):
+                cursor += 2
+                continue
+            if char == '"':
+                in_string = False
+            cursor += 1
+            continue
+
+        if char == '"':
+            in_string = True
+            cursor += 1
+            continue
+        if char in {",", ")"}:
+            break
+        cursor += 1
+    return cursor
+
+
+def _parse_identifier(text: str, index: int) -> tuple[str | None, int]:
+    if index >= len(text):
+        return None, index
+    if not (text[index].isalpha() or text[index] == "_"):
+        return None, index
+    cursor = index + 1
+    while cursor < len(text) and (text[cursor].isalnum() or text[cursor] == "_"):
+        cursor += 1
+    return text[index:cursor], cursor
+
+
+def _skip_whitespace(text: str, index: int) -> int:
+    cursor = index
+    while cursor < len(text) and text[cursor].isspace():
+        cursor += 1
+    return cursor
+
+
+def _find_matching_delimiter(
+    text: str,
+    start_index: int,
+    opening: str,
+    closing: str,
+) -> int | None:
+    depth = 0
+    index = start_index
+    while index < len(text):
+        char = text[index]
+        if text.startswith("//", index):
+            index = _line_end(text, index)
+            continue
+        if text.startswith("/*", index):
+            index = _block_comment_end(text, index)
+            continue
+        if char == '"':
+            index = _quoted_string_end(text, index, '"')
+            continue
+        if char == "'" and _looks_like_char_literal_start(text, index):
+            index = _quoted_string_end(text, index, "'")
+            continue
+        if char == "r" and _looks_like_raw_string_start(text, index):
+            index = _raw_string_end(text, index)
+            continue
+        if char == opening:
+            depth += 1
+            index += 1
+            continue
+        if char == closing:
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+
+    return None
+
+
+def _line_end(text: str, index: int) -> int:
+    newline = text.find("\n", index)
+    return len(text) if newline == -1 else newline + 1
+
+
+def _block_comment_end(text: str, index: int) -> int:
+    depth = 1
+    cursor = index + 2
+    while cursor < len(text):
+        if text.startswith("/*", cursor):
+            depth += 1
+            cursor += 2
+            continue
+        if text.startswith("*/", cursor):
+            depth -= 1
+            cursor += 2
+            if depth == 0:
+                return cursor
+            continue
+        cursor += 1
+    return len(text)
+
+
+def _raw_string_end(text: str, index: int) -> int:
+    cursor = index + 1
+    hash_count = 0
+    while cursor < len(text) and text[cursor] == "#":
+        hash_count += 1
+        cursor += 1
+    if cursor >= len(text) or text[cursor] != '"':
+        return index + 1
+    cursor += 1
+    terminator = '"' + ("#" * hash_count)
+    end = text.find(terminator, cursor)
+    if end == -1:
+        return len(text)
+    return end + len(terminator)
+
+
+def _quoted_string_end(text: str, index: int, quote: str) -> int:
+    cursor = index + 1
+    while cursor < len(text):
+        char = text[cursor]
+        if char == "\\":
+            cursor += 2
+            continue
+        if char == quote:
+            return cursor + 1
+        cursor += 1
+    return len(text)
+
+
+def _looks_like_raw_string_start(text: str, index: int) -> bool:
+    if index >= len(text) or text[index] != "r":
+        return False
+    cursor = index + 1
+    while cursor < len(text) and text[cursor] == "#":
+        cursor += 1
+    return cursor < len(text) and text[cursor] == '"'
+
+
+def _looks_like_char_literal_start(text: str, index: int) -> bool:
+    if index + 2 >= len(text):
+        return False
+
+    next_char = text[index + 1]
+    if next_char == "\\":
+        cursor = index + 2
+        if cursor < len(text) and text[cursor] in {"x", "u"}:
+            cursor += 1
+            while cursor < len(text) and text[cursor] != "'":
+                cursor += 1
+            return cursor < len(text) and text[cursor] == "'"
+        return index + 3 < len(text) and text[index + 3] == "'"
+
+    # Lifetimes and labels are identifier-like and are not char literals.
+    if next_char.isalpha() or next_char == "_":
+        return False
+
+    return text[index + 2] == "'"
+
+
+def _strip_comments_preserve_lines(text: str) -> str:
+    result: list[str] = []
+    index = 0
+    while index < len(text):
+        if text.startswith("//", index):
+            result.append("  ")
+            index += 2
+            while index < len(text) and text[index] != "\n":
+                result.append(" ")
+                index += 1
+            continue
+        if text.startswith("/*", index):
+            result.append("  ")
+            index += 2
+            depth = 1
+            while index < len(text) and depth > 0:
+                if text.startswith("/*", index):
+                    result.append("  ")
+                    depth += 1
+                    index += 2
+                    continue
+                if text.startswith("*/", index):
+                    result.append("  ")
+                    depth -= 1
+                    index += 2
+                    continue
+                result.append("\n" if text[index] == "\n" else " ")
+                index += 1
+            continue
+        if text[index] == '"':
+            literal_end = _quoted_string_end(text, index, '"')
+            result.extend(text[index:literal_end])
+            index = literal_end
+            continue
+        if text[index] == "r" and _looks_like_raw_string_start(text, index):
+            literal_end = _raw_string_end(text, index)
+            result.extend(text[index:literal_end])
+            index = literal_end
+            continue
+        if text[index] == "'" and _looks_like_char_literal_start(text, index):
+            literal_end = _quoted_string_end(text, index, "'")
+            result.extend(text[index:literal_end])
+            index = literal_end
+            continue
+        result.append(text[index])
+        index += 1
+    return "".join(result)
+
+
+def _strip_c_style_comments_preserve_lines(text: str) -> str:
+    """Backwards-compatible shim for tests/imports expecting the old helper name."""
+    return _strip_comments_preserve_lines(text)
+
+
+def _line_number(content: str, offset: int) -> int:
+    return content.count("\n", 0, offset) + 1
+
+
+def _merge_line_ranges(ranges: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    if not ranges:
+        return []
+
+    sorted_ranges = sorted(ranges)
+    merged: list[tuple[int, int]] = [sorted_ranges[0]]
+    for start, end in sorted_ranges[1:]:
+        prev_start, prev_end = merged[-1]
+        if start <= prev_end + 1:
+            merged[-1] = (prev_start, max(prev_end, end))
+        else:
+            merged.append((start, end))
+    return merged
 
 
 def parse_cargo_errors(output: str, scan_path: Path) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
This PR makes Rust clippy ingestion inline-test-aware so diagnostics from `#[cfg(test)] mod ...` blocks in `src/*.rs` are not counted as production findings.

## Problem
`cargo clippy --message-format=json` reports spans by file/line, and inline unit tests live in production files. Desloppify previously treated those diagnostics as production issues, which inflated strict-score debt (especially `clippy::unwrap_used` / `clippy::expect_used`) even when findings were test-only.

## What Changed
1. Added clippy-specific filtering in [`parse_clippy_messages`](desloppify/languages/rust/tools.py) to optionally skip diagnostics inside inline test modules.
2. Added source-range detection for inline test modules guarded by cfg predicates that require `test` (for example `cfg(test)` and `cfg(all(test, ...))`).
3. Implemented syntax-aware scanning helpers so delimiter/attribute parsing remains stable around comments and literals:
- line/block comments
- strings and raw strings
- char literals (without misclassifying lifetimes)
- nested attribute brackets
4. Extended inline module matching to support raw identifiers (for example `mod r#tests { ... }`).
5. Kept cfg logic conservative: ambiguous/non-test forms (for example `cfg(any(test, ...))` or `cfg(not(test))`) are not auto-skipped.

## Test Coverage
Added/expanded parser tests in [`desloppify/languages/rust/tests/test_tools.py`](desloppify/languages/rust/tests/test_tools.py), including:
1. skip diagnostics in `cfg(test)` inline modules
2. preserve non-test diagnostics in the same file
3. keep `cfg(not(test))`
4. skip `cfg(all(test, ...))`
5. keep `cfg(any(test, ...))`
6. handle comments/doc comments between cfg attr and module
7. ignore commented-out cfg markers
8. handle braces/URLs/lifetimes in test code without breaking module range detection
9. support raw identifier module names
10. handle intervening attrs like `#[doc = "]"]`

## Validation
```bash
pytest -q desloppify/languages/rust/tests/test_tools.py
pytest -q desloppify/languages/rust/tests/test_custom.py
ruff check desloppify/languages/rust/tools.py desloppify/languages/rust/tests/test_tools.py
```

All checks passed.

## Impact
This change removes test-only clippy noise from production scoring while preserving existing behavior for non-test diagnostics and other Rust tool parsers (`cargo check`, `rustdoc`).