### PR TITLE
docs: README onboarding overhaul + TypeScript plugin README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,75 @@
 
 Desloppify gives your AI coding agent the tools to identify, understand, and systematically improve codebase quality. It combines mechanical detection (dead code, duplication, complexity) with subjective LLM review (naming, abstractions, module boundaries), then works through a prioritized fix loop. State persists across scans so it chips away over multiple sessions, and the scoring is designed to resist gaming.
 
+## What it is / What it isn't
+
+**desloppify IS:**
+- A **codebase health scanner** — finds structural debt, dead code, coupling problems, and design issues across 32 languages
+- A **scoring system** — gives you an honest health score (25% mechanical detectors, 75% AI design review) that resists gaming
+- A **prioritized action queue** — `desloppify next` always gives you the single most important thing to fix next
+- An **agent harness** — designed to be driven by AI coding agents (Claude, Codex, Cursor, etc.) that do the actual fixing guided by the queue
+- A **continuous improvement loop** — scan → score → plan → execute → rescan, tracked across sessions and PRs
+
+**desloppify IS NOT:**
+- An auto-formatter (use Prettier, Black, or gofmt for that)
+- A linter (it wraps your existing linters and adds structural analysis on top)
+- A tool that auto-fixes everything — mechanical auto-fix covers only the safest patterns (unused imports, style violations via existing tools). The vast majority of findings require a human or AI agent to implement
+- A one-time audit tool — it's designed to run continuously as a feedback loop
+- A replacement for code review — it finds structural and design debt, not logic bugs
+
+**The framing to nail:** *desloppify tells you and your AI agent exactly what slop exists, where it is, and what to fix next. The fixing is done by you or your agent — guided by the queue.*
+
+---
+
+## Supported Languages
+
+**Full plugins** — language-specific detectors, richer scoring, deeper analysis:
+
+| Language | Extensions | External tool |
+|----------|-----------|---------------|
+| Python | `.py` | `ruff` (required), `bandit` (optional) |
+| TypeScript | `.ts`, `.tsx` | `node`, `npx` |
+| JavaScript | `.js`, `.jsx`, `.mjs`, `.cjs` | `node`, `npx` |
+| Rust | `.rs` | `cargo`, `clippy` |
+| Go | `.go` | `golangci-lint` |
+| C# | `.cs` | optional: Roslyn JSON |
+| C/C++ | `.c`, `.cpp`, `.h`, `.hpp` | optional: `clang-tidy`, `cppcheck` |
+| Dart | `.dart` | — |
+| GDScript | `.gd` | — |
+
+**Generic plugins (23+)** — structural analysis, coupling, duplication, orphaned code, tree-sitter AST, and any linter you have installed:
+
+Ruby, Java, Kotlin, Swift, PHP, Scala, Elixir, Haskell, Bash, Lua, Perl, Clojure, Zig, Nim, PowerShell, R, Erlang, OCaml, F#, Julia, SCSS, Quarto, and more.
+
+Both tiers support the full agent-driven workflow. Full plugins have language-specific smell detectors and deeper scoring; generic plugins do structural/coupling/duplication/orphaned analysis and wrap any language linter you have installed.
+
+---
+
+## Quick start
+
+```bash
+# Install
+pip install "desloppify[full]"
+
+# Scan your project (produces a health score + list of issues)
+cd /your/project
+desloppify scan
+
+# Get your next action item (the single most important thing to fix)
+desloppify next
+```
+
+Before scanning, exclude directories that shouldn't be analysed (vendor folders, build output, generated code):
+
+```bash
+desloppify exclude vendor/
+desloppify exclude build/
+```
+
+Add `.desloppify/` to your `.gitignore` — it contains local state that shouldn't be committed.
+
+---
+
 <img src="assets/explained.png" width="100%">
 
 The score gives your agent a north-star, and the tooling helps it plan, execute, and resolve issues until it hits your target — with a lot of tricks to keep it on track. A score above 98 should correlate with a codebase a seasoned engineer would call beautiful.
@@ -11,8 +80,6 @@ The score gives your agent a north-star, and the tooling helps it plan, execute,
 That score generates a scorecard badge for your GitHub profile or README:
 
 <img src="assets/scorecard.png" width="100%">
-
-Currently supports 29 languages — full plugin depth for TypeScript, Python, C#, C++, Dart, GDScript, Go, and Rust; generic linter + tree-sitter support for Ruby, Java, Kotlin, and 18 more. For C++ projects, `compile_commands.json` is the primary analysis path and `Makefile` repositories fall back to best-effort local include scanning.
 
 ## For your agent's consideration...
 
@@ -79,6 +146,13 @@ scan ──→ score ──→ review ──→ triage ──→ execute ──�
 **Rescan** verifies improvements, catches cascading effects, and feeds the next cycle.
 
 State persists in `.desloppify/` so progress carries across sessions. The scoring resists gaming — wontfix items widen the gap between lenient and strict scores, and re-reviewing dimensions can lower scores if the reviewer finds new issues.
+
+## Key concepts
+
+- **Overall score** — your headline number; ignores issues you've accepted as known debt
+- **Strict score** — your north star; counts everything including accepted debt (harder to game)
+- **Triage** — the process of reviewing raw findings and promoting them into a prioritized action queue
+- **Subjective review** — AI analysis of architecture and design quality; accounts for 75% of your score
 
 ## From Vibe Coding to Vibe Engineering
 

--- a/desloppify/languages/typescript/README.md
+++ b/desloppify/languages/typescript/README.md
@@ -1,0 +1,115 @@
+# TypeScript Language Plugin for Desloppify
+
+Provides in-depth static analysis for TypeScript and React/TSX codebases.
+
+## Supported extensions
+
+`.ts`, `.tsx`
+
+## Requirements
+
+- Node.js with `npm`/`npx` available on `PATH`
+- TypeScript installed in the project: `npm install --save-dev typescript`
+
+Optional tools (enable additional phases):
+
+```bash
+npm install --save-dev knip   # dead exports and unused files
+```
+
+## Project detection
+
+Activates on projects containing a `package.json` file.
+
+## Usage
+
+```bash
+# Scan for issues
+desloppify scan --path <project>
+
+# Auto-fix safe issues (unused imports, log cleanup, etc.)
+desloppify autofix --path <project>
+```
+
+## What gets analysed
+
+| Phase | What it finds |
+|-------|--------------|
+| Unused (tsc) | Type errors, unused locals, implicit any |
+| Dead exports | Exported symbols never imported outside their module |
+| Deprecated | Uses of deprecated APIs |
+| Logs | Console statements left in production code |
+| Structural analysis | God components, large files, complexity hotspots |
+| Coupling + cycles + patterns + naming | Import cycles, tight coupling, single-use abstractions, naming issues |
+| Tree-sitter cohesion | Modules/classes that do too many unrelated things (when tree-sitter available) |
+| Signature analysis | Overly broad function signatures |
+| Test coverage | Functions/components with no corresponding tests |
+| Code smells | `any` types, empty catch blocks, `@ts-ignore`, non-null assertions, async/await misuse, and more |
+| React patterns | Hook bloat, context misuse, state sync issues, prop drilling |
+| Framework patterns | Next.js-specific issues when applicable |
+| Security | Common TypeScript/Node security patterns |
+| Subjective review | LLM analysis of architecture, abstractions, and design quality |
+| Duplicates | Near-duplicate functions across the codebase |
+
+## Exclusions
+
+The following are excluded from analysis by default:
+
+- `node_modules`
+- `*.d.ts` declaration files
+- `dist`, `build`, `.next`, `coverage`
+
+## Auto-fixers
+
+TypeScript has a set of targeted auto-fixers applied via `desloppify autofix`:
+
+- Unused import removal
+- Console log cleanup
+- `useEffect` dependency array fixes
+- Variable and parameter cleanup
+- Syntax normalization
+
+---
+
+## TypeScript Plugin Maintainer Notes
+
+### Phase layout
+
+- `phases_basic.py` — logs, unused (tsc), dead exports, deprecated
+- `phases_structural.py` — structural analysis (god objects, large files, complexity)
+- `phases_coupling.py` — coupling, cycles, orphaned, single-use, naming patterns
+- `phases_smells.py` — code smell detection
+- `phases_config.py` — shared thresholds and god-class rules
+
+### Detector layout
+
+- `detectors/smells/` — TypeScript-specific smell catalog and detection logic
+- `detectors/react/` — React/hooks-specific detectors
+- `detectors/security/` — Security pattern detectors
+- `detectors/patterns/` — Naming and structural pattern analysis
+- `detectors/deps/` — Dependency graph construction
+- `detectors/exports.py` — Dead export detection
+- `detectors/concerns.py` — Responsibility cohesion analysis
+- `detectors/contracts.py` — Interface/type contract checks
+- `detectors/deprecated.py` — Deprecated API usage
+- `detectors/knip_adapter.py` — Knip integration for dead code detection
+
+### Adding a new smell detector
+
+1. Add smell metadata to `detectors/smells/catalog.py` — `id`, `label`, `pattern`, `severity`
+2. For pattern-based smells, the catalog entry is sufficient
+3. For context-aware smells, implement detection logic in the appropriate `detector_*.py` module
+4. Run checks: `pytest -q desloppify/languages/typescript/tests/`
+
+### Testing
+
+```bash
+# Run all TypeScript plugin tests
+pytest -q desloppify/languages/typescript/tests/
+
+# Run focused smell tests
+pytest -q desloppify/languages/typescript/tests/test_ts_smells.py
+
+# Run React detector tests
+pytest -q desloppify/languages/typescript/tests/test_ts_react.py
+```


### PR DESCRIPTION
I couldn't figure out how to actually use the tool from reading the README. Eventually I had my AI agent explain it to me — and once it did, it all made sense. I figured I probably wasn't the only one bouncing off the front page, so I had it turn that explanation into proper documentation.

## What changed

**`README.md`** — four sections added:

- **What it is / What it isn't** — appears right after the one-liner. The main thing missing: new users (including me) read this as an auto-fix tool. This section makes it clear up front that desloppify finds and queues the work; you or your agent does the fixing.
- **Supported Languages** — the #1 question any new user has ("does this work for my stack?") was completely unanswered. Two-tier table: 9 full plugins with extensions and external tool requirements, then the 23+ generic plugins listed out.
- **Quick start** — three commands to go from zero to first scan, with a note on excluding vendor/build dirs and adding `.desloppify/` to `.gitignore`.
- **Key concepts** — one-sentence definitions of overall score, strict score, triage, and subjective review. These terms show up everywhere in the tool output but were never explained.

**`desloppify/languages/typescript/README.md`** — created. TypeScript is the only full plugin with no README. Covers requirements, project detection, every analysis phase in a table, exclusions, auto-fixers, and maintainer notes.

## Why each piece matters

The agent prompt is great once you know what you're dealing with — but right now a new user hits that wall of text before they know what the tool is or whether it supports their language. The new sections front-load exactly that context so the agent prompt lands with meaning instead of confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)