### PR TITLE
fix: add lower-bound guard in fix_debug_logs to prevent negative-index file corruption

### DIFF
--- a/desloppify/languages/typescript/fixers/logs.py
+++ b/desloppify/languages/typescript/fixers/logs.py
@@ -32,7 +32,7 @@ def fix_debug_logs(entries: list[dict], *, dry_run: bool = False) -> FixResult:
         lines_to_remove: set[int] = set()
         for entry in file_entries:
             start = entry["line"] - 1
-            if start >= len(lines):
+            if start < 0 or start >= len(lines):
                 continue
             if is_logger_wrapper_context(lines, start):
                 continue

--- a/desloppify/languages/typescript/tests/test_ts_fixers.py
+++ b/desloppify/languages/typescript/tests/test_ts_fixers.py
@@ -595,6 +595,24 @@ class TestFixDebugLogs:
         assert len(result.entries) == 1
         assert ts_file.read_text() == original
 
+    def test_zero_line_number_skipped(self, tmp_path):
+        """An entry with line=0 is skipped without corrupting the file."""
+        ts_file = tmp_path / "app.ts"
+        original = "function foo() {\n  return 1;\n}\n"
+        ts_file.write_text(original)
+        entries = [
+            {
+                "file": str(ts_file),
+                "line": 0,
+                "tag": "DEBUG",
+                "content": "console.log('[DEBUG] oops');",
+            }
+        ]
+        result = fix_debug_logs(entries, dry_run=False)
+        # Entry is out-of-bounds (line 0 → index -1); file must be unchanged
+        assert ts_file.read_text() == original
+        assert len(result.entries) == 0
+
     def test_result_metadata(self, tmp_path):
         """Result dict contains expected keys: file, tags, lines_removed, log_count."""
         ts_file = tmp_path / "app.ts"


### PR DESCRIPTION
## Summary

- `logs.py` was missing the `start < 0` bounds check that every other TypeScript fixer (`vars.py`, `params.py`, `if_chain.py`) already has
- A zero or negative `line` value in an entry caused `start` to become -1, silently **passing** the `start >= len(lines)` guard
- Python's negative indexing then caused the fixer to operate on lines at the **end of the file** instead of skipping the entry — silently removing the wrong lines from the codebase
- This is the "stupid refactoring" condition described in issue #421: the tool could corrupt a file by removing its last line(s) when given a malformed/zero-indexed entry

## Fix

Align `logs.py` with all other fixers by adding the lower-bound check:

```python
# Before (broken)
if start >= len(lines):

# After (fixed)
if start < 0 or start >= len(lines):
```

## Test plan

- [x] Added `test_zero_line_number_skipped` to `TestFixDebugLogs` — confirms that `line=0` entry is skipped and the file is left untouched
- [x] All 8 existing `TestFixDebugLogs` tests pass
- [x] Matches the guard pattern used in `vars.py:56`, `params.py:30`, and `if_chain.py:26`

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)