### PR TITLE
fix: support src-layout Python projects in test_coverage detector

### DIFF
--- a/desloppify/engine/detectors/coverage/mapping_analysis.py
+++ b/desloppify/engine/detectors/coverage/mapping_analysis.py
@@ -159,6 +159,10 @@ def _build_prod_by_module(
             if prod_file.startswith(root_str)
             else prod_file
         )
+        # Strip src/ prefix so src-layout projects map correctly
+        # (e.g. 'src/argos_toolkit/foo.py' -> 'argos_toolkit.foo')
+        if rel_path.startswith("src/") or rel_path.startswith("src\\"):
+            rel_path = rel_path[4:]
         module_name = rel_path.replace("/", ".").replace("\\", ".")
         if "." in module_name:
             module_name = module_name.rsplit(".", 1)[0]

--- a/desloppify/languages/python/test_coverage.py
+++ b/desloppify/languages/python/test_coverage.py
@@ -58,9 +58,16 @@ def resolve_import_spec(
         f"{module_path}.py",
         f"{module_path}/__init__.py",
     )
+    # Common source layout prefixes to try when direct match fails
+    _SRC_PREFIXES = ("src/",)
     for candidate in candidates:
         if candidate in production_files:
             return candidate
+        # Try src/-prefixed variants for src-layout projects
+        for prefix in _SRC_PREFIXES:
+            prefixed = f"{prefix}{candidate}"
+            if prefixed in production_files:
+                return prefixed
         if test_path:
             sibling = os.path.join(os.path.dirname(test_path), candidate)
             if sibling in production_files:


### PR DESCRIPTION
## Problem

In Python projects using `src/` layout (where production code lives under `src/package_name/`), the test_coverage detector fails to link test files to source files.

**`resolve_import_spec`** converts import specs like `mypackage.foo` to `mypackage/foo.py`, but production files are stored as `src/mypackage/foo.py`. The candidates never match.

**`_build_prod_by_module`** creates module aliases with a `src.` prefix (e.g. `src.mypackage.foo`) that import specs from tests never include.

This causes all modules in src-layout projects to be flagged as `untested_critical` even when comprehensive test suites exist that import them.

## Fix

1. **`resolve_import_spec`** (languages/python/test_coverage.py): After checking direct candidates against `production_files`, also try `src/`-prefixed candidates.
2. **`_build_prod_by_module`** (engine/detectors/coverage/mapping_analysis.py): Strip `src/` prefix from relative paths before computing module names, so the index maps `argos_toolkit.foo` instead of `src.argos_toolkit.foo`.

## Testing

- All 5495 existing tests pass.
- Verified against a real src-layout project (argos-toolkit): test health detection went from broken (0%) to correctly detecting 22.0% coverage.