### PR TITLE
fix: handle generic fixers that return entries without 'removed' key

### DIFF
--- a/desloppify/app/commands/autofix/apply_flow.py
+++ b/desloppify/app/commands/autofix/apply_flow.py
@@ -59,9 +59,13 @@ def _print_fix_summary(
         )
     )
     for result in results[:30]:
-        symbols = ", ".join(result["removed"][:5])
-        if len(result["removed"]) > 5:
-            symbols += f" (+{len(result['removed']) - 5})"
+        removed = result.get("removed", [])
+        if removed:
+            symbols = ", ".join(removed[:5])
+            if len(removed) > 5:
+                symbols += f" (+{len(removed) - 5})"
+        else:
+            symbols = result.get("summary", "fixed")
         extra = f"  ({result['lines_removed']} lines)" if result.get("lines_removed") else ""
         print(f"  {rel(result['file'])}{extra}  →  {symbols}")
     if len(results) > 30:

--- a/desloppify/app/commands/autofix/apply_retro.py
+++ b/desloppify/app/commands/autofix/apply_retro.py
@@ -25,7 +25,7 @@ def _resolve_fixer_results(
     resolved_ids = []
     for result in results:
         result_file = rel(result["file"])
-        for symbol in result["removed"]:
+        for symbol in result.get("removed", []):
             issue_id = f"{detector}::{result_file}::{symbol}"
             if issue_id in work_items and work_items[issue_id]["status"] == "open":
                 work_items[issue_id]["status"] = "fixed"
@@ -91,8 +91,8 @@ def _cascade_unused_import_cleanup(
         print(colorize("  Cascade: no orphaned imports found", "dim"))
         return
 
-    removed_count = sum(len(result["removed"]) for result in results)
-    removed_lines = sum(result["lines_removed"] for result in results)
+    removed_count = sum(len(result["removed"]) if "removed" in result else 1 for result in results)
+    removed_lines = sum(result.get("lines_removed", 0) for result in results)
     print(
         colorize(
             f"  Cascade: removed {removed_count} now-orphaned imports "

--- a/desloppify/app/commands/autofix/cmd.py
+++ b/desloppify/app/commands/autofix/cmd.py
@@ -37,7 +37,7 @@ def cmd_autofix(args: argparse.Namespace) -> None:
     raw = fixer.fix(entries, dry_run=dry_run)
     results = raw.entries
     skip_reasons = raw.skip_reasons
-    total_items = sum(len(r["removed"]) for r in results)
+    total_items = sum(len(r["removed"]) if "removed" in r else 1 for r in results)
     total_lines = sum(r.get("lines_removed", 0) for r in results)
     _print_fix_summary(fixer, results, total_items, total_lines, dry_run)
 

--- a/desloppify/app/commands/autofix/preview.py
+++ b/desloppify/app/commands/autofix/preview.py
@@ -16,14 +16,14 @@ def show_fix_dry_run_samples(entries: list[dict], results: list[dict]) -> None:
     print(colorize("\n  ── Sample changes (before → after) ──", "cyan"))
     for result in results[:5]:
         _print_fix_file_sample(result, entries)
-    removed_count = sum(len(r["removed"]) for r in results)
+    removed_count = sum(len(r["removed"]) if "removed" in r else 1 for r in results)
     if len(entries) > removed_count:
         print(colorize(f"\n  Note: {len(entries) - removed_count} of {len(entries)} entries were skipped (complex patterns, rest elements, etc.)", "dim"))
     print()
 
 
 def _print_fix_file_sample(result: dict, entries: list[dict]) -> None:
-    filepath, removed_set = result["file"], set(result["removed"])
+    filepath, removed_set = result["file"], set(result.get("removed", []))
     try:
         path = Path(filepath) if Path(filepath).is_absolute() else Path(".") / filepath
         lines = path.read_text().splitlines()


### PR DESCRIPTION
## Problem

Running `desloppify autofix eslint-warning` (and any other generic fixer using `fix_cmd`) crashes with:

```
  File ".../desloppify/app/commands/autofix/cmd.py", line 40, in cmd_autofix
    total_items = sum(len(r["removed"]) for r in results)
KeyError: 'removed'
```

**Root cause**: `make_generic_fixer` in `tool_factories.py` returns `FixResult` entries with shape `{"file": ..., "line": ...}` (dry-run) or `{"file": ..., "fixed": True}` (actual fix), whereas TypeScript-style fixers return `{"removed": [...symbols], "lines_removed": N}`. Four places in the autofix pipeline assumed `"removed"` is always present.

## Fix

Guard all four access sites with `.get("removed", [])` / `"removed" in r` checks:

- `cmd.py`: count each entry as 1 item when `"removed"` is absent
- `apply_flow.py`: fall back to `"fixed"` label in the per-file summary
- `preview.py`: guard the count sum and `set()` construction
- `apply_retro.py`: guard symbol iteration and count/lines aggregation

## Verification

```
python3 -m pytest desloppify/tests/ -q
# 5438 passed, 3 skipped

python3 -m desloppify autofix eslint-warning --path <project> --dry-run
# Works correctly now
```

Tested against a real project with 154 eslint_warning findings.