### PR TITLE
feat: add Factory Droid skill harness support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ I want you to improve the quality of this codebase. To do this, install and run 
 Run ALL of the following (requires Python 3.11+):
 
 pip install --upgrade "desloppify[full]"
-desloppify update-skill claude    # installs the full workflow guide — pick yours: claude, cursor, codex, copilot, windsurf, gemini
+desloppify update-skill claude    # installs the full workflow guide — pick yours: claude, cursor, codex, copilot, droid, windsurf, gemini
 
 Add .desloppify/ to your .gitignore — it contains local state that shouldn't be committed.
 

--- a/desloppify/app/skill_docs.py
+++ b/desloppify/app/skill_docs.py
@@ -9,7 +9,7 @@ from desloppify.base.discovery.paths import get_project_root
 
 # Bump this integer whenever docs/SKILL.md changes in a way that agents
 # should pick up (new commands, changed workflows, removed sections).
-SKILL_VERSION = 5
+SKILL_VERSION = 6
 
 SKILL_VERSION_RE = re.compile(r"<!--\s*desloppify-skill-version:\s*(\d+)\s*-->")
 SKILL_OVERLAY_RE = re.compile(r"<!--\s*desloppify-overlay:\s*(\w+)\s*-->")
@@ -19,6 +19,7 @@ SKILL_END = "<!-- desloppify-end -->"
 
 # Locations where the skill doc might be installed, relative to project root.
 SKILL_SEARCH_PATHS = (
+    ".factory/skills/desloppify/SKILL.md",
     ".agents/skills/desloppify/SKILL.md",
     ".claude/skills/desloppify/SKILL.md",
     ".opencode/skills/desloppify/SKILL.md",
@@ -38,6 +39,7 @@ SKILL_TARGETS: dict[str, tuple[str, str, bool]] = {
     "codex": (".agents/skills/desloppify/SKILL.md", "CODEX", True),
     "cursor": (".cursor/rules/desloppify.md", "CURSOR", True),
     "copilot": (".github/copilot-instructions.md", "COPILOT", False),
+    "droid": (".factory/skills/desloppify/SKILL.md", "DROID", True),
     "windsurf": ("AGENTS.md", "WINDSURF", False),
     "gemini": ("AGENTS.md", "GEMINI", False),
     "hermes": ("AGENTS.md", "HERMES", False),

--- a/docs/DROID.md
+++ b/docs/DROID.md
@@ -1,0 +1,39 @@
+## Droid Overlay
+
+Droid skills are installed at `.factory/skills/desloppify/SKILL.md`. Droid
+automatically discovers and invokes skills based on the task context,
+or you can invoke directly with `/desloppify`.
+
+### Subagents
+
+Droid supports custom droids (subagents) for parallel work. Use the `worker`
+droid for delegating independent tasks — it inherits the project's tool
+configuration and is ideal for parallel smell detection, file analysis,
+or cross-cutting refactoring work.
+
+### Review workflow
+
+1. Run `desloppify review --prepare` to generate `query.json` and
+   `.desloppify/review_packet_blind.json`.
+2. Split dimensions into 3-4 batches by theme.
+3. For each batch, launch a worker subagent:
+   ```
+   Task("worker", "review batch 1",
+     prompt="Score these dimensions: <list>. Read .desloppify/review_packet_blind.json. Score from code evidence only. Write results to review_batch_1.json.")
+   ```
+4. Merge assessments (average overlapping scores) and concatenate findings.
+5. Import: `desloppify review --import merged.json --manual-override --attest "Worker subagents ran blind reviews" --scan-after-import`.
+
+Each worker must consume `.desloppify/review_packet_blind.json` (not full
+`query.json`) to avoid score anchoring.
+
+### Triage workflow
+
+1. For each stage (observe → reflect → organize → enrich):
+   - Get prompt: `desloppify plan triage --stage-prompt <stage>`
+   - Launch worker with that prompt.
+   - Confirm: `desloppify plan triage --confirm <stage> --attestation "..."`
+2. Complete: `desloppify plan triage --complete --strategy "..." --attestation "..."`
+
+<!-- desloppify-overlay: droid -->
+<!-- desloppify-end -->

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: Bash(desloppify *)
 ---
 
 <!-- desloppify-begin -->
-<!-- desloppify-skill-version: 5 -->
+<!-- desloppify-skill-version: 6 -->
 
 # Desloppify
 


### PR DESCRIPTION
## Summary

 Adds support for Factory Droid as a skill harness target:

 - Adds `droid` to `SKILL_TARGETS` with `.factory/skills/desloppify/SKILL.md` path
 - Adds `.factory/skills/` to `SKILL_SEARCH_PATHS` for auto-discovery
 - Creates `docs/DROID.md` overlay with Droid-specific workflow documentation:
   - Subagent (worker droid) usage for parallel tasks
   - Review workflow with blind review packets
   - Triage workflow with stage-by-stage confirmation
 - Bumps `SKILL_VERSION` to 6
 - Adds `droid` to README harness list

 ## Files changed

 - `README.md` (+1 line, add droid to harness list)
 - `desloppify/app/skill_docs.py` (+4 lines)
 - `docs/DROID.md` (+39 lines, new file)
 - `docs/SKILL.md` (+1 line, version bump)

 ## Testing

 Manual testing: `desloppify update-skill droid` installs the skill at
 `.factory/skills/desloppify/SKILL.md`

 ## Dependencies

 None - this is an independent feature addition.