### PR TITLE
fix: handle dataclass serialization in json_default

### DIFF
--- a/desloppify/engine/_state/schema_scores.py
+++ b/desloppify/engine/_state/schema_scores.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,8 @@ def json_default(obj: Any) -> Any:
         return str(obj).replace("\\", "/")
     if hasattr(obj, "isoformat"):
         return obj.isoformat()
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return dataclasses.asdict(obj)
     raise TypeError(
         f"Object of type {type(obj).__name__} is not JSON serializable: {obj!r}"
     )


### PR DESCRIPTION
## Problem
`desloppify scan` crashes during state persistence when `EcosystemFrameworkDetection` (a dataclass) is stored in scan state. `json_default` in `schema_scores.py` doesn't handle dataclass instances, causing:

```
TypeError: Object of type EcosystemFrameworkDetection is not JSON serializable: EcosystemFrameworkDetection(ecosystem='node', ...)
```

## Fix
Added a `dataclasses.is_dataclass()` check to `json_default` that converts dataclass instances to dicts via `dataclasses.asdict()`, matching the existing pattern for other non-JSON-native types (sets, Paths, datetime objects).