### PR TITLE
fix: clear stale test coverage issues on zone reclassification

### DIFF
--- a/desloppify/app/commands/scan/workflow.py
+++ b/desloppify/app/commands/scan/workflow.py
@@ -443,6 +443,7 @@ def merge_scan_results(
 
     if runtime.lang and runtime.lang.zone_map is not None:
         runtime.state["zone_distribution"] = runtime.lang.zone_map.counts()
+    zone_lookup = runtime.lang.zone_map.get if runtime.lang and runtime.lang.zone_map is not None else None
     _persist_scan_coverage(runtime.state, runtime.lang)
 
     target_score = target_strict_score_from_config(runtime.config)
@@ -461,6 +462,7 @@ def merge_scan_results(
             ignore=runtime.config.get("ignore", []),
             subjective_integrity_target=target_score,
             project_root=str(get_project_root()),
+            zone_lookup=zone_lookup,
         ),
     )
 

--- a/desloppify/engine/_state/merge.py
+++ b/desloppify/engine/_state/merge.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from collections.abc import Callable
 from typing import Any
 
 __all__ = [
@@ -147,6 +148,7 @@ class MergeScanOptions:
     ignore: list[str] | None = None
     subjective_integrity_target: float | None = None
     project_root: str | None = None
+    zone_lookup: Callable[[str], object] | None = None
 
 
 def merge_scan(
@@ -217,6 +219,7 @@ def merge_scan(
         scan_path=resolved_options.scan_path,
         exclude=resolved_options.exclude,
         project_root=resolved_options.project_root,
+        zone_lookup=resolved_options.zone_lookup,
     )
 
     # Mark subjective assessments stale when mechanical issues changed.

--- a/desloppify/engine/_state/merge_issues.py
+++ b/desloppify/engine/_state/merge_issues.py
@@ -11,6 +11,22 @@ from desloppify.engine._state.issue_semantics import (
     is_assessment_request,
 )
 
+_NON_PRODUCTION_ZONES = {"test", "config", "generated", "vendor"}
+
+
+def _normalized_zone_value(zone_lookup, file_path: str) -> str | None:
+    """Best-effort normalization for zone lookup values."""
+    if zone_lookup is None or not file_path:
+        return None
+    try:
+        value = zone_lookup(file_path)
+    except Exception:
+        return None
+    raw = getattr(value, "value", value)
+    if raw is None:
+        return None
+    return str(raw).strip().lower() or None
+
 
 def find_suspect_detectors(
     existing: dict,
@@ -83,6 +99,7 @@ def verify_disappeared(
     scan_path: str | None,
     exclude: tuple[str, ...] = (),
     project_root: str | None = None,
+    zone_lookup=None,
 ) -> tuple[int, int, int, set[str]]:
     """Update scan corroboration for issues absent from scan.
 
@@ -146,6 +163,19 @@ def verify_disappeared(
                 file_deleted = not os.path.exists(
                     os.path.join(project_root, file_path)
                 )
+            # test_coverage findings should disappear automatically when files
+            # are now explicitly non-production by current zone policy.
+            if previous.get("detector") == "test_coverage":
+                zone_value = _normalized_zone_value(zone_lookup, file_path)
+                if zone_value in _NON_PRODUCTION_ZONES:
+                    previous["status"] = "auto_resolved"
+                    previous["resolved_at"] = now
+                    previous["note"] = (
+                        f"Auto-resolved: test_coverage file reclassified to {zone_value} zone"
+                    )
+                    resolved_detectors.add(previous.get("detector", "unknown"))
+                    resolved += 1
+                    continue
             if not file_deleted:
                 continue
             previous["status"] = "auto_resolved"

--- a/desloppify/languages/javascript/__init__.py
+++ b/desloppify/languages/javascript/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from desloppify.languages._framework.generic_support.core import generic_lang
 from desloppify.languages._framework.treesitter import JS_SPEC
+from desloppify.languages.javascript._zones import JS_ZONE_RULES
 
 
 cfg = generic_lang(
@@ -24,10 +25,12 @@ cfg = generic_lang(
     detect_markers=["package.json"],
     default_src="src",
     treesitter_spec=JS_SPEC,
+    zone_rules=JS_ZONE_RULES,
     frameworks=True,
 )
 
 __all__ = [
     "generic_lang",
     "JS_SPEC",
+    "JS_ZONE_RULES",
 ]

--- a/desloppify/languages/javascript/_zones.py
+++ b/desloppify/languages/javascript/_zones.py
@@ -1,0 +1,29 @@
+"""Zone/path classification rules for JavaScript."""
+
+from __future__ import annotations
+
+from desloppify.engine.policy.zones import COMMON_ZONE_RULES, Zone, ZoneRule
+
+JS_ZONE_RULES = [
+    ZoneRule(
+        Zone.TEST,
+        ["/__tests__/", ".test.", ".spec.", ".stories.", "/__mocks__/", "setupTests."],
+    ),
+    ZoneRule(
+        Zone.CONFIG,
+        [
+            "vite.config",
+            "tailwind.config",
+            "postcss.config",
+            "eslint",
+            "prettier",
+            "jest.config",
+            "vitest.config",
+            "next.config",
+            "webpack.config",
+            "babel.config",
+        ],
+    ),
+] + COMMON_ZONE_RULES
+
+__all__ = ["JS_ZONE_RULES"]

--- a/desloppify/languages/javascript/tests/test_init.py
+++ b/desloppify/languages/javascript/tests/test_init.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pytest
 
+from desloppify.engine.policy.zones import FileZoneMap, Zone
 from desloppify.languages import get_lang
 from desloppify.languages._framework.generic_parts.parsers import parse_eslint
 
@@ -83,6 +84,21 @@ def test_command_has_no_placeholder(cfg):
 def test_fix_cmd_registered(cfg):
     """JavaScript supports autofix — at least one fixer must be registered."""
     assert cfg.fixers, "expected at least one fixer (fix_cmd) to be registered for JavaScript"
+
+
+def test_zone_rules_classify_test_markers(cfg):
+    """JS plugin should classify common test markers into the test zone."""
+    files = [
+        "src/foo.test.js",
+        "src/bar.spec.jsx",
+        "src/__tests__/baz.js",
+        "src/app.js",
+    ]
+    zone_map = FileZoneMap(files, cfg.zone_rules)
+    assert zone_map.get("src/foo.test.js") == Zone.TEST
+    assert zone_map.get("src/bar.spec.jsx") == Zone.TEST
+    assert zone_map.get("src/__tests__/baz.js") == Zone.TEST
+    assert zone_map.get("src/app.js") == Zone.PRODUCTION
 
 
 def test_parsing_eslint_format():

--- a/desloppify/tests/commands/test_queue_count_consistency.py
+++ b/desloppify/tests/commands/test_queue_count_consistency.py
@@ -171,6 +171,55 @@ class TestAutoResolveOutOfScope:
         )
         assert "smells" in detectors
 
+    def test_open_test_coverage_issue_auto_resolves_when_file_now_in_test_zone(self):
+        """Stale open coverage findings should clear once the file is non-production."""
+        existing = {
+            "f1": {
+                "id": "f1",
+                "status": "open",
+                "file": "src/foo.test.ts",
+                "detector": "test_coverage",
+            },
+        }
+        resolved, _lang, out_of_scope, detectors = verify_disappeared(
+            existing,
+            current_ids=set(),
+            suspect_detectors=set(),
+            now="2026-04-01T00:00:00+00:00",
+            lang=None,
+            scan_path=".",
+            zone_lookup=lambda _file: "test",
+        )
+        assert existing["f1"]["status"] == "auto_resolved"
+        assert "reclassified to test zone" in existing["f1"]["note"]
+        assert out_of_scope == 0
+        assert resolved == 1
+        assert detectors == {"test_coverage"}
+
+    def test_open_non_coverage_issue_does_not_auto_resolve_from_zone_lookup(self):
+        """Manual authority remains for non-test_coverage open findings."""
+        existing = {
+            "f1": {
+                "id": "f1",
+                "status": "open",
+                "file": "src/foo.test.ts",
+                "detector": "unused",
+            },
+        }
+        resolved, _lang, out_of_scope, detectors = verify_disappeared(
+            existing,
+            current_ids=set(),
+            suspect_detectors=set(),
+            now="2026-04-01T00:00:00+00:00",
+            lang=None,
+            scan_path=".",
+            zone_lookup=lambda _file: "test",
+        )
+        assert existing["f1"]["status"] == "open"
+        assert out_of_scope == 0
+        assert resolved == 0
+        assert detectors == set()
+
 
 # ---------------------------------------------------------------------------
 # Fix 2: queue counting functions pass scan_path

--- a/desloppify/tests/commands/test_transitive_engine.py
+++ b/desloppify/tests/commands/test_transitive_engine.py
@@ -55,6 +55,7 @@ class TestMergeScanOptions:
         assert opts.include_slow is True
         assert opts.ignore is None
         assert opts.subjective_integrity_target is None
+        assert opts.zone_lookup is None
 
     def test_override_values(self):
         opts = MergeScanOptions(
@@ -68,6 +69,7 @@ class TestMergeScanOptions:
             include_slow=False,
             ignore=["secret_*"],
             subjective_integrity_target=0.8,
+            zone_lookup=lambda _path: "test",
         )
         assert opts.lang == "python"
         assert opts.scan_path == "src"
@@ -79,6 +81,7 @@ class TestMergeScanOptions:
         assert opts.include_slow is False
         assert opts.ignore == ["secret_*"]
         assert opts.subjective_integrity_target == 0.8
+        assert callable(opts.zone_lookup)
 
 
 class TestMergeScan:


### PR DESCRIPTION
## Problem
`desloppify` was surfacing stale `test_coverage` findings for files that had already been reclassified into non-production zones, including `.test.js` files in the current project. The detector logic itself was not necessarily re-emitting those findings; they were persisting through state merge/reconciliation.

## Fix
- pass live `zone_lookup` into scan merge reconciliation
- auto-resolve open `test_coverage` issues when the current file zone is non-production (`test`, `config`, `generated`, `vendor`)
- harden JavaScript zone rules so `.test.`, `.spec.`, and `__tests__` classify as `test`
- add focused tests for reconciliation and JS zone classification

## Verification
- `python -m py_compile` on the touched Python files succeeded under the local 3.12 env
- custom reconciliation check confirmed stale open `test_coverage` issues resolve when `zone_lookup` returns `test`
- simulated merge against a real project state reduced open `.test.js` `test_coverage` issues from 108 to 0
