### PR TITLE
fix: force UTF-8 in review runner logs and payload parsing

### DIFF
--- a/desloppify/app/commands/review/runner_failures.py
+++ b/desloppify/app/commands/review/runner_failures.py
@@ -144,7 +144,9 @@ def summarize_failure_categories(*, failures: list[int], logs_dir: Path) -> dict
             category = "missing_log"
         else:
             try:
-                category = classify_runner_failure(log_file.read_text())
+                category = classify_runner_failure(
+                    log_file.read_text(encoding="utf-8", errors="replace")
+                )
             except OSError:
                 category = "log_read_error"
         categories[category] = categories.get(category, 0) + 1
@@ -191,7 +193,7 @@ def runner_failure_hints(*, failures: list[int], logs_dir: Path) -> list[str]:
         log_file = logs_dir / f"batch-{idx + 1}.log"
         raw = ""
         try:
-            raw = log_file.read_text()
+            raw = log_file.read_text(encoding="utf-8", errors="replace")
         except OSError as exc:
             log_best_effort_failure(
                 logger,
@@ -216,7 +218,9 @@ def any_restricted_sandbox_failures(*, failures: list[int], logs_dir: Path) -> b
         log_file = logs_dir / f"batch-{idx + 1}.log"
         text = ""
         try:
-            text = _normalize_runner_failure_text(log_file.read_text())
+            text = _normalize_runner_failure_text(
+                log_file.read_text(encoding="utf-8", errors="replace")
+            )
         except OSError as exc:
             log_best_effort_failure(
                 logger,

--- a/desloppify/app/commands/review/runner_parallel/__init__.py
+++ b/desloppify/app/commands/review/runner_parallel/__init__.py
@@ -114,7 +114,9 @@ def collect_batch_results(
         parsed_from_log = False
         if raw_path.exists():
             try:
-                payload = extract_payload_fn(raw_path.read_text())
+                payload = extract_payload_fn(
+                    raw_path.read_text(encoding="utf-8", errors="replace")
+                )
             except OSError as exc:
                 logger.warning("Failed reading batch payload %s: %s", raw_path, exc)
                 payload = None

--- a/desloppify/app/commands/review/runner_process_impl/attempts.py
+++ b/desloppify/app/commands/review/runner_process_impl/attempts.py
@@ -109,6 +109,8 @@ def _start_runner_process(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,
         )
     except OSError as exc:
@@ -261,6 +263,8 @@ def _run_via_subprocess(
                 cmd,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=deps.timeout_seconds,
             )
         except deps.timeout_error:


### PR DESCRIPTION
## Problem
On Windows/Codex review runs, the batch runner and failure reporter still use the platform default text encoding in a few places. That causes two concrete failures:

- live stream/log reads can throw `charmap` decode errors while Codex emits UTF-8
- payload and log recovery can misread UTF-8 batch output, which then surfaces as malformed JSON or crashes in failure reporting

In a real `desloppify review --run-batches --runner codex --parallel --scan-after-import` run against `zoteropit`, this showed up as:
- `batch output JSON parse failed: Expecting ',' delimiter`
- `UnicodeDecodeError: 'charmap' codec can't decode byte ...` in `runner_failures.py`

After forcing UTF-8 decoding locally, the same retry path no longer crashed in parsing/reporting and correctly surfaced the real environment issue (`usage limit`) instead of a tool failure.

## Fix
- force `encoding="utf-8", errors="replace"` in the subprocess runner paths
- read runner logs with UTF-8 replacement in failure classification/hint generation
- read raw batch payload files with UTF-8 replacement during result collection

## Verification
- `python -m pytest desloppify/tests/review/test_runner_internals.py -q`
- `python -m pytest desloppify/tests/review/test_runner_parallel_internals.py -q`
- `python -m pytest desloppify/tests/review/review_commands_runner_cases.py -q`

All passed locally.
