### PR TITLE
fix: handle dataclass objects in json_default serializer

### DIFF
--- a/desloppify/engine/_state/schema_scores.py
+++ b/desloppify/engine/_state/schema_scores.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,8 @@ def json_default(obj: Any) -> Any:
         return str(obj).replace("\\", "/")
     if hasattr(obj, "isoformat"):
         return obj.isoformat()
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return dataclasses.asdict(obj)
     raise TypeError(
         f"Object of type {type(obj).__name__} is not JSON serializable: {obj!r}"
     )


### PR DESCRIPTION
## Problem
`desloppify scan` crashes during `save_state` when `EcosystemFrameworkDetection` (a dataclass) is in the state dict. The `json_default` fallback in `schema_scores.py` doesn't handle dataclass instances.

```
TypeError: Object of type EcosystemFrameworkDetection is not JSON serializable: EcosystemFrameworkDetection(ecosystem='node', package_root=PosixPath('...'), package_json_relpath='package.json', present={})
```

Command: `desloppify scan --path .` on a Node/TypeScript monorepo.

## Fix
Added `dataclasses.is_dataclass()` check to `json_default()` that converts dataclass instances to dicts via `dataclasses.asdict()`, before the `TypeError` raise.