### PR TITLE
fix: keep framework caches out of persisted review state

### DIFF
--- a/desloppify/languages/_framework/base/types.py
+++ b/desloppify/languages/_framework/base/types.py
@@ -82,6 +82,7 @@ class LangRuntimeContract(Protocol):
     zone_map: FileZoneMap | None
     dep_graph: dict[str, dict[str, Any]] | None
     complexity_map: dict[str, float]
+    runtime_cache: dict[str, Any]
     review_cache: dict[str, Any]
     review_max_age_days: int
     subjective_assessments: dict[str, Any]

--- a/desloppify/languages/_framework/frameworks/detection.py
+++ b/desloppify/languages/_framework/frameworks/detection.py
@@ -16,6 +16,14 @@ from .types import DetectionConfig, EcosystemFrameworkDetection, FrameworkEviden
 _CACHE_PREFIX = "frameworks.ecosystem.present"
 
 
+def _framework_runtime_cache(lang: LangRuntimeContract | None) -> dict[str, Any] | None:
+    """Return scan-scoped framework cache storage."""
+    if lang is None:
+        return None
+    cache = getattr(lang, "runtime_cache", None)
+    return cache if isinstance(cache, dict) else None
+
+
 def _find_nearest_package_json(scan_path: Path, project_root: Path) -> Path | None:
     resolved = scan_path if scan_path.is_absolute() else (project_root / scan_path)
     resolved = resolved.resolve()
@@ -133,13 +141,12 @@ def detect_ecosystem_frameworks(
     eco = str(ecosystem or "").strip().lower()
     resolved_scan_path = Path(scan_path).resolve()
     cache_key = f"{_CACHE_PREFIX}:{eco}:{resolved_scan_path.as_posix()}"
+    cache = _framework_runtime_cache(lang)
 
-    if lang is not None:
-        cache = getattr(lang, "review_cache", None)
-        if isinstance(cache, dict):
-            cached = cache.get(cache_key)
-            if isinstance(cached, EcosystemFrameworkDetection):
-                return cached
+    if cache is not None:
+        cached = cache.get(cache_key)
+        if isinstance(cached, EcosystemFrameworkDetection):
+            return cached
 
     project_root = get_project_root()
 
@@ -150,8 +157,8 @@ def detect_ecosystem_frameworks(
             package_json_relpath=None,
             present={},
         )
-        if lang is not None and isinstance(getattr(lang, "review_cache", None), dict):
-            lang.review_cache[cache_key] = result
+        if cache is not None:
+            cache[cache_key] = result
         return result
 
     package_json = _find_nearest_package_json(resolved_scan_path, project_root)
@@ -201,10 +208,8 @@ def detect_ecosystem_frameworks(
         present=present,
     )
 
-    if lang is not None:
-        cache = getattr(lang, "review_cache", None)
-        if isinstance(cache, dict):
-            cache[cache_key] = result
+    if cache is not None:
+        cache[cache_key] = result
 
     return result
 

--- a/desloppify/languages/_framework/frameworks/specs/nextjs.py
+++ b/desloppify/languages/_framework/frameworks/specs/nextjs.py
@@ -46,7 +46,7 @@ _NEXTJS_INFO_CACHE_PREFIX = "framework.nextjs.info"
 
 def _nextjs_info(scan_root: Path, lang: LangRuntimeContract) -> NextjsFrameworkInfo:
     key = f"{_NEXTJS_INFO_CACHE_PREFIX}:{scan_root.resolve().as_posix()}"
-    cache = getattr(lang, "review_cache", None)
+    cache = getattr(lang, "runtime_cache", None)
     if isinstance(cache, dict):
         cached = cache.get(key)
         if isinstance(cached, NextjsFrameworkInfo):

--- a/desloppify/languages/_framework/runtime_support/accessors.py
+++ b/desloppify/languages/_framework/runtime_support/accessors.py
@@ -39,6 +39,14 @@ class LangRunStateAccessors:
         self.state.complexity_map = value
 
     @property
+    def runtime_cache(self) -> dict[str, Any]:
+        return self.state.runtime_cache
+
+    @runtime_cache.setter
+    def runtime_cache(self, value: dict[str, Any]) -> None:
+        self.state.runtime_cache = value
+
+    @property
     def review_cache(self) -> dict[str, Any]:
         return self.state.review_cache
 

--- a/desloppify/languages/_framework/runtime_support/runtime.py
+++ b/desloppify/languages/_framework/runtime_support/runtime.py
@@ -26,6 +26,7 @@ class LangRuntimeState:
     zone_map: FileZoneMap | None = None
     dep_graph: dict[str, dict[str, Any]] | None = None
     complexity_map: dict[str, float] = field(default_factory=dict)
+    runtime_cache: dict[str, Any] = field(default_factory=dict)
     review_cache: dict[str, Any] = field(default_factory=dict)
     review_max_age_days: int = 30
     subjective_assessments: dict[str, Any] = field(default_factory=dict)
@@ -44,6 +45,7 @@ class LangRunOverrides:
     zone_map: FileZoneMap | None = _UNSET
     dep_graph: dict[str, dict[str, Any]] | None = _UNSET
     complexity_map: dict[str, float] | None = _UNSET
+    runtime_cache: dict[str, Any] | None = _UNSET
     review_cache: dict[str, Any] | None = _UNSET
     review_max_age_days: int | None = _UNSET
     subjective_assessments: dict[str, Any] | None = _UNSET
@@ -60,6 +62,7 @@ _LANG_OVERRIDE_FIELDS = tuple(f.name for f in fields(LangRunOverrides))
 _LANG_OVERRIDE_DICT_FIELDS = frozenset(
     {
         "complexity_map",
+        "runtime_cache",
         "review_cache",
         "subjective_assessments",
         "runtime_settings",

--- a/desloppify/tests/lang/common/test_framework_registration_and_commands_split_direct.py
+++ b/desloppify/tests/lang/common/test_framework_registration_and_commands_split_direct.py
@@ -476,6 +476,7 @@ class _AccessorHarness(accessors_mod.LangRunStateAccessors):
             zone_map=None,
             dep_graph=None,
             complexity_map={},
+            runtime_cache={},
             review_cache={},
             review_max_age_days=30,
             runtime_settings={},
@@ -499,6 +500,7 @@ def test_runtime_accessors_cover_state_and_default_resolution() -> None:
     run.zone_map = {"src/a.py": "production"}
     run.dep_graph = {"src/a.py": {"imports": set(), "importers": set()}}
     run.complexity_map = {"src/a.py": 4.2}
+    run.runtime_cache = {"framework": {"present": True}}
     run.review_cache = {"src/a.py": {"score": 92}}
     run.review_max_age_days = "60"
     run.runtime_settings = {"flag": {"x": 9}}
@@ -511,6 +513,7 @@ def test_runtime_accessors_cover_state_and_default_resolution() -> None:
     assert run.zone_map["src/a.py"] == "production"
     assert run.dep_graph["src/a.py"]["imports"] == set()
     assert run.complexity_map["src/a.py"] == 4.2
+    assert run.runtime_cache["framework"]["present"] is True
     assert run.review_cache["src/a.py"]["score"] == 92
     assert run.review_max_age_days == 60
     assert run.runtime_settings["flag"] == {"x": 9}

--- a/desloppify/tests/lang/common/test_lang_runtime_isolation.py
+++ b/desloppify/tests/lang/common/test_lang_runtime_isolation.py
@@ -31,6 +31,7 @@ def test_make_lang_run_instances_do_not_share_runtime_state() -> None:
     run_a.zone_map = {"a.py": "production"}
     run_a.dep_graph = {"a.py": {"imports": set(), "importers": set()}}
     run_a.complexity_map["a.py"] = 99
+    run_a.runtime_cache["framework"] = {"detected": True}
     run_a.review_cache["a.py"] = {"reviewed_at": "2026-01-01T00:00:00+00:00"}
     run_a.state.runtime_settings["alpha"] = 2
     run_a.state.runtime_options["beta"] = "y"
@@ -38,11 +39,13 @@ def test_make_lang_run_instances_do_not_share_runtime_state() -> None:
     assert run_b.zone_map is None
     assert run_b.dep_graph is None
     assert run_b.complexity_map == {}
+    assert run_b.runtime_cache == {}
     assert run_b.review_cache == {}
     assert run_b.runtime_setting("alpha", None) is None
     assert run_b.runtime_option("beta", None) is None
 
     assert run_a.complexity_map is not run_b.complexity_map
+    assert run_a.runtime_cache is not run_b.runtime_cache
     assert run_a.review_cache is not run_b.review_cache
     assert run_a.state.runtime_settings is not run_b.state.runtime_settings
     assert run_a.state.runtime_options is not run_b.state.runtime_options

--- a/desloppify/tests/scan/test_scan_workflow_integration_direct.py
+++ b/desloppify/tests/scan/test_scan_workflow_integration_direct.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 from desloppify import state as state_mod
@@ -11,8 +12,18 @@ from desloppify.app.commands.scan.workflow import (
     merge_scan_results,
     prepare_scan_runtime,
 )
+from desloppify.base.runtime_state import RuntimeContext, runtime_scope
 from desloppify.base.discovery.file_paths import rel
 from desloppify.engine.plan_state import empty_plan, load_plan, save_plan
+from desloppify.languages._framework.frameworks.detection import (
+    detect_ecosystem_frameworks,
+)
+from desloppify.languages._framework.frameworks.specs.nextjs import _nextjs_info
+from desloppify.languages._framework.runtime_support.runtime import (
+    LangRunOverrides,
+    make_lang_run,
+)
+from desloppify.languages.typescript import TypeScriptConfig
 
 
 def test_prepare_scan_runtime_uses_real_runtime_and_resets_subjective(tmp_path):
@@ -121,3 +132,35 @@ def test_merge_scan_results_persists_state_and_reconciles_plan(tmp_path):
     assert stale_id in plan_after.get("superseded", {})
     plan_start = plan_after.get("plan_start_scores", {})
     assert isinstance(plan_start.get("strict"), float)
+
+
+def test_framework_runtime_cache_stays_out_of_persisted_review_cache(tmp_path: Path):
+    state_path = tmp_path / "state.json"
+    (tmp_path / "package.json").write_text(
+        '{"dependencies":{"next":"15.0.0"},"scripts":{"build":"next build"}}\n'
+    )
+    (tmp_path / "next.config.ts").write_text("export default {};\n")
+    (tmp_path / "app").mkdir()
+    (tmp_path / "app" / "page.tsx").write_text("export default function Page() { return null; }\n")
+
+    state = state_mod.empty_state()
+    review_cache: dict[str, object] = {}
+    state["review_cache"] = review_cache
+    lang = make_lang_run(
+        TypeScriptConfig(),
+        overrides=LangRunOverrides(review_cache=review_cache),
+    )
+
+    with runtime_scope(RuntimeContext(project_root=tmp_path)):
+        detection = detect_ecosystem_frameworks(tmp_path, lang, "node")
+        info = _nextjs_info(tmp_path, lang)
+        state_mod.save_state(state, state_path)
+
+    assert "nextjs" in detection.present
+    assert info.package_root == tmp_path
+    assert state["review_cache"] == {}
+    assert any(key.startswith("frameworks.ecosystem.present:node:") for key in lang.runtime_cache)
+    assert any(key.startswith("framework.nextjs.info:") for key in lang.runtime_cache)
+
+    persisted = state_mod.load_state(state_path)
+    assert persisted.get("review_cache", {}) == {}


### PR DESCRIPTION
Closes #482

## Problem
`desloppify scan --path .` could complete detection and then crash while saving state for Next.js projects. The root cause was framework detection memoization writing runtime dataclass objects like `EcosystemFrameworkDetection` and `NextjsFrameworkInfo` into persisted `review_cache`, which is later serialized to JSON.

## Fix
- add a dedicated per-run `runtime_cache` to `LangRun` state
- move framework detection caching to `runtime_cache` instead of persisted `review_cache`
- keep framework cache access tolerant of lightweight/duck-typed lang objects that do not expose `runtime_cache`
- add regression coverage for runtime state accessors, runtime isolation, and state persistence for framework detection

## Verification
- `uv run --with pytest pytest desloppify/languages/typescript/tests/test_ts_nextjs_framework.py -q`
- `uv run --with pytest pytest desloppify/languages/javascript/tests/test_js_nextjs_framework.py -q`
- `uv run --with pytest pytest desloppify/tests/scan/test_scan_workflow_integration_direct.py -q`
- `uv run --with pytest pytest desloppify/tests/lang/common/test_lang_runtime_isolation.py -q`
- `uv run --with pytest pytest desloppify/tests/lang/common/test_framework_registration_and_commands_split_direct.py -q`

I also verified the patched package against a real Next.js repo (`/Users/mav/work/flyps/hivemind`) by reproducing framework detection and state save successfully with persisted `review_cache` left empty.