### PR TITLE
fix: handle framework dataclass cache + synthetic deferred loop

### DIFF
--- a/desloppify/engine/_state/schema_scores.py
+++ b/desloppify/engine/_state/schema_scores.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +13,8 @@ def json_default(obj: Any) -> Any:
         return sorted(obj)
     if isinstance(obj, Path):
         return str(obj).replace("\\", "/")
+    if is_dataclass(obj):
+        return asdict(obj)
     if hasattr(obj, "isoformat"):
         return obj.isoformat()
     raise TypeError(

--- a/desloppify/engine/_work_queue/synthetic_workflow.py
+++ b/desloppify/engine/_work_queue/synthetic_workflow.py
@@ -12,6 +12,7 @@ from desloppify.engine._plan.constants import (
     WORKFLOW_IMPORT_SCORES_ID,
     WORKFLOW_RUN_SCAN_ID,
     WORKFLOW_SCORE_CHECKPOINT_ID,
+    is_synthetic_id,
 )
 from desloppify.engine._plan.refresh_lifecycle import (
     postflight_scan_pending,
@@ -269,7 +270,12 @@ def _temporary_skipped_ids(plan: dict) -> list[str]:
         if not isinstance(entry, dict):
             continue
         if str(entry.get("kind", "temporary")) == "temporary":
-            deferred.append(str(issue_id))
+            candidate = str(issue_id)
+            # Synthetic queue IDs (workflow/triage/subjective) are not real
+            # deferred issue work and can create phantom deferred loops.
+            if is_synthetic_id(candidate):
+                continue
+            deferred.append(candidate)
     deferred.sort()
     return deferred
 

--- a/desloppify/tests/engine/test_state_schema_scores_direct.py
+++ b/desloppify/tests/engine/test_state_schema_scores_direct.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from desloppify.engine._state.schema_scores import json_default
+from desloppify.languages._framework.frameworks.types import (
+    EcosystemFrameworkDetection,
+)
+
+
+def test_json_default_serializes_dataclass_payloads() -> None:
+    detection = EcosystemFrameworkDetection(
+        ecosystem="node",
+        package_root=Path("/tmp/example"),
+        package_json_relpath="package.json",
+        present={"nextjs": {"dep_hits": ["next"]}},
+    )
+
+    serialized = json_default(detection)
+
+    assert isinstance(serialized, dict)
+    assert serialized["ecosystem"] == "node"
+    assert serialized["package_root"] == Path("/tmp/example")
+    assert serialized["present"]["nextjs"]["dep_hits"] == ["next"]

--- a/desloppify/tests/review/test_work_queue_synthetic_workflow_direct.py
+++ b/desloppify/tests/review/test_work_queue_synthetic_workflow_direct.py
@@ -232,3 +232,16 @@ def test_build_deferred_disposition_item_counts_clusters_and_individuals() -> No
     assert "2 clusters + 1 individual item" in item["summary"]
     assert item["detail"]["deferred_cluster_count"] == 2
     assert item["detail"]["deferred_individual_count"] == 1
+
+
+def test_build_deferred_disposition_item_ignores_synthetic_skip_ids() -> None:
+    item = workflow_mod.build_deferred_disposition_item(
+        {
+            "skipped": {
+                "workflow::deferred-disposition": {"kind": "temporary"},
+                "triage::observe": {"kind": "temporary"},
+            }
+        }
+    )
+
+    assert item is None


### PR DESCRIPTION
## Problem
- `desloppify scan` can crash while saving state when framework detection objects are present in `review_cache` with:
  - `TypeError: Object of type EcosystemFrameworkDetection is not JSON serializable`
- `workflow::deferred-disposition` can reappear indefinitely when temporary-skipped entries include synthetic IDs (workflow/triage), creating a phantom deferred loop.

## Fix
- Extend JSON fallback serialization in `schema_scores.json_default()` to handle dataclass instances via `dataclasses.asdict(...)`.
- Filter synthetic IDs out of deferred temporary-skip counting in `build_deferred_disposition_item()` so only real issue IDs participate.
- Add regression tests for both behaviors:
  - dataclass serialization in state score schema helpers
  - synthetic-skip exclusion in deferred workflow item generation

## Verification
- `uv run --directory /tmp/desloppify-fix --with pytest pytest /tmp/desloppify-fix/desloppify/tests/engine/test_state_schema_scores_direct.py /tmp/desloppify-fix/desloppify/tests/review/test_work_queue_synthetic_workflow_direct.py -q`
- `uv run --directory /tmp/desloppify-fix desloppify scan --path /Users/alexanderting/Documents/frquick`
  - completes without the prior serialization crash
- `uv run --directory /tmp/desloppify-fix desloppify next --format json --count 1`
  - no phantom `workflow::deferred-disposition` loop in this run

Made with [Cursor](https://cursor.com)