### PR TITLE
fix: auto-resolve wontfix clippy/cargo items absent after cfg(test) filtering

### DIFF
--- a/desloppify/engine/_state/merge_issues.py
+++ b/desloppify/engine/_state/merge_issues.py
@@ -155,6 +155,24 @@ def verify_disappeared(
             resolved += 1
             continue
 
+        # Wontfix items from clippy/cargo that disappeared after inline-test
+        # filtering was introduced should be auto-resolved: the filter now
+        # correctly excludes test-only diagnostics, so the wontfix decision
+        # is obsolete.
+        if previous_status == "wontfix" and previous.get("detector", "") in (
+            "clippy_warning",
+            "cargo_error",
+        ):
+            previous["status"] = "auto_resolved"
+            previous["resolved_at"] = now
+            previous["note"] = (
+                "Auto-resolved: absent from scan after inline cfg(test) "
+                "filtering was introduced"
+            )
+            resolved_detectors.add(previous.get("detector", "unknown"))
+            resolved += 1
+            continue
+
         verification_note = (
             "Still absent from scan after manual wontfix"
             if previous_status == "wontfix"


### PR DESCRIPTION
## Summary

- When inline `cfg(test)` filtering was introduced (by me), clippy and cargo diagnostics originating from test-only modules are now correctly excluded from scans. This left behind stale `wontfix` issues from those detectors that would never reappear - but weren't being cleaned up either.
- This change auto-resolves `wontfix` items from `clippy_warning` and `cargo_error` detectors when they're absent from a scan, since the original wontfix decision is now obsolete (the filter handles it).