### PR TITLE
fix: prevent catastrophic backtracking in dart function extractor regex

### DIFF
--- a/desloppify/languages/dart/extractors.py
+++ b/desloppify/languages/dart/extractors.py
@@ -19,10 +19,10 @@ DART_FILE_EXCLUSIONS = ["build", ".dart_tool", ".fvm", ".git", "node_modules"]
 
 _FUNC_DECL_RE = re.compile(
     r"(?m)^\s*"
-    r"(?:(?:@[\w\.\(\),<>\s]+)\s*)*"
-    r"(?:(?:external|static|final|const|factory|late|required|covariant)\s+)*"
-    r"(?:[A-Za-z_]\w*(?:<[^>{}]+>)?\??\s+)?"
-    r"([A-Za-z_]\w*)\s*\(([^)]*)\)\s*(?:async\s*)?(=>|\{)"
+    r"(?:(?:@[\w\.\(\),<>\s]++)\s*+)*"
+    r"(?:(?:external|static|final|const|factory|late|required|covariant)\s++)*"
+    r"(?:[A-Za-z_]\w*(?:<[^>{}]+>)?\??\s++)?"
+    r"([A-Za-z_]\w*)\s*+\(([^)]*)\)\s*+(?:async\s*+)?(=>|\{)"
 )
 _KEYWORDS = {"if", "for", "while", "switch", "catch", "return"}
 


### PR DESCRIPTION
## Problem
The `desloppify scan` command gets stuck and hangs indefinitely at the `[3/8] Signature analysis...` step when analyzing certain Dart files.

This is caused by catastrophic backtracking in the `_FUNC_DECL_RE` regex within `desloppify/languages/dart/extractors.py`. The nested quantifiers `(?:(?:@[\w\.\(\),<>\s]+)\s*)*` can cause exponential backtracking if a string contains multiple matches for the inner group (such as SQL strings containing `@` parameters) separated by whitespace, because both `[\w\.\(\),<>\s]+` and `\s*` can consume whitespace characters, leading to massive evaluation times.

## Fix
Replaced the non-possessive quantifiers `+` and `*` with possessive quantifiers `++` and `*+` in `_FUNC_DECL_RE` for all parts of the regex that consume characters safely. This guarantees that once a string is matched by the inner pattern, the regex engine won't backtrack and try splitting up the whitespace, thereby instantly failing or matching the text without any performance penalties.

Verified that tests pass and the dart project now completes its scan properly.

Made with [Cursor](https://cursor.com)