### PR TITLE
fix: handle dataclass/dict/list in json_default for nested Path objects

### DIFF
--- a/desloppify/engine/_state/schema_scores.py
+++ b/desloppify/engine/_state/schema_scores.py
@@ -2,18 +2,28 @@
 
 from __future__ import annotations
 
+from dataclasses import is_dataclass
 from pathlib import Path
 from typing import Any
 
 
 def json_default(obj: Any) -> Any:
     """JSON serializer fallback for known non-JSON-native state values."""
+    if obj is None or isinstance(obj, (bool, int, float, str)):
+        return obj
     if isinstance(obj, set):
         return sorted(obj)
     if isinstance(obj, Path):
         return str(obj).replace("\\", "/")
     if hasattr(obj, "isoformat"):
         return obj.isoformat()
+    if is_dataclass(obj):
+        # Handle dataclass instances with Path attributes
+        return {k: json_default(v) for k, v in vars(obj).items()}
+    if isinstance(obj, dict):
+        return {k: json_default(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [json_default(item) for item in obj]
     raise TypeError(
         f"Object of type {type(obj).__name__} is not JSON serializable: {obj!r}"
     )


### PR DESCRIPTION
Fixes crash when saving scan state with EcosystemFrameworkDetection dataclass instances containing PosixPath objects.

Error: TypeError: Object of type EcosystemFrameworkDetection is not JSON serializable

Fixes #482