### PR TITLE
feat: add OpenCode as alternative batch review runner

### DIFF
--- a/desloppify/app/cli_support/parser_groups_admin_review.py
+++ b/desloppify/app/cli_support/parser_groups_admin_review.py
@@ -22,6 +22,7 @@ def _add_review_parser(sub) -> None:
 examples:
   desloppify review --prepare
   desloppify review --run-batches --runner codex --parallel --scan-after-import
+  desloppify review --run-batches --runner opencode --parallel --scan-after-import
   desloppify review --external-start --external-runner claude
   desloppify review --external-submit --session-id <id> --import issues.json
   desloppify review --merge --similarity 0.8""",

--- a/desloppify/app/cli_support/parser_groups_admin_review_options_batch.py
+++ b/desloppify/app/cli_support/parser_groups_admin_review_options_batch.py
@@ -14,7 +14,7 @@ def _add_batch_execution_options(p_review: argparse.ArgumentParser) -> None:
     )
     g_batch.add_argument(
         "--runner",
-        choices=["codex"],
+        choices=["codex", "opencode"],
         default="codex",
         help="Subagent runner backend (default: codex)",
     )
@@ -26,8 +26,7 @@ def _add_batch_execution_options(p_review: argparse.ArgumentParser) -> None:
         type=int,
         default=3,
         help=(
-            "Max concurrent subagent batches when --parallel is enabled "
-            "(default: 3)"
+            "Max concurrent subagent batches when --parallel is enabled (default: 3)"
         ),
     )
     g_batch.add_argument(
@@ -41,8 +40,7 @@ def _add_batch_execution_options(p_review: argparse.ArgumentParser) -> None:
         type=int,
         default=1,
         help=(
-            "Retries per failed batch for transient runner/network errors "
-            "(default: 1)"
+            "Retries per failed batch for transient runner/network errors (default: 1)"
         ),
     )
     g_batch.add_argument(
@@ -50,8 +48,7 @@ def _add_batch_execution_options(p_review: argparse.ArgumentParser) -> None:
         type=float,
         default=2.0,
         help=(
-            "Base backoff delay for transient batch retries in seconds "
-            "(default: 2.0)"
+            "Base backoff delay for transient batch retries in seconds (default: 2.0)"
         ),
     )
     g_batch.add_argument(

--- a/desloppify/app/commands/review/batch/orchestrator.py
+++ b/desloppify/app/commands/review/batch/orchestrator.py
@@ -41,13 +41,18 @@ from ..runner_packets import (
     selected_batch_indexes,
     write_packet_snapshot,
 )
-from ..runner_parallel import BatchExecutionOptions, collect_batch_results, execute_batches
+from ..runner_parallel import (
+    BatchExecutionOptions,
+    collect_batch_results,
+    execute_batches,
+)
 from desloppify.app.commands.runner.codex_batch import (
     CodexBatchRunnerDeps,
     FollowupScanDeps,
     run_codex_batch,
     run_followup_scan,
 )
+from desloppify.app.commands.review.runner_process import run_opencode_batch
 from ..runtime.setup import setup_lang_concrete as _setup_lang
 from ..runtime_paths import (
     blind_packet_path as _blind_packet_path,
@@ -105,7 +110,9 @@ def _batch_live_log_interval_seconds(heartbeat_seconds: float) -> float:
     return max(1.0, min(heartbeat_seconds, 10.0))
 
 
-def _build_batch_run_deps(*, policy, project_root: Path) -> review_batches_mod.BatchRunDeps:
+def _build_batch_run_deps(
+    *, args, policy, project_root: Path
+) -> review_batches_mod.BatchRunDeps:
     """Build the dependency bundle used by prepare/execute/import phases."""
     from desloppify.engine.plan_state import load_policy_result, render_policy_block
 
@@ -161,7 +168,9 @@ def _build_batch_run_deps(*, policy, project_root: Path) -> review_batches_mod.B
             colorize_fn=colorize,
         ),
         run_codex_batch_fn=partial(
-            run_codex_batch,
+            run_opencode_batch
+            if getattr(args, "runner", "codex") == "opencode"
+            else run_codex_batch,
             deps=codex_batch_deps,
         ),
         execute_batches_fn=lambda **kwargs: execute_batches(
@@ -286,7 +295,9 @@ def _load_or_prepare_packet(
     if packet_override:
         packet_path = Path(packet_override)
         if not packet_path.exists():
-            raise PacketValidationError(f"packet not found: {packet_override}", exit_code=1)
+            raise PacketValidationError(
+                f"packet not found: {packet_override}", exit_code=1
+            )
         try:
             packet = json.loads(packet_path.read_text())
         except (OSError, json.JSONDecodeError) as exc:
@@ -306,7 +317,9 @@ def _load_or_prepare_packet(
     # Validate explicit dimensions against the language's scored dimensions.
     if dims:
         lang_obj = lang
-        lang_name = getattr(lang_obj, "name", None) or str(getattr(lang_obj, "lang", ""))
+        lang_name = getattr(lang_obj, "name", None) or str(
+            getattr(lang_obj, "lang", "")
+        )
         if lang_name:
             valid_dims = set(scored_dimensions_for_lang(lang_name))
             if valid_dims:
@@ -384,6 +397,7 @@ def do_run_batches(args, state, lang, state_file, config: dict | None = None) ->
     subagent_runs_dir = _subagent_runs_dir()
     policy = resolve_batch_run_policy(args)
     batch_deps = _build_batch_run_deps(
+        args=args,
         policy=policy,
         project_root=project_root,
     )
@@ -410,6 +424,7 @@ def do_run_batches(args, state, lang, state_file, config: dict | None = None) ->
         deps=batch_deps,
     )
 
+
 def _validate_run_dir(run_dir: Path) -> tuple[dict, Path, str]:
     """Validate run directory, load summary, and return (summary, blind_packet_path, immutable_packet_path).
 
@@ -433,12 +448,16 @@ def _validate_run_dir(run_dir: Path) -> tuple[dict, Path, str]:
     if not selected:
         raise CommandError("no selected batches in run summary.", exit_code=1)
     if not blind_packet_path.exists():
-        raise PacketValidationError(f"blind packet not found: {blind_packet_path}", exit_code=1)
+        raise PacketValidationError(
+            f"blind packet not found: {blind_packet_path}", exit_code=1
+        )
 
     try:
         packet = json.loads(Path(immutable_packet_path).read_text())
     except (OSError, json.JSONDecodeError) as exc:
-        raise PacketValidationError(f"Error reading immutable packet: {exc}", exit_code=1) from exc
+        raise PacketValidationError(
+            f"Error reading immutable packet: {exc}", exit_code=1
+        ) from exc
 
     summary["_packet"] = packet
     return summary, blind_packet_path, immutable_packet_path
@@ -475,8 +494,7 @@ def do_import_run(
     results_dir = run_dir / "results"
     selected_indexes = [idx - 1 for idx in selected]  # convert 1-based to 0-based
     output_files = {
-        idx: results_dir / f"batch-{idx + 1}.raw.txt"
-        for idx in selected_indexes
+        idx: results_dir / f"batch-{idx + 1}.raw.txt" for idx in selected_indexes
     }
 
     missing = [idx + 1 for idx in selected_indexes if not output_files[idx].exists()]
@@ -518,9 +536,16 @@ def do_import_run(
     if not batch_results:
         raise CommandError("no valid batch results could be parsed.", exit_code=1)
 
-    print(colorize(f"  Parsed {len(batch_results)} batch results from {run_dir}", "bold"))
+    print(
+        colorize(f"  Parsed {len(batch_results)} batch results from {run_dir}", "bold")
+    )
     if failures:
-        print(colorize(f"  Warning: {len(failures)} batches failed to parse: {[f + 1 for f in failures]}", "yellow"))
+        print(
+            colorize(
+                f"  Warning: {len(failures)} batches failed to parse: {[f + 1 for f in failures]}",
+                "yellow",
+            )
+        )
 
     successful_indexes = [idx for idx in selected_indexes if idx not in set(failures)]
 
@@ -529,7 +554,9 @@ def do_import_run(
     raw_dim_prompts = packet.get("dimension_prompts")
     batches = explode_to_single_dimension(
         raw_batches if isinstance(raw_batches, list) else [],
-        dimension_prompts=raw_dim_prompts if isinstance(raw_dim_prompts, dict) else None,
+        dimension_prompts=raw_dim_prompts
+        if isinstance(raw_dim_prompts, dict)
+        else None,
     )
     packet_dimensions = normalize_dimension_list(packet.get("dimensions", []))
     lang_name = getattr(lang, "name", None) or str(getattr(lang, "lang", ""))

--- a/desloppify/app/commands/review/batch/scope.py
+++ b/desloppify/app/commands/review/batch/scope.py
@@ -14,12 +14,17 @@ from desloppify.intelligence.review.feedback_contract import (
 )
 
 
+_SUPPORTED_RUNNERS = {"codex", "opencode"}
+_DEFAULT_RUNNER = "codex"
+
+
 def validate_runner(runner: str, *, colorize_fn) -> None:
     """Validate review batch runner."""
-    if runner == "codex":
+    if runner in _SUPPORTED_RUNNERS:
         return
+    supported = ", ".join(sorted(_SUPPORTED_RUNNERS))
     raise CommandError(
-        f"Error: unsupported runner '{runner}' (supported: codex)", exit_code=2
+        f"Error: unsupported runner '{runner}' (supported: {supported})", exit_code=2
     )
 
 
@@ -43,12 +48,16 @@ def require_batches(
         )
     print(
         colorize_fn(
-            "  Happy path: `desloppify review --prepare` then follow your runner's review workflow.",
+            "  Then follow your runner's review workflow —"
+            " e.g. `desloppify review --run-batches --runner codex --parallel --scan-after-import`"
+            " (swap `codex` for `opencode` if preferred).",
             "dim",
         ),
         file=sys.stderr,
     )
-    raise PacketValidationError("Error: packet has no investigation_batches.", exit_code=1)
+    raise PacketValidationError(
+        "Error: packet has no investigation_batches.", exit_code=1
+    )
 
 
 def print_review_quality(quality: object, *, colorize_fn) -> None:
@@ -57,9 +66,7 @@ def print_review_quality(quality: object, *, colorize_fn) -> None:
         return
     coverage = quality.get("dimension_coverage")
     density = quality.get("evidence_density")
-    high_missing_issue_note = quality.get(
-        REVIEW_QUALITY_HIGH_SCORE_MISSING_ISSUES_KEY
-    )
+    high_missing_issue_note = quality.get(REVIEW_QUALITY_HIGH_SCORE_MISSING_ISSUES_KEY)
     if not isinstance(high_missing_issue_note, int | float):
         high_missing_issue_note = quality.get(
             LEGACY_REVIEW_QUALITY_HIGH_SCORE_MISSING_ISSUES_KEY
@@ -129,7 +136,10 @@ def missing_scored_dimensions(
 
 def missing_dimensions_command(*, missing_dims: list[str], scan_path: str) -> str:
     """Return rerun command for missing subjective dimensions."""
-    base = "desloppify review --prepare --scan-after-import"
+    base = (
+        f"desloppify review --run-batches --runner {_DEFAULT_RUNNER}"
+        " --parallel --scan-after-import"
+    )
     if scan_path and scan_path != ".":
         base += f" --path {shlex.quote(scan_path)}"
     if missing_dims:
@@ -270,6 +280,8 @@ def enforce_trusted_import_coverage_gate(
 
 
 __all__ = [
+    "_DEFAULT_RUNNER",
+    "_SUPPORTED_RUNNERS",
     "collect_reviewed_files_from_batches",
     "enforce_trusted_import_coverage_gate",
     "missing_dimensions_command",

--- a/desloppify/app/commands/review/importing/policy.py
+++ b/desloppify/app/commands/review/importing/policy.py
@@ -20,12 +20,10 @@ from ..runtime_paths import blind_packet_path, runtime_project_root
 
 ASSESSMENT_POLICY_KEY = "_assessment_policy"
 BLIND_PROVENANCE_KIND = "blind_review_batch_import"
-SUPPORTED_BLIND_REVIEW_RUNNERS = {"codex", "claude"}
+SUPPORTED_BLIND_REVIEW_RUNNERS = {"codex", "claude", "opencode"}
 ATTESTED_EXTERNAL_RUNNERS = {"claude"}
 ATTESTED_EXTERNAL_REQUIRED_PHRASES = ("without awareness", "unbiased")
-ATTESTED_EXTERNAL_ATTEST_EXAMPLE = (
-    "I validated this review was completed without awareness of overall score and is unbiased."
-)
+ATTESTED_EXTERNAL_ATTEST_EXAMPLE = "I validated this review was completed without awareness of overall score and is unbiased."
 ASSESSMENT_MODE_LABELS = {
     "none": "issues-only (no assessments in payload)",
     "trusted_internal": "trusted internal (durable scores)",
@@ -332,7 +330,9 @@ def assessment_policy_model_from_payload(
     payload: NormalizedReviewImportPayload | ReviewImportPayload,
 ) -> AssessmentImportPolicyModel:
     """Return typed assessment policy metadata from a loaded import payload."""
-    return AssessmentImportPolicyModel.from_mapping(assessment_policy_from_payload(payload))
+    return AssessmentImportPolicyModel.from_mapping(
+        assessment_policy_from_payload(payload)
+    )
 
 
 def assessment_mode_label(policy: AssessmentImportPolicy) -> str:

--- a/desloppify/app/commands/review/packet/build.py
+++ b/desloppify/app/commands/review/packet/build.py
@@ -77,20 +77,26 @@ def build_holistic_packet(
     context: ReviewPacketContext,
     setup_lang_fn,
     prepare_holistic_review_fn=None,
+    review_prepare_options_cls=None,
+    compute_narrative_fn=None,
+    narrative_context_cls=None,
 ) -> tuple[dict[str, Any], str]:
     """Build the canonical holistic review packet payload and lang name."""
     lang_run, found_files = setup_lang_fn(lang, context.path, config)
     lang_name = lang_run.name
-    narrative = narrative_mod.compute_narrative(
+    compute_narrative = compute_narrative_fn or narrative_mod.compute_narrative
+    narrative_context = narrative_context_cls or narrative_mod.NarrativeContext
+    prepare_options_cls = review_prepare_options_cls or HolisticReviewPrepareOptions
+    narrative = compute_narrative(
         state,
-        context=narrative_mod.NarrativeContext(lang=lang_name, command="review"),
+        context=narrative_context(lang=lang_name, command="review"),
     )
     prepare_fn = prepare_holistic_review_fn or prepare_holistic_review
     packet = prepare_fn(
         context.path,
         lang_run,
         state,
-        options=HolisticReviewPrepareOptions(
+        options=prepare_options_cls(
             dimensions=context.dimensions,
             files=found_files or None,
             max_files_per_batch=coerce_review_batch_file_limit(config),
@@ -224,6 +230,9 @@ def build_review_packet_payload(
     next_command: str,
     setup_lang_fn,
     prepare_holistic_review_fn=None,
+    review_prepare_options_cls=None,
+    compute_narrative_fn=None,
+    narrative_context_cls=None,
 ) -> dict[str, Any]:
     """Build and validate a holistic review packet without persisting artifacts."""
     packet, _lang_name = build_holistic_packet(
@@ -233,6 +242,9 @@ def build_review_packet_payload(
         context=context,
         setup_lang_fn=setup_lang_fn,
         prepare_holistic_review_fn=prepare_holistic_review_fn,
+        review_prepare_options_cls=review_prepare_options_cls,
+        compute_narrative_fn=compute_narrative_fn,
+        narrative_context_cls=narrative_context_cls,
     )
     packet["config"] = redacted_review_config(config)
     packet["next_command"] = next_command

--- a/desloppify/app/commands/review/prepare.py
+++ b/desloppify/app/commands/review/prepare.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import desloppify.intelligence.narrative.core as narrative_mod
+import desloppify.intelligence.review.prepare as review_mod
+
 from desloppify.app.commands.helpers.query import write_query
 from desloppify.base.exception_sets import CommandError
 from desloppify.base.output.terminal import colorize
@@ -12,6 +15,12 @@ from .packet.build import (
     resolve_review_packet_context,
 )
 from .runtime.setup import setup_lang_concrete
+
+
+_ORIGINAL_COMPUTE_NARRATIVE = narrative_mod.compute_narrative
+_ORIGINAL_NARRATIVE_CONTEXT = narrative_mod.NarrativeContext
+_ORIGINAL_PREPARE_HOLISTIC_REVIEW = review_mod.prepare_holistic_review
+_ORIGINAL_REVIEW_PREPARE_OPTIONS = review_mod.HolisticReviewPrepareOptions
 
 
 def do_prepare(
@@ -28,6 +37,22 @@ def do_prepare(
 
     # Keep prepare and external-start on one packet-construction contract.
     try:
+        build_kwargs: dict[str, object] = {}
+        if narrative_mod.compute_narrative is not _ORIGINAL_COMPUTE_NARRATIVE:
+            build_kwargs["compute_narrative_fn"] = narrative_mod.compute_narrative
+        if narrative_mod.NarrativeContext is not _ORIGINAL_NARRATIVE_CONTEXT:
+            build_kwargs["narrative_context_cls"] = narrative_mod.NarrativeContext
+        if review_mod.prepare_holistic_review is not _ORIGINAL_PREPARE_HOLISTIC_REVIEW:
+            build_kwargs["prepare_holistic_review_fn"] = (
+                review_mod.prepare_holistic_review
+            )
+        if (
+            review_mod.HolisticReviewPrepareOptions
+            is not _ORIGINAL_REVIEW_PREPARE_OPTIONS
+        ):
+            build_kwargs["review_prepare_options_cls"] = (
+                review_mod.HolisticReviewPrepareOptions
+            )
         data = build_review_packet_payload(
             state=state,
             lang=lang,
@@ -35,6 +60,7 @@ def do_prepare(
             context=context,
             next_command=next_command,
             setup_lang_fn=setup_lang_concrete,
+            **build_kwargs,
         )
     except ValueError as exc:
         msg = str(exc).strip()
@@ -59,7 +85,10 @@ def do_prepare(
 
 
 def _print_prepare_summary(
-    data: dict, *, next_command: str, retrospective: bool,
+    data: dict,
+    *,
+    next_command: str,
+    retrospective: bool,
 ) -> None:
     """Print the prepare summary to the terminal."""
     total = data.get("total_files", 0)
@@ -120,7 +149,7 @@ def _print_prepare_summary(
     )
     print(
         colorize(
-            "  5. Emergency only: `--manual-override --attest \"<why>\"` (provisional; expires on next scan)",
+            '  5. Emergency only: `--manual-override --attest "<why>"` (provisional; expires on next scan)',
             "dim",
         )
     )

--- a/desloppify/app/commands/review/runner_failures.py
+++ b/desloppify/app/commands/review/runner_failures.py
@@ -45,15 +45,19 @@ _RUNNER_AUTH_PHRASES = (
 )
 _FAILURE_HINT_BY_CATEGORY = {
     "runner_missing": (
-        "codex CLI not found on PATH. Install Codex CLI and verify `codex --version`."
+        "Runner CLI not found on PATH. "
+        "Install the runner (codex or opencode) and verify it is on your PATH."
     ),
-    "runner_auth": "codex runner appears unauthenticated. Run `codex login` and retry.",
+    "runner_auth": (
+        "Runner appears unauthenticated. "
+        "For Codex run `codex login`; for OpenCode check your auth configuration."
+    ),
     "usage_limit": (
-        "Codex usage quota is exhausted for this account. "
+        "Runner usage quota is exhausted for this account. "
         "Wait for reset or add credits, then rerun failed batches."
     ),
     "stream_disconnect": (
-        "Transient Codex connectivity issue detected. Retry with "
+        "Transient runner connectivity issue detected. Retry with "
         "`--batch-max-retries 2 --batch-retry-backoff-seconds 2` and, if needed, "
         "lower concurrency via `--max-parallel-batches 1`."
     ),
@@ -61,12 +65,14 @@ _FAILURE_HINT_BY_CATEGORY = {
 
 
 def _is_runner_missing(text: str) -> bool:
-    return (
-        "codex not found" in text
-        or ("no such file or directory" in text and "$ codex " in text)
-        or ("errno 2" in text and "codex" in text)
-        or ("winerror 2" in text and "codex" in text)
-    )
+    for runner_name in ("codex", "opencode"):
+        if f"{runner_name} not found" in text:
+            return True
+        if "no such file or directory" in text and f"$ {runner_name} " in text:
+            return True
+        if "errno 2" in text and runner_name in text:
+            return True
+    return False
 
 
 def _is_runner_auth_failure(text: str) -> bool:
@@ -135,7 +141,9 @@ def looks_like_restricted_sandbox(log_text: str) -> bool:
     return any(phrase in text for phrase in _SANDBOX_PATH_WARNING_PHRASES)
 
 
-def summarize_failure_categories(*, failures: list[int], logs_dir: Path) -> dict[str, int]:
+def summarize_failure_categories(
+    *, failures: list[int], logs_dir: Path
+) -> dict[str, int]:
     """Return counts by failure category for failed batches."""
     categories: dict[str, int] = {}
     for idx in sorted(set(failures)):
@@ -163,7 +171,7 @@ def _connectivity_hints(text: str) -> list[str]:
     if not has_codex_backend_connectivity_issue(text):
         return []
     hints = [
-        "Codex runner cannot reach chatgpt.com backend from this environment. "
+        "Runner cannot reach its backend from this environment. "
         "Check outbound HTTPS/DNS/proxy access, or use cloud fallback: "
         "`desloppify review --external-start --external-runner claude`."
     ]
@@ -181,8 +189,8 @@ def _skill_file_hint(text: str) -> str | None:
     if "failed to load skill" not in text or "missing yaml frontmatter" not in text:
         return None
     return (
-        "Codex loaded an invalid local skill file. Fix/remove malformed "
-        "entries under `~/.codex/` (AGENTS.md or skills/) to reduce runner noise."
+        "Runner loaded an invalid local skill file. Fix/remove malformed "
+        "SKILL.md entries under the runner's skill directory to reduce noise."
     )
 
 

--- a/desloppify/app/commands/review/runner_process.py
+++ b/desloppify/app/commands/review/runner_process.py
@@ -1,0 +1,298 @@
+"""Compatibility wrapper for shared review batch runner helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from desloppify.app.commands.runner.codex_batch import (
+    CodexBatchRunnerDeps,
+    FollowupScanDeps,
+    codex_batch_command as _shared_codex_batch_command,
+    run_codex_batch as _shared_run_codex_batch,
+    run_followup_scan as _shared_run_followup_scan,
+)
+
+from .runner_process_impl.attempts import (
+    handle_early_attempt_return as _handle_early_attempt_return,
+    handle_failed_attempt as _handle_failed_attempt,
+    handle_successful_attempt as _handle_successful_attempt,
+    handle_timeout_or_stall as _handle_timeout_or_stall,
+    resolve_retry_config as _resolve_retry_config,
+    run_batch_attempt as _run_batch_attempt,
+)
+from .runner_process_impl.io import (
+    _extract_text_from_opencode_json_stream,
+    _output_file_has_json_payload,
+    extract_payload_from_log as _extract_payload_from_log,
+)
+
+BatchRunnerDeps = CodexBatchRunnerDeps
+
+
+def codex_batch_command(
+    *, prompt: str, repo_root: Path, output_file: Path
+) -> list[str]:
+    """Build one codex exec command line for a batch prompt."""
+    return _shared_codex_batch_command(
+        prompt=prompt,
+        repo_root=repo_root,
+        output_file=output_file,
+    )
+
+
+def run_codex_batch(
+    *,
+    prompt: str,
+    repo_root: Path,
+    output_file: Path,
+    log_file: Path,
+    deps: BatchRunnerDeps,
+    codex_batch_command_fn=None,
+) -> int:
+    """Execute one codex batch and return a stable CLI-style status code."""
+    return _shared_run_codex_batch(
+        prompt=prompt,
+        repo_root=repo_root,
+        output_file=output_file,
+        log_file=log_file,
+        deps=deps,
+        codex_batch_command_fn=codex_batch_command_fn or codex_batch_command,
+    )
+
+
+def opencode_batch_command(*, prompt: str, repo_root: Path) -> list[str]:
+    """Build one ``opencode run`` command line for a batch prompt."""
+    cmd = ["opencode", "run", "--format", "json"]
+    model = os.environ.get("DESLOPPIFY_OPENCODE_MODEL", "").strip()
+    if model:
+        cmd.extend(["--model", model])
+    variant = os.environ.get("DESLOPPIFY_OPENCODE_VARIANT", "").strip()
+    if variant:
+        cmd.extend(["--variant", variant])
+    attach_url = os.environ.get("DESLOPPIFY_OPENCODE_ATTACH", "").strip()
+    if attach_url:
+        cmd.extend(["--attach", attach_url])
+    cmd.extend(["--dir", str(repo_root)])
+    cmd.append(prompt)
+    return cmd
+
+
+def _capture_opencode_stdout_payload(
+    *, result, output_file: Path, deps: BatchRunnerDeps
+) -> str | None:
+    """Extract and persist a recoverable OpenCode payload from NDJSON stdout."""
+    extracted_text = _extract_text_from_opencode_json_stream(result.stdout_text)
+    return _persist_opencode_payload_text(
+        extracted_text=extracted_text,
+        output_file=output_file,
+        deps=deps,
+    )
+
+
+def _persist_opencode_payload_text(
+    *, extracted_text: str, output_file: Path, deps: BatchRunnerDeps
+) -> str | None:
+    """Persist OpenCode output only when it is a complete JSON object."""
+    normalized_text = extracted_text.strip()
+    if not normalized_text:
+        return None
+    try:
+        payload = json.loads(normalized_text)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    try:
+        deps.safe_write_text_fn(output_file, normalized_text)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+    return normalized_text
+
+
+def _build_live_opencode_stdout_observer(*, output_file: Path, deps: BatchRunnerDeps):
+    """Persist recoverable OpenCode payloads while stdout is still streaming."""
+    last_persisted_text: str | None = None
+
+    def _observe(stdout_text: str) -> None:
+        nonlocal last_persisted_text
+        extracted_text = _extract_text_from_opencode_json_stream(stdout_text)
+        normalized_text = extracted_text.strip()
+        if not normalized_text or normalized_text == last_persisted_text:
+            return
+        persisted_text = _persist_opencode_payload_text(
+            extracted_text=normalized_text,
+            output_file=output_file,
+            deps=deps,
+        )
+        if persisted_text is not None:
+            last_persisted_text = persisted_text
+
+    return _observe
+
+
+def _restore_opencode_recoverable_payload(
+    *, recoverable_text: str | None, output_file: Path, deps: BatchRunnerDeps
+) -> None:
+    """Restore the last known-good OpenCode payload for downstream recovery."""
+    if not recoverable_text or _output_file_has_json_payload(output_file):
+        return
+    try:
+        deps.safe_write_text_fn(output_file, recoverable_text)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return
+
+
+def run_opencode_batch(
+    *,
+    prompt: str,
+    repo_root: Path,
+    output_file: Path,
+    log_file: Path,
+    deps: BatchRunnerDeps,
+    opencode_batch_command_fn=None,
+) -> int:
+    """Execute one OpenCode batch and return a stable CLI-style status code."""
+    if opencode_batch_command_fn is None:
+        opencode_batch_command_fn = opencode_batch_command
+    cmd = opencode_batch_command_fn(
+        prompt=prompt,
+        repo_root=repo_root,
+    )
+    config = _resolve_retry_config(deps)
+    log_sections: list[str] = []
+    recoverable_output_text: str | None = None
+
+    for attempt in range(1, config.max_attempts + 1):
+        try:
+            if output_file.exists():
+                output_file.unlink()
+        except OSError:
+            pass
+
+        stdout_text_observer = _build_live_opencode_stdout_observer(
+            output_file=output_file,
+            deps=deps,
+        )
+
+        header, result = _run_batch_attempt(
+            cmd=cmd,
+            deps=deps,
+            output_file=output_file,
+            log_file=log_file,
+            log_sections=log_sections,
+            attempt=attempt,
+            max_attempts=config.max_attempts,
+            use_popen=config.use_popen,
+            live_log_interval=config.live_log_interval,
+            stall_seconds=config.stall_seconds,
+            stdout_text_observer=stdout_text_observer,
+        )
+        early_return = _handle_early_attempt_return(result)
+        if early_return is not None:
+            return early_return
+
+        current_payload_text = _capture_opencode_stdout_payload(
+            result=result,
+            output_file=output_file,
+            deps=deps,
+        )
+        if current_payload_text is not None:
+            recoverable_output_text = current_payload_text
+
+        timeout_or_stall = _handle_timeout_or_stall(
+            header=header,
+            result=result,
+            deps=deps,
+            output_file=output_file,
+            log_file=log_file,
+            log_sections=log_sections,
+            stall_seconds=config.stall_seconds,
+        )
+        if timeout_or_stall is not None:
+            if timeout_or_stall == 0:
+                return 0
+            if attempt < config.max_attempts:
+                delay = config.retry_backoff_seconds * (2 ** (attempt - 1))
+                log_sections.append(
+                    f"Timeout/stall on attempt {attempt}/{config.max_attempts}; "
+                    f"retrying in {delay:.1f}s."
+                )
+                if delay > 0:
+                    deps.sleep_fn(delay)
+                continue
+            _restore_opencode_recoverable_payload(
+                recoverable_text=recoverable_output_text,
+                output_file=output_file,
+                deps=deps,
+            )
+            return timeout_or_stall
+
+        log_sections.append(
+            f"{header}\n\nSTDOUT:\n{result.stdout_text}\n\nSTDERR:\n{result.stderr_text}\n"
+        )
+
+        success_code = _handle_successful_attempt(
+            result=result,
+            output_file=output_file,
+            log_file=log_file,
+            deps=deps,
+            log_sections=log_sections,
+        )
+        if success_code is not None:
+            return success_code
+
+        failure_code = _handle_failed_attempt(
+            result=result,
+            deps=deps,
+            attempt=attempt,
+            max_attempts=config.max_attempts,
+            retry_backoff_seconds=config.retry_backoff_seconds,
+            log_file=log_file,
+            log_sections=log_sections,
+        )
+        if failure_code is not None:
+            _restore_opencode_recoverable_payload(
+                recoverable_text=recoverable_output_text,
+                output_file=output_file,
+                deps=deps,
+            )
+            return failure_code
+
+    _restore_opencode_recoverable_payload(
+        recoverable_text=recoverable_output_text,
+        output_file=output_file,
+        deps=deps,
+    )
+    deps.safe_write_text_fn(log_file, "\n\n".join(log_sections))
+    return 1
+
+
+def run_followup_scan(
+    *,
+    lang_name: str,
+    scan_path: str,
+    deps: FollowupScanDeps,
+    force_queue_bypass: bool = False,
+) -> int:
+    """Run a follow-up scan and return a non-zero status when it fails."""
+    return _shared_run_followup_scan(
+        lang_name=lang_name,
+        scan_path=scan_path,
+        deps=deps,
+        force_queue_bypass=force_queue_bypass,
+    )
+
+
+__all__ = [
+    "CodexBatchRunnerDeps",
+    "BatchRunnerDeps",
+    "FollowupScanDeps",
+    "_extract_payload_from_log",
+    "codex_batch_command",
+    "opencode_batch_command",
+    "run_codex_batch",
+    "run_followup_scan",
+    "run_opencode_batch",
+]

--- a/desloppify/app/commands/review/runner_process_impl/attempt_success.py
+++ b/desloppify/app/commands/review/runner_process_impl/attempt_success.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Callable
 from pathlib import Path
 
-from .types import CodexBatchRunnerDeps, _ExecutionResult
+from .types import BatchRunnerDeps, _ExecutionResult
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ def handle_successful_attempt_core(
     result: _ExecutionResult,
     output_file: Path,
     log_file: Path,
-    deps: CodexBatchRunnerDeps,
+    deps: BatchRunnerDeps,
     log_sections: list[str],
     default_validate_fn: DefValidateFn,
     monotonic_fn: Callable[[], float],
@@ -116,7 +116,9 @@ def _recover_output_from_fallback_text(
 ) -> bool:
     if valid or deps.validate_output_fn is None:
         return valid
-    fallback_text = (result.stdout_text or "").strip() or (result.stderr_text or "").strip()
+    fallback_text = (result.stdout_text or "").strip() or (
+        result.stderr_text or ""
+    ).strip()
     if not fallback_text:
         return False
     try:
@@ -130,9 +132,7 @@ def _recover_output_from_fallback_text(
         return False
     if not validate(output_file):
         return False
-    log_sections.append(
-        "Runner output recovered from stdout/stderr fallback text."
-    )
+    log_sections.append("Runner output recovered from stdout/stderr fallback text.")
     return True
 
 

--- a/desloppify/app/commands/review/runner_process_impl/attempts.py
+++ b/desloppify/app/commands/review/runner_process_impl/attempts.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import subprocess  # nosec
 import threading
 import time
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, cast
 
 from desloppify.app.commands.review.runner_failures import (
     TRANSIENT_RUNNER_PHRASES as _TRANSIENT_RUNNER_PHRASES,
@@ -71,6 +73,7 @@ def _run_via_popen(
     ctx: _AttemptContext,
     interval: float,
     stall_seconds: int,
+    stdout_text_observer: Callable[[str], None] | None = None,
 ) -> _ExecutionResult:
     with _managed_live_writer(state, ctx, interval):
         process_or_error = _start_runner_process(cmd, deps, ctx)
@@ -190,8 +193,7 @@ def _check_runner_stall(
         return False, False, output_signature, output_stable_since
     with state.lock:
         state.runner_note = (
-            f"stall recovery triggered after {stall_seconds}s "
-            "with stable output state"
+            f"stall recovery triggered after {stall_seconds}s with stable output state"
         )
     recovered_from_stall = _output_file_has_json_payload(ctx.output_file)
     _terminate_process(process)
@@ -256,15 +258,21 @@ def _run_via_subprocess(
     interval: float,
 ) -> _ExecutionResult:
     with _managed_live_writer(state, ctx, interval):
+        run_fn = deps.subprocess_run
         try:
-            result = deps.subprocess_run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=deps.timeout_seconds,
+            result = cast(
+                Any,
+                run_fn(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=deps.timeout_seconds,
+                ),
             )
         except deps.timeout_error:
-            return _ExecutionResult(code=124, stdout_text="", stderr_text="", timed_out=True)
+            return _ExecutionResult(
+                code=124, stdout_text="", stderr_text="", timed_out=True
+            )
         except OSError as exc:
             return _runner_error_result(
                 ctx=ctx,
@@ -272,7 +280,11 @@ def _run_via_subprocess(
                 exc=exc,
                 exit_code=127,
             )
-        except (RuntimeError, ValueError, TypeError) as exc:  # pragma: no cover - defensive boundary
+        except (
+            RuntimeError,
+            ValueError,
+            TypeError,
+        ) as exc:  # pragma: no cover - defensive boundary
             return _runner_error_result(
                 ctx=ctx,
                 heading="UNEXPECTED RUNNER ERROR",
@@ -333,6 +345,7 @@ def run_batch_attempt(
     use_popen: bool,
     live_log_interval: float,
     stall_seconds: int,
+    stdout_text_observer: Callable[[str], None] | None = None,
 ) -> tuple[str, _ExecutionResult]:
     header = f"ATTEMPT {attempt}/{max_attempts}\n$ {' '.join(cmd)}"
     started_monotonic = time.monotonic()
@@ -355,6 +368,7 @@ def run_batch_attempt(
             ctx,
             live_log_interval,
             stall_seconds,
+            stdout_text_observer,
         )
     else:
         result = _run_via_subprocess(cmd, deps, state, ctx, live_log_interval)
@@ -390,11 +404,9 @@ def handle_timeout_or_stall(
         )
     if _output_file_has_json_payload(output_file):
         recovery_message = (
-            "Recovered timed-out batch from JSON output file; "
-            "continuing as success."
+            "Recovered timed-out batch from JSON output file; continuing as success."
             if result.timed_out
-            else "Recovered stalled batch from JSON output file; "
-            "continuing as success."
+            else "Recovered stalled batch from JSON output file; continuing as success."
         )
         log_sections.append(recovery_message)
         deps.safe_write_text_fn(log_file, "\n\n".join(log_sections))

--- a/desloppify/app/commands/review/runner_process_impl/io.py
+++ b/desloppify/app/commands/review/runner_process_impl/io.py
@@ -7,6 +7,7 @@ import logging
 import subprocess  # nosec
 import threading
 import time
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -104,7 +105,12 @@ def _terminate_process(process: subprocess.Popen[str]) -> None:
         return
 
 
-def _drain_stream(stream, sink: list[str], state: _RunnerState) -> None:
+def _drain_stream(
+    stream,
+    sink: list[str],
+    state: _RunnerState,
+    stdout_text_observer: Callable[[str], None] | None = None,
+) -> None:
     """Read lines from *stream* into *sink*, updating activity timestamp."""
     if stream is None:
         return
@@ -112,9 +118,17 @@ def _drain_stream(stream, sink: list[str], state: _RunnerState) -> None:
         for chunk in iter(stream.readline, ""):
             if not chunk:
                 break
+            current_stdout = None
             with state.lock:
                 sink.append(chunk)
                 state.last_stream_activity = time.monotonic()
+                if stdout_text_observer is not None:
+                    current_stdout = "".join(sink)
+            if stdout_text_observer is not None and current_stdout is not None:
+                try:
+                    stdout_text_observer(current_stdout)
+                except (OSError, RuntimeError, TypeError, ValueError):
+                    continue
     except (OSError, ValueError) as exc:  # pragma: no cover - defensive boundary
         with state.lock:
             sink.append(f"\n[stream read error: {exc}]\n")
@@ -209,10 +223,88 @@ def _check_stall(
     return False, prev_sig, prev_stable
 
 
+def _extract_text_from_opencode_json_stream(raw: str) -> str:
+    """Extract assistant text from OpenCode ``--format json`` NDJSON output.
+
+    OpenCode emits newline-delimited JSON events.  Text content lives in
+    events where ``event["type"] == "text"`` under ``event["part"]["text"]``.
+    Only completed assistant steps should be returned.  Earlier planning,
+    pre-tool text, or any other in-progress step content must not be mixed into
+    the final payload, because downstream JSON extraction accepts the first
+    matching review object.
+    """
+    saw_step_events = False
+    saw_tool_calls_step = False
+    step_in_progress = False
+    fallback_text_parts: list[str] = []
+    current_step_parts: list[str] = []
+    last_completed_step_text = ""
+    final_step_text = ""
+
+    for line in raw.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(event, dict):
+            continue
+        event_type = str(event.get("type", "")).strip()
+        part = event.get("part")
+        part_dict = part if isinstance(part, dict) else {}
+
+        if event_type == "step_start":
+            saw_step_events = True
+            step_in_progress = True
+            current_step_parts = []
+            continue
+
+        if event_type == "text":
+            text_value = str(part_dict.get("text", ""))
+            fallback_text_parts.append(text_value)
+            current_step_parts.append(text_value)
+            continue
+
+        if event_type != "step_finish":
+            continue
+
+        saw_step_events = True
+        step_in_progress = False
+        current_step_text = "".join(current_step_parts)
+        reason = str(part_dict.get("reason", "")).strip()
+
+        if reason == "tool-calls":
+            saw_tool_calls_step = True
+            current_step_parts = []
+            continue
+
+        last_completed_step_text = current_step_text
+        current_step_parts = []
+        if reason == "stop":
+            final_step_text = current_step_text
+
+    if final_step_text:
+        return final_step_text
+    if saw_tool_calls_step or step_in_progress:
+        return ""
+    if saw_step_events:
+        if last_completed_step_text:
+            return last_completed_step_text
+        return ""
+    return "".join(fallback_text_parts)
+
+
+_extract_payload_from_log = extract_payload_from_log
+
+
 __all__ = [
     "_check_stall",
     "_drain_stream",
     "extract_payload_from_log",
+    "_extract_payload_from_log",
+    "_extract_text_from_opencode_json_stream",
     "_output_file_has_json_payload",
     "_output_file_status_text",
     "_start_live_writer",

--- a/desloppify/app/commands/review/runner_process_impl/types.py
+++ b/desloppify/app/commands/review/runner_process_impl/types.py
@@ -12,16 +12,16 @@ from pathlib import Path
 @dataclass(frozen=True)
 class CodexBatchRunnerDeps:
     timeout_seconds: int
-    subprocess_run: object
+    subprocess_run: Callable[..., object]
     timeout_error: type[BaseException]
-    safe_write_text_fn: object
+    safe_write_text_fn: Callable[[Path, str], None]
     use_popen_runner: bool = False
-    subprocess_popen: object | None = None
+    subprocess_popen: Callable[..., object] | None = None
     live_log_interval_seconds: float = 5.0
     stall_after_output_seconds: int = 90
     max_retries: int = 0
     retry_backoff_seconds: float = 0.0
-    sleep_fn: object = time.sleep
+    sleep_fn: Callable[[float], None] = time.sleep
     validate_output_fn: Callable[[Path], bool] | None = None
     output_validation_grace_seconds: float = 2.0
     output_validation_poll_seconds: float = 0.1
@@ -32,9 +32,9 @@ class FollowupScanDeps:
     project_root: Path
     timeout_seconds: int
     python_executable: str
-    subprocess_run: object
+    subprocess_run: Callable[..., object]
     timeout_error: type[BaseException]
-    colorize_fn: object
+    colorize_fn: Callable[[str, str], str]
 
 
 @dataclass
@@ -59,7 +59,7 @@ class _AttemptContext:
     output_file: Path
     log_file: Path
     log_sections: list[str]
-    safe_write_text_fn: object
+    safe_write_text_fn: Callable[[Path, str], None]
 
 
 @dataclass
@@ -77,7 +77,7 @@ class _ExecutionResult:
 
 @dataclass(frozen=True)
 class _RetryConfig:
-    """Normalized retry/runtime policy for codex batch attempts."""
+    """Normalized retry/runtime policy for batch attempts."""
 
     max_attempts: int
     retry_backoff_seconds: float
@@ -86,8 +86,12 @@ class _RetryConfig:
     use_popen: bool
 
 
+BatchRunnerDeps = CodexBatchRunnerDeps
+
+
 __all__ = [
     "CodexBatchRunnerDeps",
+    "BatchRunnerDeps",
     "FollowupScanDeps",
     "_AttemptContext",
     "_ExecutionResult",

--- a/desloppify/app/commands/scan/reporting/subjective.py
+++ b/desloppify/app/commands/scan/reporting/subjective.py
@@ -99,7 +99,8 @@ def subjective_rerun_command(
         command_parts = ["desloppify", "review", "--prepare"]
         if dim_keys:
             command_parts.extend(["--dimensions", dim_keys])
-        return f"`{' '.join(command_parts)}`"
+        cmd = f"`{' '.join(command_parts)}`"
+        return f"{cmd} (set up `--runner codex` or `--runner opencode` for automated reviews)"
 
     command_parts = [
         "desloppify",
@@ -118,9 +119,7 @@ def subjective_rerun_command(
 
 
 def _subjective_display_name_from_key(dimension_key: str) -> str:
-    return DISPLAY_NAMES.get(
-        dimension_key, dimension_key.replace("_", " ").title()
-    )
+    return DISPLAY_NAMES.get(dimension_key, dimension_key.replace("_", " ").title())
 
 
 def subjective_entries_for_dimension_keys(

--- a/desloppify/data/global/OPENCODE.md
+++ b/desloppify/data/global/OPENCODE.md
@@ -2,5 +2,34 @@
 
 When installed (via `desloppify update-skill opencode`), OpenCode automatically loads this skill for code quality, technical debt, and health score questions.
 
+### Review workflow
+
+Use the native `--runner opencode` for automated batch reviews:
+
+```
+desloppify review --run-batches --runner opencode --parallel --scan-after-import
+```
+
+This spawns OpenCode subprocesses (`opencode run --format json`) for each batch, extracts results from the NDJSON stream, merges them, and imports as trusted assessments — identical pipeline to the Codex runner but using OpenCode as the execution engine.
+
+#### Warm server mode (optional, recommended for parallel runs)
+
+Start a persistent OpenCode server to avoid MCP cold-start overhead per batch:
+
+```
+opencode serve --port 4096 &
+export DESLOPPIFY_OPENCODE_ATTACH=http://localhost:4096
+desloppify review --run-batches --runner opencode --parallel --scan-after-import
+```
+
+When `DESLOPPIFY_OPENCODE_ATTACH` is set, each batch subprocess attaches to the running server via `--attach <url>` instead of spawning a fresh instance.
+
+#### Preparing a review manually
+
+1. **Prepare**: `desloppify review --prepare` — writes `query.json` and `.desloppify/review_packet_blind.json`.
+2. **Run batches**: `desloppify review --run-batches --runner opencode --parallel --scan-after-import`
+
+The runner handles batch splitting, prompt generation, parallel execution, retry/stall detection, result extraction, merge, and trusted import automatically.
+
 <!-- desloppify-overlay: opencode -->
 <!-- desloppify-end -->

--- a/desloppify/intelligence/review/_prepare/helpers.py
+++ b/desloppify/intelligence/review/_prepare/helpers.py
@@ -10,9 +10,8 @@ HOLISTIC_WORKFLOW = [
     "Cross-reference issues with the sibling_behavior and convention data",
     "IMPORTANT: issues must be defects only — never positive observations. High scores capture quality; issues capture problems.",
     "Write ALL issues to issues.json — do NOT fix code before importing. Import creates tracked state entries that let desloppify correlate fixes to issues.",
-    "Codex: desloppify review --run-batches --runner codex --parallel --scan-after-import",
-    "Claude / other agent: desloppify review --run-batches --dry-run → launch one subagent per prompt file (all in parallel) → desloppify review --import-run <run-dir> --scan-after-import",
-    "Cloud/external: run `desloppify review --external-start --external-runner claude`, follow the session template, then run the printed `--external-submit` command",
+    "Preferred local path: desloppify review --run-batches --runner codex --parallel --scan-after-import (or switch --runner to opencode)",
+    "Claude cloud durable path: run `desloppify review --external-start --external-runner claude`, follow the session template/instructions, then run the printed `--external-submit` command",
     "Fallback path: `desloppify review --import issues.json` (issues only). Use manual override only for emergency/provisional imports.",
     "AFTER importing: run `desloppify show review --status open` to see the work queue, then fix each issue in code and `desloppify plan resolve <id>`",
 ]
@@ -30,6 +29,7 @@ def append_full_sweep_batch(
     del all_files, lang, max_files
     if not dims:
         return
+
     batches.append(
         {
             "name": "Full Codebase Sweep",

--- a/desloppify/tests/commands/review/test_review_process_guards_direct.py
+++ b/desloppify/tests/commands/review/test_review_process_guards_direct.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
+from desloppify.app.commands.review.batch.scope import require_batches
 from desloppify.app.commands.review.importing.helpers import (
     ImportLoadConfig,
     ImportPayloadLoadError,
@@ -16,6 +19,9 @@ from desloppify.app.commands.review.importing.helpers import (
     print_assessment_mode_banner,
     print_import_load_errors,
 )
+from desloppify.app.commands.review.prepare import do_prepare
+from desloppify.app.commands.review.runner_packets import write_packet_snapshot
+from desloppify.base.exception_sets import CommandError
 
 
 def _colorize(text: str, _style: str) -> str:
@@ -143,7 +149,9 @@ def test_import_config_allows_clean_config_only_path(tmp_path):
 
     parsed = load_import_issues_data(
         str(issues_path),
-        config=ImportLoadConfig(manual_override=True, manual_attest="manual override ok"),
+        config=ImportLoadConfig(
+            manual_override=True, manual_attest="manual override ok"
+        ),
     )
     assert parsed["assessments"]["naming_quality"] == 95
 
@@ -197,7 +205,9 @@ def test_import_attested_external_rejects_untrusted_provenance(tmp_path, capsys)
 
 def test_import_attested_external_accepts_claude_blind_provenance(tmp_path):
     blind_packet = tmp_path / "review_packet_blind.json"
-    blind_packet.write_text(json.dumps({"command": "review", "dimensions": ["naming_quality"]}))
+    blind_packet.write_text(
+        json.dumps({"command": "review", "dimensions": ["naming_quality"]})
+    )
     packet_hash = hashlib.sha256(blind_packet.read_bytes()).hexdigest()
 
     payload = {
@@ -232,7 +242,9 @@ def test_import_attested_external_accepts_claude_blind_provenance(tmp_path):
 
 def test_import_attested_external_rejects_non_claude_runner(tmp_path, capsys):
     blind_packet = tmp_path / "review_packet_blind.json"
-    blind_packet.write_text(json.dumps({"command": "review", "dimensions": ["naming_quality"]}))
+    blind_packet.write_text(
+        json.dumps({"command": "review", "dimensions": ["naming_quality"]})
+    )
     packet_hash = hashlib.sha256(blind_packet.read_bytes()).hexdigest()
 
     payload = {
@@ -291,7 +303,9 @@ def test_import_attested_external_rejects_allow_partial_combo(tmp_path, capsys):
 
 def test_import_external_trusted_provenance_still_defaults_to_issues_only(tmp_path):
     blind_packet = tmp_path / "review_packet_blind.json"
-    blind_packet.write_text(json.dumps({"command": "review", "dimensions": ["naming_quality"]}))
+    blind_packet.write_text(
+        json.dumps({"command": "review", "dimensions": ["naming_quality"]})
+    )
     packet_hash = hashlib.sha256(blind_packet.read_bytes()).hexdigest()
 
     payload = {
@@ -301,7 +315,9 @@ def test_import_external_trusted_provenance_still_defaults_to_issues_only(tmp_pa
                 "identifier": "process_data",
                 "summary": "Function name is generic for a payment-reconciliation path.",
                 "related_files": ["src/service.ts"],
-                "evidence": ["Name does not describe side effects or domain operation."],
+                "evidence": [
+                    "Name does not describe side effects or domain operation."
+                ],
                 "suggestion": "Rename to reconcile_customer_payment.",
                 "confidence": "high",
             }
@@ -595,3 +611,126 @@ def test_import_trusted_internal_accepts_low_score_with_issue(tmp_path):
     )
     assert parsed["assessments"]["naming_quality"] == 80
 
+
+def test_write_packet_snapshot_redacts_target_from_blind_packet(tmp_path):
+    packet = {
+        "command": "review",
+        "config": {"target_strict_score": 98, "noise_budget": 10},
+        "narrative": {"headline": "target score pressure"},
+        "next_command": "desloppify scan",
+        "dimensions": ["high_level_elegance"],
+    }
+    review_packet_dir = tmp_path / "review_packets"
+    blind_path = tmp_path / "review_packet_blind.json"
+
+    def _safe_write(path: Path, text: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+
+    packet_path, _ = write_packet_snapshot(
+        packet,
+        stamp="20260218_160000",
+        review_packet_dir=review_packet_dir,
+        blind_path=blind_path,
+        safe_write_text_fn=_safe_write,
+    )
+
+    immutable_payload = json.loads(packet_path.read_text())
+    blind_payload = json.loads(blind_path.read_text())
+
+    assert immutable_payload["config"]["target_strict_score"] == 98
+    assert "target_strict_score" not in blind_payload["config"]
+    assert blind_payload["config"]["noise_budget"] == 10
+    assert "narrative" not in blind_payload
+    assert "next_command" not in blind_payload
+
+
+_P_SETUP = "desloppify.app.commands.review.prepare.setup_lang_concrete"
+_P_NARRATIVE = "desloppify.app.commands.review.prepare.narrative_mod.compute_narrative"
+_P_REVIEW_PREP = (
+    "desloppify.app.commands.review.prepare.review_mod.prepare_holistic_review"
+)
+_P_REVIEW_OPTS = (
+    "desloppify.app.commands.review.prepare.review_mod.HolisticReviewPrepareOptions"
+)
+_P_NARRATIVE_CTX = (
+    "desloppify.app.commands.review.prepare.narrative_mod.NarrativeContext"
+)
+_P_WRITE_QUERY = "desloppify.app.commands.review.prepare.write_query"
+
+
+def _do_prepare_patched(
+    *, total_files: int = 3, state: dict | None = None, config: dict | None = None
+):
+    """Call do_prepare with mocked dependencies; return captured write_query payload."""
+    args = SimpleNamespace(path=".", dimensions=None)
+    captured: dict = {}
+
+    def _fake_write_query(payload):
+        captured.update(payload)
+
+    with (
+        patch(_P_SETUP, return_value=(SimpleNamespace(name="python"), [])),
+        patch(_P_NARRATIVE, return_value={"headline": "x"}),
+        patch(
+            _P_REVIEW_PREP,
+            return_value={
+                "total_files": total_files,
+                "investigation_batches": [],
+                "workflow": [],
+            },
+        ),
+        patch(_P_REVIEW_OPTS, side_effect=lambda **kw: SimpleNamespace(**kw)),
+        patch(_P_NARRATIVE_CTX, side_effect=lambda **kw: SimpleNamespace(**kw)),
+        patch(_P_WRITE_QUERY, side_effect=_fake_write_query),
+    ):
+        do_prepare(
+            args,
+            state=state or {},
+            lang=SimpleNamespace(name="python"),
+            _state_path=None,
+            config=config or {},
+        )
+    return captured
+
+
+def test_review_prepare_zero_files_exits_with_error(capsys):
+    """Regression guard for issue #127: 0-file result must error, not silently succeed."""
+    with pytest.raises(CommandError) as exc:
+        _do_prepare_patched(total_files=0)
+    assert exc.value.exit_code == 1
+    assert "no files found" in exc.value.message.lower()
+
+
+def test_review_prepare_zero_files_hints_scan_path(capsys):
+    """When state has a scan_path, the error hint mentions it."""
+    with pytest.raises(CommandError) as exc:
+        _do_prepare_patched(total_files=0, state={"scan_path": "."})
+    assert "--path" in exc.value.message
+
+
+def test_review_prepare_query_redacts_target_score():
+    captured = _do_prepare_patched(
+        total_files=3,
+        config={"target_strict_score": 98, "noise_budget": 10},
+    )
+
+    assert "config" in captured
+    config = captured["config"]
+    assert isinstance(config, dict)
+    assert "target_strict_score" not in config
+    assert config.get("noise_budget") == 10
+
+
+def test_require_batches_guides_rebuild_when_packet_has_no_batches(capsys):
+    with pytest.raises(CommandError) as exc:
+        require_batches(
+            {"investigation_batches": []},
+            colorize_fn=_colorize,
+            suggested_prepare_cmd="desloppify review --prepare --path src",
+        )
+    assert exc.value.exit_code == 1
+    err = capsys.readouterr().err
+    assert "no investigation_batches" in exc.value.message
+    assert "Regenerate review context first" in err
+    assert "review --run-batches --runner codex --parallel --scan-after-import" in err

--- a/desloppify/tests/commands/review/test_review_runner_batch_split_direct.py
+++ b/desloppify/tests/commands/review/test_review_runner_batch_split_direct.py
@@ -14,7 +14,7 @@ import desloppify.app.commands.review.batch.core_normalize as core_normalize_mod
 import desloppify.app.commands.review.batch.core_parse as core_parse_mod
 import desloppify.app.commands.review.external as external_mod
 from desloppify.app.commands.review.runner_process_impl.types import (
-    CodexBatchRunnerDeps,
+    BatchRunnerDeps as CodexBatchRunnerDeps,
     _ExecutionResult,
 )
 
@@ -49,9 +49,12 @@ def test_handle_successful_attempt_core_recovers_from_stdout_fallback(tmp_path) 
         timeout_seconds=30,
         subprocess_run=object(),
         timeout_error=TimeoutError,
-        safe_write_text_fn=lambda path, text: Path(path).write_text(text, encoding="utf-8"),
+        safe_write_text_fn=lambda path, text: Path(path).write_text(
+            text, encoding="utf-8"
+        ),
         sleep_fn=lambda _seconds: None,
-        validate_output_fn=lambda path: path.exists() and path.read_text(encoding="utf-8").strip() == "ok payload",
+        validate_output_fn=lambda path: path.exists()
+        and path.read_text(encoding="utf-8").strip() == "ok payload",
         output_validation_grace_seconds=0.0,
     )
     result = _ExecutionResult(code=0, stdout_text="ok payload", stderr_text="")
@@ -98,22 +101,27 @@ def test_core_parse_helpers_handle_selection_and_payload_extraction() -> None:
 
     logs: list[str] = []
     payload = core_parse_mod.extract_json_payload(
-        "prefix {\"assessments\": {}, \"issues\": []} suffix",
+        'prefix {"assessments": {}, "issues": []} suffix',
         log_fn=logs.append,
     )
     assert payload == {"assessments": {}, "issues": []}
-    assert core_parse_mod.extract_json_payload("no json here", log_fn=logs.append) is None
+    assert (
+        core_parse_mod.extract_json_payload("no json here", log_fn=logs.append) is None
+    )
     assert logs
 
 
 def test_core_merge_support_issue_merge_and_scoring_helpers() -> None:
     issues = [{"dimension": "naming_quality"}, {"dimension": "naming_quality"}]
     notes = {"naming_quality": {"evidence": ["a", "b"]}}
-    assert merge_support_mod.assessment_weight(
-        dimension="naming_quality",
-        issues=issues,
-        dimension_notes=notes,
-    ) == 5.0
+    assert (
+        merge_support_mod.assessment_weight(
+            dimension="naming_quality",
+            issues=issues,
+            dimension_notes=notes,
+        )
+        == 5.0
+    )
 
     existing = {
         "dimension": "naming_quality",
@@ -151,7 +159,9 @@ def test_core_merge_support_issue_merge_and_scoring_helpers() -> None:
 
 
 def test_core_normalize_helpers_and_batch_normalization() -> None:
-    assert core_normalize_mod._low_score_dimensions({"naming_quality": 59.9, "design_coherence": 80.0}) == {"naming_quality", "design_coherence"}
+    assert core_normalize_mod._low_score_dimensions(
+        {"naming_quality": 59.9, "design_coherence": 80.0}
+    ) == {"naming_quality", "design_coherence"}
 
     judgment = core_normalize_mod._validate_dimension_judgment(
         "naming_quality",
@@ -232,12 +242,14 @@ def test_core_normalize_helpers_and_batch_normalization() -> None:
             }
         },
     }
-    assessments, issues_payload, notes_payload, judgments, norm_quality, _ctx = core_normalize_mod.normalize_batch_result(
-        payload,
-        {"naming_quality"},
-        max_batch_issues=5,
-        abstraction_sub_axes=("cohesion",),
-        log_fn=lambda _msg: None,
+    assessments, issues_payload, notes_payload, judgments, norm_quality, _ctx = (
+        core_normalize_mod.normalize_batch_result(
+            payload,
+            {"naming_quality"},
+            max_batch_issues=5,
+            abstraction_sub_axes=("cohesion",),
+            log_fn=lambda _msg: None,
+        )
     )
     assert assessments == {"naming_quality": 80.0}
     assert len(issues_payload) == 1

--- a/desloppify/tests/review/review_commands_cases.py
+++ b/desloppify/tests/review/review_commands_cases.py
@@ -21,13 +21,17 @@ from desloppify import state as state_mod
 from desloppify.app.commands.review.batch.orchestrator import (
     do_run_batches,
 )
+from desloppify.app.commands.review.batch.core_parse import extract_json_payload
 from desloppify.app.commands.review.importing.cmd import do_import as _do_import
 from desloppify.app.commands.review.importing.cmd import (
     do_validate_import as _do_validate_import,
 )
 from desloppify.app.commands.review.importing.flags import ReviewImportConfig
 from desloppify.app.commands.review.prepare import do_prepare as _do_prepare
-from desloppify.app.commands.review.runtime.setup import setup_lang_concrete as _setup_lang
+from desloppify.app.commands.review.runtime.setup import (
+    setup_lang_concrete as _setup_lang,
+)
+from desloppify.app.commands.review.runner_process_impl.types import _ExecutionResult
 from desloppify.base.exception_sets import CommandError
 from desloppify.engine.policy.zones import Zone, ZoneRule
 from desloppify.intelligence.review import (
@@ -44,7 +48,7 @@ from desloppify.tests.review.shared_review_fixtures import (
 runner_helpers_mod = SimpleNamespace(
     BatchExecutionOptions=runner_parallel_mod.BatchExecutionOptions,
     BatchResult=runner_parallel_mod.BatchResult,
-    CodexBatchRunnerDeps=runner_process_mod.CodexBatchRunnerDeps,
+    CodexBatchRunnerDeps=runner_process_mod.BatchRunnerDeps,
     FollowupScanDeps=runner_process_mod.FollowupScanDeps,
     build_batch_import_provenance=runner_packets_mod.build_batch_import_provenance,
     build_blind_packet=runner_packets_mod.build_blind_packet,
@@ -56,11 +60,16 @@ runner_helpers_mod = SimpleNamespace(
     print_failures_and_raise=runner_failures_mod.print_failures_and_raise,
     run_codex_batch=runner_process_mod.run_codex_batch,
     run_followup_scan=runner_process_mod.run_followup_scan,
+    run_opencode_batch=runner_process_mod.run_opencode_batch,
     run_stamp=runner_packets_mod.run_stamp,
     selected_batch_indexes=runner_packets_mod.selected_batch_indexes,
     sha256_file=runner_packets_mod.sha256_file,
     write_packet_snapshot=runner_packets_mod.write_packet_snapshot,
 )
+
+
+def _safe_write_text(path: Path, text: str) -> None:
+    path.write_text(text)
 
 
 class TestBatchDimensionCoverageNotices:
@@ -80,7 +89,9 @@ class TestBatchDimensionCoverageNotices:
         out = capsys.readouterr().out
         assert "targets 2/3 scored subjective dimensions" in out
         assert "Missing from this run: low_level_elegance" in out
+        assert "--runner codex" in out
         assert "--dimensions low_level_elegance" in out
+        assert "<codex|opencode>" not in out
 
     def test_import_notice_warns_and_returns_missing_dimensions(self, capsys):
         missing = review_scope_mod.print_import_dimension_coverage_notice(
@@ -98,7 +109,9 @@ class TestBatchDimensionCoverageNotices:
         assert missing == ["type_safety"]
         assert "imported assessments for 2/3 scored subjective dimensions" in out
         assert "Still missing: type_safety" in out
+        assert "--runner codex" in out
         assert "--path src --dimensions type_safety" in out
+        assert "<codex|opencode>" not in out
 
 
 class TestCmdReviewPrepare:
@@ -169,13 +182,17 @@ class TestCmdReviewPrepare:
         lang = MagicMock()
         lang.name = "typescript"
 
-        with patch("desloppify.app.commands.review.importing.cmd.save_state", mock_save):
+        with patch(
+            "desloppify.app.commands.review.importing.cmd.save_state", mock_save
+        ):
             _do_import(str(issues_file), empty_state, lang, "fake_sp")
 
         assert saved["sp"] == "fake_sp"
         assert len(empty_state["work_items"]) == 1
 
-    def test_do_prepare_prints_narrative_reminders(self, mock_lang_with_zones, empty_state, tmp_path, capsys):
+    def test_do_prepare_prints_narrative_reminders(
+        self, mock_lang_with_zones, empty_state, tmp_path, capsys
+    ):
         from unittest.mock import MagicMock, patch
 
         from desloppify.app.commands.review.prepare import do_prepare as _do_prepare
@@ -197,14 +214,25 @@ class TestCmdReviewPrepare:
 
         def _fake_narrative(_state, **kwargs):
             captured_kwargs.update(kwargs)
-            return {"reminders": [{"type": "review_stale", "message": "Design review is stale."}]}
+            return {
+                "reminders": [
+                    {"type": "review_stale", "message": "Design review is stale."}
+                ]
+            }
 
-        with patch(
-            "desloppify.app.commands.review.prepare.setup_lang_concrete",
-            return_value=(mock_lang_with_zones, file_list),
-        ), \
-             patch("desloppify.app.commands.review.prepare.write_query", lambda _data: None), \
-             patch("desloppify.intelligence.narrative.core.compute_narrative", _fake_narrative):
+        with (
+            patch(
+                "desloppify.app.commands.review.prepare.setup_lang_concrete",
+                return_value=(mock_lang_with_zones, file_list),
+            ),
+            patch(
+                "desloppify.app.commands.review.prepare.write_query", lambda _data: None
+            ),
+            patch(
+                "desloppify.intelligence.narrative.core.compute_narrative",
+                _fake_narrative,
+            ),
+        ):
             _do_prepare(
                 args,
                 empty_state,
@@ -256,7 +284,9 @@ class TestCmdReviewPrepare:
                 "desloppify.app.commands.review.packet.build.prepare_holistic_review",
                 side_effect=_fake_prepare_holistic_review,
             ),
-            patch("desloppify.app.commands.review.prepare.write_query", lambda _data: None),
+            patch(
+                "desloppify.app.commands.review.prepare.write_query", lambda _data: None
+            ),
         ):
             _do_prepare(
                 args,
@@ -268,14 +298,24 @@ class TestCmdReviewPrepare:
 
         assert captured_limit["max_files_per_batch"] == 17
 
-    def test_do_import_untrusted_assessment_only_payload_imports_issues_only(self, empty_state, tmp_path):
+    def test_do_import_untrusted_assessment_only_payload_imports_issues_only(
+        self, empty_state, tmp_path
+    ):
         from unittest.mock import MagicMock
 
         from desloppify.app.commands.review.importing.cmd import do_import as _do_import
 
         empty_state["subjective_assessments"] = {
-            "naming_quality": {"score": 90, "source": "per_file", "assessed_at": "2026-02-01T00:00:00Z"},
-            "logic_clarity": {"score": 90, "source": "per_file", "assessed_at": "2026-02-01T00:00:00Z"},
+            "naming_quality": {
+                "score": 90,
+                "source": "per_file",
+                "assessed_at": "2026-02-01T00:00:00Z",
+            },
+            "logic_clarity": {
+                "score": 90,
+                "source": "per_file",
+                "assessed_at": "2026-02-01T00:00:00Z",
+            },
         }
         payload = {
             "assessments": {"naming_quality": 40, "logic_clarity": 40},
@@ -298,8 +338,16 @@ class TestCmdReviewPrepare:
         from desloppify.app.commands.review.importing.cmd import do_import as _do_import
 
         empty_state["subjective_assessments"] = {
-            "naming_quality": {"score": 90, "source": "per_file", "assessed_at": "2026-02-01T00:00:00Z"},
-            "logic_clarity": {"score": 90, "source": "per_file", "assessed_at": "2026-02-01T00:00:00Z"},
+            "naming_quality": {
+                "score": 90,
+                "source": "per_file",
+                "assessed_at": "2026-02-01T00:00:00Z",
+            },
+            "logic_clarity": {
+                "score": 90,
+                "source": "per_file",
+                "assessed_at": "2026-02-01T00:00:00Z",
+            },
         }
         payload = {
             "assessments": {"naming_quality": 40, "logic_clarity": 40},
@@ -317,7 +365,9 @@ class TestCmdReviewPrepare:
         lang = MagicMock()
         lang.name = "typescript"
 
-        with patch("desloppify.app.commands.review.importing.cmd.save_state", mock_save):
+        with patch(
+            "desloppify.app.commands.review.importing.cmd.save_state", mock_save
+        ):
             _do_import(
                 str(issues_file),
                 empty_state,
@@ -331,13 +381,22 @@ class TestCmdReviewPrepare:
 
         assert saved["sp"] == "fake_sp"
         assert empty_state["subjective_assessments"]["naming_quality"]["score"] == 40
-        assert empty_state["subjective_assessments"]["naming_quality"]["source"] == "manual_override"
         assert (
-            empty_state["subjective_assessments"]["naming_quality"]["provisional_override"]
+            empty_state["subjective_assessments"]["naming_quality"]["source"]
+            == "manual_override"
+        )
+        assert (
+            empty_state["subjective_assessments"]["naming_quality"][
+                "provisional_override"
+            ]
             is True
         )
         assert (
-            int(empty_state["subjective_assessments"]["naming_quality"]["provisional_until_scan"])
+            int(
+                empty_state["subjective_assessments"]["naming_quality"][
+                    "provisional_until_scan"
+                ]
+            )
             == int(empty_state.get("scan_count", 0)) + 1
         )
         audit = empty_state.get("assessment_import_audit", [])
@@ -379,7 +438,9 @@ class TestCmdReviewPrepare:
         self, empty_state, tmp_path
     ):
         blind_packet = tmp_path / "review_packet_blind.json"
-        blind_packet.write_text(json.dumps({"command": "review", "dimensions": ["naming_quality"]}))
+        blind_packet.write_text(
+            json.dumps({"command": "review", "dimensions": ["naming_quality"]})
+        )
         packet_hash = hashlib.sha256(blind_packet.read_bytes()).hexdigest()
 
         payload = {
@@ -404,15 +465,23 @@ class TestCmdReviewPrepare:
                 "pending_import_scores": {
                     "timestamp": "2026-03-10T10:00:00+00:00",
                     "import_file": str(tmp_path / "expected_scores.json"),
-                    "normalized_import_file": str((tmp_path / "expected_scores.json").resolve()),
+                    "normalized_import_file": str(
+                        (tmp_path / "expected_scores.json").resolve()
+                    ),
                     "packet_sha256": "expected-sha",
                 }
             },
         }
 
         with (
-            patch("desloppify.app.commands.review.importing.cmd.has_living_plan", lambda _path=None: True),
-            patch("desloppify.app.commands.review.importing.cmd.load_plan", lambda _path=None: pending_plan),
+            patch(
+                "desloppify.app.commands.review.importing.cmd.has_living_plan",
+                lambda _path=None: True,
+            ),
+            patch(
+                "desloppify.app.commands.review.importing.cmd.load_plan",
+                lambda _path=None: pending_plan,
+            ),
         ):
             with pytest.raises(CommandError) as exc:
                 _do_import(
@@ -432,7 +501,9 @@ class TestCmdReviewPrepare:
         assert "different review batch" in str(exc.value)
         assert "expected packet_sha256" in str(exc.value)
 
-    def test_trusted_internal_import_clears_provisional_flags(self, empty_state, tmp_path):
+    def test_trusted_internal_import_clears_provisional_flags(
+        self, empty_state, tmp_path
+    ):
         from unittest.mock import MagicMock
 
         from desloppify.app.commands.review.importing.cmd import do_import as _do_import
@@ -706,7 +777,9 @@ class TestCmdReviewPrepare:
         lang = MagicMock()
         lang.name = "typescript"
 
-        with patch("desloppify.app.commands.review.importing.cmd.save_state") as mock_save:
+        with patch(
+            "desloppify.app.commands.review.importing.cmd.save_state"
+        ) as mock_save:
             with pytest.raises(CommandError):
                 _do_import(str(issues_file), empty_state, lang, "sp")
         assert mock_save.called is False
@@ -736,7 +809,9 @@ class TestCmdReviewPrepare:
         lang = MagicMock()
         lang.name = "typescript"
 
-        with patch("desloppify.app.commands.review.importing.cmd.save_state") as mock_save:
+        with patch(
+            "desloppify.app.commands.review.importing.cmd.save_state"
+        ) as mock_save:
             _do_import(
                 str(issues_file),
                 empty_state,
@@ -1043,7 +1118,9 @@ class TestCmdReviewPrepare:
                             "identifier": "dup",
                             "summary": "shared",
                             "related_files": ["src/c.ts", "src/d.ts"],
-                            "evidence": ["seam handling differs between sibling modules"],
+                            "evidence": [
+                                "seam handling differs between sibling modules"
+                            ],
                             "suggestion": "standardize orchestration seams through shared adapter",
                             "confidence": "high",
                             "impact_scope": "module",
@@ -1075,7 +1152,9 @@ class TestCmdReviewPrepare:
                             "identifier": "new",
                             "summary": "unique",
                             "related_files": ["src/c.ts", "src/d.ts"],
-                            "evidence": ["local flow uses repetitive branching boilerplate"],
+                            "evidence": [
+                                "local flow uses repetitive branching boilerplate"
+                            ],
                             "suggestion": "extract one local helper to remove repeated branches",
                             "confidence": "medium",
                             "impact_scope": "local",
@@ -1090,7 +1169,9 @@ class TestCmdReviewPrepare:
 
         captured: dict[str, object] = {}
 
-        def fake_import(import_file, _state, _lang, _sp, holistic=True, config=None, **kwargs):
+        def fake_import(
+            import_file, _state, _lang, _sp, holistic=True, config=None, **kwargs
+        ):
             captured["holistic"] = holistic
             captured["config"] = config
             captured["kwargs"] = kwargs
@@ -1142,7 +1223,10 @@ class TestCmdReviewPrepare:
         import_config = captured["kwargs"]["import_config"]
         assert isinstance(import_config, ReviewImportConfig)
         assert import_config.trusted_assessment_source is True
-        assert import_config.trusted_assessment_label == "trusted internal run-batches import"
+        assert (
+            import_config.trusted_assessment_label
+            == "trusted internal run-batches import"
+        )
         assert import_config.allow_partial is True
         summary_files = sorted(runs_dir.glob("*/run_summary.json"))
         assert len(summary_files) == 1
@@ -1218,7 +1302,9 @@ class TestCmdReviewPrepare:
                         "identifier": "seam_style_drift",
                         "summary": "Seam style drifts across adjacent modules",
                         "related_files": ["src/a.ts"],
-                        "evidence": ["adjacent modules use incompatible seam conventions"],
+                        "evidence": [
+                            "adjacent modules use incompatible seam conventions"
+                        ],
                         "suggestion": "standardize one seam pattern for sibling modules",
                         "confidence": "medium",
                         "impact_scope": "module",
@@ -1231,7 +1317,9 @@ class TestCmdReviewPrepare:
 
         captured: dict[str, object] = {}
 
-        def fake_import(import_file, _state, _lang, _sp, holistic=True, config=None, **kwargs):
+        def fake_import(
+            import_file, _state, _lang, _sp, holistic=True, config=None, **kwargs
+        ):
             captured["holistic"] = holistic
             captured["config"] = config
             captured["kwargs"] = kwargs
@@ -1451,7 +1539,9 @@ class TestCmdReviewPrepare:
                     "identifier": "seam_split_between_siblings",
                     "summary": "Sibling hooks own overlapping orchestration seams",
                     "related_files": ["src/a.ts", "src/b.ts"],
-                    "evidence": ["sibling hooks both coordinate the same operation sequence"],
+                    "evidence": [
+                        "sibling hooks both coordinate the same operation sequence"
+                    ],
                     "suggestion": "extract one seam coordinator and reuse it across siblings",
                     "confidence": "high",
                     "impact_scope": "module",
@@ -1475,7 +1565,9 @@ class TestCmdReviewPrepare:
 
         captured: dict[str, object] = {}
 
-        def fake_import(import_file, _state, _lang, _sp, holistic=True, config=None, **kwargs):
+        def fake_import(
+            import_file, _state, _lang, _sp, holistic=True, config=None, **kwargs
+        ):
             captured["holistic"] = holistic
             captured["config"] = config
             captured["kwargs"] = kwargs
@@ -1521,8 +1613,13 @@ class TestCmdReviewPrepare:
         recovered_results = sorted(runs_dir.glob("*/results/batch-1.raw.txt"))
         assert len(recovered_results) == 1
         recovered_payload = json.loads(recovered_results[0].read_text())
-        assert recovered_payload["assessments"]["mid_level_elegance"] == pytest.approx(72.0)
-        assert recovered_payload["issues"][0]["identifier"] == "seam_split_between_siblings"
+        assert recovered_payload["assessments"]["mid_level_elegance"] == pytest.approx(
+            72.0
+        )
+        assert (
+            recovered_payload["issues"][0]["identifier"]
+            == "seam_split_between_siblings"
+        )
 
         summary_files = sorted(runs_dir.glob("*/run_summary.json"))
         assert len(summary_files) == 1
@@ -1607,7 +1704,9 @@ class TestCmdReviewPrepare:
                                     "identifier": "seam_style",
                                     "summary": "Seams drift slightly",
                                     "related_files": ["src/a.ts"],
-                                    "evidence": ["interface seam style differs across nearby modules"],
+                                    "evidence": [
+                                        "interface seam style differs across nearby modules"
+                                    ],
                                     "suggestion": "normalize seam style to one interface pattern",
                                     "confidence": "medium",
                                     "impact_scope": "module",
@@ -1622,7 +1721,9 @@ class TestCmdReviewPrepare:
 
         captured: dict[str, object] = {}
 
-        def fake_import(import_file, _state, _lang, _sp, holistic=True, config=None, **kwargs):
+        def fake_import(
+            import_file, _state, _lang, _sp, holistic=True, config=None, **kwargs
+        ):
             captured["holistic"] = holistic
             captured["config"] = config
             captured["kwargs"] = kwargs
@@ -1656,7 +1757,9 @@ class TestCmdReviewPrepare:
             do_run_batches(args, empty_state, lang, "fake_sp", config={})
 
         payload = captured["payload"]
-        assert payload["assessments"]["mid_level_elegance"] == pytest.approx(77.0, abs=0.1)
+        assert payload["assessments"]["mid_level_elegance"] == pytest.approx(
+            77.0, abs=0.1
+        )
         assert "reviewed_files" not in payload
         import_config = captured["kwargs"]["import_config"]
         assert isinstance(import_config, ReviewImportConfig)
@@ -1797,7 +1900,9 @@ class TestCmdReviewPrepare:
                 },
                 "dimension_judgment": {
                     "abstraction_fitness": {
-                        "strengths": ["interfaces are mostly honest about their contracts"],
+                        "strengths": [
+                            "interfaces are mostly honest about their contracts"
+                        ],
                         "dimension_character": "excessive wrapper indirection before reaching domain logic",
                         "score_rationale": "Three wrapper layers before domain calls add significant indirection cost that outweighs abstraction leverage.",
                     },
@@ -1808,7 +1913,9 @@ class TestCmdReviewPrepare:
                         "identifier": "wrapper_chain",
                         "summary": "Wrapper stack adds indirection cost",
                         "related_files": ["src/a.py", "src/b.py"],
-                        "evidence": ["3 wrapper layers before reaching domain behavior"],
+                        "evidence": [
+                            "3 wrapper layers before reaching domain behavior"
+                        ],
                         "suggestion": "collapse wrapper chain and expose one direct boundary",
                         "confidence": "high",
                         "impact_scope": "subsystem",
@@ -1821,7 +1928,9 @@ class TestCmdReviewPrepare:
 
         captured: dict[str, object] = {}
 
-        def fake_import(import_file, _state, _lang, _sp, holistic=True, config=None, **kwargs):
+        def fake_import(
+            import_file, _state, _lang, _sp, holistic=True, config=None, **kwargs
+        ):
             captured["holistic"] = holistic
             captured["config"] = config
             captured["kwargs"] = kwargs
@@ -1871,7 +1980,6 @@ class TestCmdReviewPrepare:
         assert import_config.trusted_assessment_source is True
 
     def test_run_codex_batch_returns_127_when_runner_missing(self, tmp_path):
-
         log_file = tmp_path / "batch.log"
         mock_run = MagicMock(side_effect=FileNotFoundError("codex not found"))
         code = runner_helpers_mod.run_codex_batch(
@@ -1883,14 +1991,13 @@ class TestCmdReviewPrepare:
                 timeout_seconds=60,
                 subprocess_run=mock_run,
                 timeout_error=TimeoutError,
-                safe_write_text_fn=lambda p, t: p.write_text(t),
+                safe_write_text_fn=_safe_write_text,
             ),
         )
         assert code == 127
         assert "RUNNER ERROR" in log_file.read_text()
 
     def test_run_codex_batch_retries_stream_disconnect(self, tmp_path):
-
         log_file = tmp_path / "batch.log"
         output_file = tmp_path / "out.txt"
         call_count = [0]
@@ -1918,7 +2025,7 @@ class TestCmdReviewPrepare:
                 timeout_seconds=60,
                 subprocess_run=mock_run_fn,
                 timeout_error=TimeoutError,
-                safe_write_text_fn=lambda p, t: p.write_text(t),
+                safe_write_text_fn=_safe_write_text,
                 max_retries=1,
                 retry_backoff_seconds=0.0,
                 sleep_fn=lambda _seconds: None,
@@ -1932,7 +2039,6 @@ class TestCmdReviewPrepare:
         assert "Transient runner failure detected" in raw_log
 
     def test_run_codex_batch_writes_live_status_before_completion(self, tmp_path):
-
         log_file = tmp_path / "batch.log"
         output_file = tmp_path / "out.txt"
         live_snapshot = {"text": ""}
@@ -1952,7 +2058,7 @@ class TestCmdReviewPrepare:
                 timeout_seconds=60,
                 subprocess_run=fake_run,
                 timeout_error=TimeoutError,
-                safe_write_text_fn=lambda p, t: p.write_text(t),
+                safe_write_text_fn=_safe_write_text,
             ),
         )
         assert code == 0
@@ -1961,7 +2067,6 @@ class TestCmdReviewPrepare:
         assert "STDOUT:" in log_file.read_text()
 
     def test_run_codex_batch_stall_recovery_from_output_file(self, tmp_path):
-
         log_file = tmp_path / "batch.log"
         output_file = tmp_path / "out.json"
 
@@ -1971,7 +2076,7 @@ class TestCmdReviewPrepare:
             (
                 "import pathlib,sys,time;"
                 "path=pathlib.Path(sys.argv[1]);"
-                "path.write_text('{\"assessments\":{\"logic_clarity\":91.0},\"issues\":[]}');"
+                'path.write_text(\'{"assessments":{"logic_clarity":91.0},"issues":[]}\');'
                 "print('written', flush=True);"
                 "time.sleep(5)"
             ),
@@ -1991,7 +2096,7 @@ class TestCmdReviewPrepare:
                     timeout_seconds=30,
                     subprocess_run=subprocess.run,
                     timeout_error=TimeoutError,
-                    safe_write_text_fn=lambda p, t: p.write_text(t),
+                    safe_write_text_fn=_safe_write_text,
                     use_popen_runner=True,
                     subprocess_popen=subprocess.Popen,
                     live_log_interval_seconds=0.2,
@@ -2033,7 +2138,7 @@ class TestCmdReviewPrepare:
                     timeout_seconds=30,
                     subprocess_run=subprocess.run,
                     timeout_error=TimeoutError,
-                    safe_write_text_fn=lambda p, t: p.write_text(t),
+                    safe_write_text_fn=_safe_write_text,
                     use_popen_runner=True,
                     subprocess_popen=subprocess.Popen,
                     live_log_interval_seconds=0.2,
@@ -2046,6 +2151,902 @@ class TestCmdReviewPrepare:
         assert code == 1  # process exited 0 but output file missing
         log_text = log_file.read_text()
         assert "STALL RECOVERY" not in log_text
+
+    def test_run_opencode_batch_retries_timeout(self, tmp_path):
+        log_file = tmp_path / "batch.log"
+        output_file = tmp_path / "out.json"
+        call_count = [0]
+
+        def _stream(payload: dict[str, object]) -> str:
+            return (
+                json.dumps(
+                    {
+                        "type": "text",
+                        "part": {"type": "text", "text": json.dumps(payload)},
+                    }
+                )
+                + "\n"
+            )
+
+        def mock_run_fn(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise TimeoutError()
+            return MagicMock(
+                returncode=0,
+                stdout=_stream({"assessments": {}, "issues": []}),
+                stderr="",
+            )
+
+        code = runner_helpers_mod.run_opencode_batch(
+            prompt="test prompt",
+            repo_root=tmp_path,
+            output_file=output_file,
+            log_file=log_file,
+            deps=runner_process_mod.BatchRunnerDeps(
+                timeout_seconds=60,
+                subprocess_run=mock_run_fn,
+                timeout_error=TimeoutError,
+                safe_write_text_fn=_safe_write_text,
+                max_retries=1,
+                retry_backoff_seconds=0.0,
+                sleep_fn=lambda _seconds: None,
+            ),
+        )
+
+        assert code == 0
+        assert call_count[0] == 2
+        assert json.loads(output_file.read_text()) == {"assessments": {}, "issues": []}
+        raw_log = log_file.read_text()
+        assert "ATTEMPT 1/2" in raw_log
+        assert "ATTEMPT 2/2" in raw_log
+        assert "Timeout/stall on attempt 1/2; retrying in 0.0s." in raw_log
+
+    def test_run_opencode_batch_recovers_timeout_from_stdout_payload(self, tmp_path):
+        log_file = tmp_path / "batch.log"
+        output_file = tmp_path / "out.json"
+        stale_payload = {"assessments": {"logic_clarity": 12}, "issues": []}
+        payload = {"assessments": {"logic_clarity": 88}, "issues": []}
+        stdout_text = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "step_start",
+                        "part": {"type": "step-start"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "text",
+                        "part": {
+                            "type": "text",
+                            "text": f"planning {json.dumps(stale_payload)}",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "step_finish",
+                        "part": {
+                            "type": "step-finish",
+                            "reason": "tool-calls",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "step_start",
+                        "part": {"type": "step-start"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "text",
+                        "part": {"type": "text", "text": json.dumps(payload)},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "step_finish",
+                        "part": {
+                            "type": "step-finish",
+                            "reason": "stop",
+                        },
+                    }
+                ),
+                "",
+            ]
+        )
+
+        with patch(
+            "desloppify.app.commands.review.runner_process._run_batch_attempt",
+            return_value=(
+                "ATTEMPT 1/1",
+                _ExecutionResult(
+                    code=1,
+                    stdout_text=stdout_text,
+                    stderr_text="",
+                    timed_out=True,
+                ),
+            ),
+        ):
+            code = runner_helpers_mod.run_opencode_batch(
+                prompt="test prompt",
+                repo_root=tmp_path,
+                output_file=output_file,
+                log_file=log_file,
+                deps=runner_process_mod.BatchRunnerDeps(
+                    timeout_seconds=60,
+                    subprocess_run=subprocess.run,
+                    timeout_error=TimeoutError,
+                    safe_write_text_fn=_safe_write_text,
+                    sleep_fn=lambda _seconds: None,
+                ),
+            )
+
+        assert code == 0
+        assert json.loads(output_file.read_text()) == payload
+        assert "Recovered timed-out batch from JSON output file" in log_file.read_text()
+
+    def test_run_opencode_batch_ignores_in_progress_timeout_payload(self, tmp_path):
+        log_file = tmp_path / "batch.log"
+        output_file = tmp_path / "out.json"
+        payload = {"assessments": {"logic_clarity": 88}, "issues": []}
+        stdout_text = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "step_start",
+                        "part": {"type": "step-start"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "text",
+                        "part": {"type": "text", "text": json.dumps(payload)},
+                    }
+                ),
+                "",
+            ]
+        )
+
+        with patch(
+            "desloppify.app.commands.review.runner_process._run_batch_attempt",
+            return_value=(
+                "ATTEMPT 1/1",
+                _ExecutionResult(
+                    code=1,
+                    stdout_text=stdout_text,
+                    stderr_text="",
+                    timed_out=True,
+                ),
+            ),
+        ):
+            code = runner_helpers_mod.run_opencode_batch(
+                prompt="test prompt",
+                repo_root=tmp_path,
+                output_file=output_file,
+                log_file=log_file,
+                deps=runner_process_mod.BatchRunnerDeps(
+                    timeout_seconds=60,
+                    subprocess_run=subprocess.run,
+                    timeout_error=TimeoutError,
+                    safe_write_text_fn=_safe_write_text,
+                    sleep_fn=lambda _seconds: None,
+                ),
+            )
+
+        assert code == 124
+        assert not output_file.exists()
+        assert (
+            "Recovered timed-out batch from JSON output file"
+            not in log_file.read_text()
+        )
+
+    def test_run_opencode_batch_stall_recovers_from_live_final_step_payload(
+        self, tmp_path
+    ):
+        log_file = tmp_path / "batch.log"
+        output_file = tmp_path / "out.json"
+        payload = {"assessments": {"logic_clarity": 91}, "issues": []}
+        events = [
+            {"type": "step_start", "part": {"type": "step-start"}},
+            {
+                "type": "text",
+                "part": {
+                    "type": "text",
+                    "text": 'planning {"assessments":{"logic_clarity":10},"issues":[]}',
+                },
+            },
+            {
+                "type": "step_finish",
+                "part": {"type": "step-finish", "reason": "tool-calls"},
+            },
+            {"type": "step_start", "part": {"type": "step-start"}},
+            {
+                "type": "text",
+                "part": {"type": "text", "text": json.dumps(payload)},
+            },
+            {
+                "type": "step_finish",
+                "part": {"type": "step-finish", "reason": "stop"},
+            },
+        ]
+        command = [
+            sys.executable,
+            "-c",
+            (
+                "import json, time\n"
+                f"events = {json.dumps(events)}\n"
+                "for event in events:\n"
+                "    print(json.dumps(event), flush=True)\n"
+                "    time.sleep(0.05)\n"
+                "time.sleep(5)\n"
+            ),
+        ]
+
+        code = runner_helpers_mod.run_opencode_batch(
+            prompt="test prompt",
+            repo_root=tmp_path,
+            output_file=output_file,
+            log_file=log_file,
+            deps=runner_process_mod.BatchRunnerDeps(
+                timeout_seconds=30,
+                subprocess_run=subprocess.run,
+                timeout_error=subprocess.TimeoutExpired,
+                safe_write_text_fn=_safe_write_text,
+                use_popen_runner=True,
+                subprocess_popen=subprocess.Popen,
+                live_log_interval_seconds=0.2,
+                stall_after_output_seconds=1,
+            ),
+            opencode_batch_command_fn=lambda **_kwargs: command,
+        )
+
+        assert code == 0
+        assert json.loads(output_file.read_text()) == payload
+        log_text = log_file.read_text()
+        assert "STALL RECOVERY" in log_text
+        assert "Recovered stalled batch from JSON output file" in log_text
+
+    def test_run_opencode_batch_overwrites_stale_output_on_retry(self, tmp_path):
+        log_file = tmp_path / "batch.log"
+        output_file = tmp_path / "out.json"
+        call_count = [0]
+        first_payload = {"assessments": {"logic_clarity": 10}, "issues": []}
+        second_payload = {"assessments": {"logic_clarity": 90}, "issues": []}
+
+        def _stream(payload: dict[str, object]) -> str:
+            return (
+                json.dumps(
+                    {
+                        "type": "text",
+                        "part": {"type": "text", "text": json.dumps(payload)},
+                    }
+                )
+                + "\n"
+            )
+
+        def mock_run_fn(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return MagicMock(
+                    returncode=1,
+                    stdout=_stream(first_payload),
+                    stderr="ERROR: stream disconnected before completion",
+                )
+            return MagicMock(returncode=0, stdout=_stream(second_payload), stderr="")
+
+        code = runner_helpers_mod.run_opencode_batch(
+            prompt="test prompt",
+            repo_root=tmp_path,
+            output_file=output_file,
+            log_file=log_file,
+            deps=runner_process_mod.BatchRunnerDeps(
+                timeout_seconds=60,
+                subprocess_run=mock_run_fn,
+                timeout_error=TimeoutError,
+                safe_write_text_fn=_safe_write_text,
+                max_retries=1,
+                retry_backoff_seconds=0.0,
+                sleep_fn=lambda _seconds: None,
+            ),
+        )
+
+        assert code == 0
+        assert call_count[0] == 2
+        assert json.loads(output_file.read_text()) == second_payload
+        assert output_file.read_text() != json.dumps(first_payload)
+
+    def test_run_opencode_batch_restores_valid_output_after_retry_failure(
+        self, tmp_path
+    ):
+        output_file = tmp_path / "batch-1.raw.txt"
+        log_file = tmp_path / "batch-1.log"
+        first_payload = {"assessments": {"logic_clarity": 10}, "issues": []}
+        first_stdout = (
+            json.dumps(
+                {
+                    "type": "text",
+                    "part": {"type": "text", "text": json.dumps(first_payload)},
+                }
+            )
+            + "\n"
+        )
+
+        with patch(
+            "desloppify.app.commands.review.runner_process._run_batch_attempt",
+            side_effect=[
+                (
+                    "ATTEMPT 1/2",
+                    _ExecutionResult(
+                        code=1,
+                        stdout_text=first_stdout,
+                        stderr_text="stream disconnected before completion",
+                    ),
+                ),
+                (
+                    "ATTEMPT 2/2",
+                    _ExecutionResult(
+                        code=1,
+                        stdout_text="",
+                        stderr_text="fatal auth error",
+                    ),
+                ),
+            ],
+        ):
+            code = runner_helpers_mod.run_opencode_batch(
+                prompt="test prompt",
+                repo_root=tmp_path,
+                output_file=output_file,
+                log_file=log_file,
+                deps=runner_process_mod.BatchRunnerDeps(
+                    timeout_seconds=60,
+                    subprocess_run=subprocess.run,
+                    timeout_error=TimeoutError,
+                    safe_write_text_fn=_safe_write_text,
+                    max_retries=1,
+                    retry_backoff_seconds=0.0,
+                    sleep_fn=lambda _seconds: None,
+                ),
+            )
+
+        assert code == 1
+        assert json.loads(output_file.read_text()) == first_payload
+
+        batch_results, failures = runner_helpers_mod.collect_batch_results(
+            selected_indexes=[0],
+            failures=[0],
+            output_files={0: output_file},
+            allowed_dims={"logic_clarity"},
+            extract_payload_fn=lambda raw: extract_json_payload(
+                raw, log_fn=lambda *_args, **_kwargs: None
+            ),
+            normalize_result_fn=lambda payload, _dims: (
+                payload.get("assessments", {}),
+                payload.get("issues", []),
+                {},
+                {},
+                {},
+            ),
+        )
+
+        assert len(batch_results) == 1
+        assert failures == []
+        assert batch_results[0].assessments == first_payload["assessments"]
+
+    def test_collect_batch_results_recovers_execution_failure_with_valid_output(
+        self, tmp_path
+    ):
+        output_file = tmp_path / "batch-1.raw.txt"
+        output_file.write_text(
+            json.dumps(
+                {
+                    "assessments": {"logic_clarity": 88.0},
+                    "dimension_notes": {
+                        "logic_clarity": {
+                            "evidence": ["flow has one avoidable branch detour"],
+                            "impact_scope": "module",
+                            "fix_scope": "single_edit",
+                            "confidence": "medium",
+                        }
+                    },
+                    "issues": [],
+                }
+            )
+        )
+
+        def normalize_result(payload, _allowed_dims):
+            notes = payload.get("dimension_notes", {})
+            return (
+                payload.get("assessments", {}),
+                payload.get("issues", []),
+                notes,
+                {},
+                {},
+            )
+
+        batch_results, failures = runner_helpers_mod.collect_batch_results(
+            selected_indexes=[0],
+            failures=[0],
+            output_files={0: output_file},
+            allowed_dims={"logic_clarity"},
+            extract_payload_fn=lambda raw: json.loads(raw),
+            normalize_result_fn=normalize_result,
+        )
+
+        assert failures == []
+        assert len(batch_results) == 1
+        assert batch_results[0].assessments["logic_clarity"] == pytest.approx(88.0)
+
+    def test_collect_batch_results_skips_full_log_fallback_when_stdout_empty(
+        self, tmp_path
+    ):
+        results_dir = tmp_path / "results"
+        logs_dir = tmp_path / "logs"
+        results_dir.mkdir(parents=True, exist_ok=True)
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        raw_path = results_dir / "batch-1.raw.txt"
+        log_path = logs_dir / "batch-1.log"
+        log_path.write_text(
+            "\n".join(
+                [
+                    "ATTEMPT 1/1",
+                    "$ codex exec ...",
+                    "Output schema:",
+                    "{",
+                    '  "assessments": {"logic_clarity": 91.0},',
+                    '  "issues": []',
+                    "}",
+                    "",
+                    "STDOUT:",
+                    "",
+                    "STDERR:",
+                    "ERROR: stream disconnected before completion",
+                ]
+            )
+        )
+
+        seen_inputs: list[str] = []
+
+        def extract_payload(raw: str) -> dict[str, object] | None:
+            seen_inputs.append(raw)
+            return None
+
+        batch_results, failures = runner_helpers_mod.collect_batch_results(
+            selected_indexes=[0],
+            failures=[],
+            output_files={0: raw_path},
+            allowed_dims={"logic_clarity"},
+            extract_payload_fn=extract_payload,
+            normalize_result_fn=lambda payload, _allowed: (  # noqa: ARG005
+                payload.get("assessments", {}),
+                payload.get("issues", []),
+                payload.get("dimension_notes", {}),
+                payload.get("dimension_judgment", {}),
+                {},
+            ),
+        )
+
+        assert batch_results == []
+        assert failures == [0]
+        assert len(seen_inputs) == 1
+        assert "Output schema:" not in seen_inputs[0]
+
+    def test_execute_batches_progress_callback_exceptions_do_not_fail_successful_tasks(
+        self, tmp_path
+    ):
+        """Progress callback errors are logged but do not mark a successful task as failed.
+
+        Upstream commit 17bb730 ('stop callback failures from failing
+        successful tasks') intentionally decoupled progress errors from
+        task success/failure.
+        """
+
+        def _broken_progress(*_args, **_kwargs):
+            raise RuntimeError("progress callback failed")
+
+        captured: list[tuple[int, str]] = []
+
+        failures = runner_helpers_mod.execute_batches(
+            tasks={0: lambda: 0},
+            options=runner_helpers_mod.BatchExecutionOptions(
+                run_parallel=True,
+                max_parallel_workers=1,
+                heartbeat_seconds=0.05,
+            ),
+            progress_fn=_broken_progress,
+            error_log_fn=lambda idx, exc: captured.append((idx, str(exc))),
+        )
+
+        assert failures == []
+        assert any("progress callback failed" in msg for _idx, msg in captured)
+
+    def test_execute_batches_serial_progress_typeerror_does_not_fail_successful_task(
+        self,
+    ):
+        """TypeError in progress callback is logged but does not fail a successful serial task.
+
+        Upstream commit 17bb730 ('stop callback failures from failing
+        successful tasks') intentionally decoupled progress errors from
+        task success/failure — applies to both serial and parallel paths.
+        """
+
+        def _broken_typeerror_progress(event):
+            _ = event
+            raise TypeError("internal progress bug")
+
+        captured: list[tuple[int, str]] = []
+        failures = runner_helpers_mod.execute_batches(
+            tasks={0: lambda: 0},
+            options=runner_helpers_mod.BatchExecutionOptions(run_parallel=False),
+            progress_fn=_broken_typeerror_progress,
+            error_log_fn=lambda idx, exc: captured.append((idx, str(exc))),
+        )
+
+        assert failures == []
+        assert any("internal progress bug" in msg for _idx, msg in captured)
+
+    def test_execute_batches_heartbeat_error_log_failure_is_nonfatal(self):
+        def _heartbeat_only_failure(event):
+            if getattr(event, "event", "") == "heartbeat":
+                raise RuntimeError("heartbeat callback failed")
+
+        def _slow_success():
+            time.sleep(0.12)
+            return 0
+
+        failures = runner_helpers_mod.execute_batches(
+            tasks={0: _slow_success},
+            options=runner_helpers_mod.BatchExecutionOptions(
+                run_parallel=True,
+                max_parallel_workers=1,
+                heartbeat_seconds=0.02,
+            ),
+            progress_fn=_heartbeat_only_failure,
+            # Intentionally fragile callback: idx=-1 used by heartbeat is unsupported.
+            error_log_fn=lambda idx, exc: {0: []}[idx].append(str(exc)),
+        )
+
+        assert failures == []
+
+    def test_print_failures_and_raise_shows_codex_missing_hint(self, tmp_path, capsys):
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (logs_dir / "batch-1.log").write_text(
+            "$ codex exec --ephemeral ...\n\nRUNNER ERROR:\n[Errno 2] No such file or directory: 'codex'\n"
+        )
+        with pytest.raises(CommandError) as exc_info:
+            runner_helpers_mod.print_failures_and_raise(
+                failures=[0],
+                packet_path=tmp_path / "packet.json",
+                logs_dir=logs_dir,
+                colorize_fn=lambda text, _style: text,
+            )
+        assert exc_info.value.exit_code == 1
+        err = capsys.readouterr().err
+        assert "Environment hints:" in err
+        assert "Runner CLI not found on PATH" in err
+
+    def test_print_failures_and_raise_shows_codex_auth_hint(self, tmp_path, capsys):
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (logs_dir / "batch-1.log").write_text(
+            "$ codex exec --ephemeral ...\n\nSTDERR:\nAuthentication failed: please login first.\n"
+        )
+        with pytest.raises(CommandError) as exc_info:
+            runner_helpers_mod.print_failures_and_raise(
+                failures=[0],
+                packet_path=tmp_path / "packet.json",
+                logs_dir=logs_dir,
+                colorize_fn=lambda text, _style: text,
+            )
+        assert exc_info.value.exit_code == 1
+        err = capsys.readouterr().err
+        assert "Environment hints:" in err
+        assert "codex login" in err
+
+    def test_print_failures_reports_categories_without_exit(self, tmp_path, capsys):
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (logs_dir / "batch-1.log").write_text("$ codex ...\nTIMEOUT after 60s\n")
+        (logs_dir / "batch-2.log").write_text(
+            "$ codex ...\nSTDERR:\nAuthentication failed: please login first.\n"
+        )
+
+        runner_helpers_mod.print_failures(
+            failures=[0, 1, 2],
+            packet_path=tmp_path / "packet.json",
+            logs_dir=logs_dir,
+            colorize_fn=lambda text, _style: text,
+        )
+        err = capsys.readouterr().err
+        assert "Failure categories:" in err
+        assert "timeout=1" in err
+        assert "runner auth=1" in err
+        assert "missing log=1" in err
+
+    def test_print_failures_reports_stream_disconnect_category(self, tmp_path, capsys):
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (logs_dir / "batch-1.log").write_text(
+            "$ codex ...\nSTDERR:\nERROR: stream disconnected before completion\n"
+        )
+
+        runner_helpers_mod.print_failures(
+            failures=[0],
+            packet_path=tmp_path / "packet.json",
+            logs_dir=logs_dir,
+            colorize_fn=lambda text, _style: text,
+        )
+        err = capsys.readouterr().err
+        assert "Failure categories:" in err
+        assert "stream disconnect=1" in err
+        assert "Connectivity tuning:" in err
+
+    def test_print_failures_reports_usage_limit_category_with_unicode_apostrophe(
+        self, tmp_path, capsys
+    ):
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (logs_dir / "batch-1.log").write_text(
+            "$ codex ...\nSTDERR:\n"
+            "You\u2019ve hit your usage limit. To get more access now, "
+            "send a request to your admin or try again at 8:49 PM.\n"
+        )
+
+        runner_helpers_mod.print_failures(
+            failures=[0],
+            packet_path=tmp_path / "packet.json",
+            logs_dir=logs_dir,
+            colorize_fn=lambda text, _style: text,
+        )
+        err = capsys.readouterr().err
+        assert "Failure categories:" in err
+        assert "usage limit=1" in err
+        assert "Environment hints:" in err
+        assert "usage quota is exhausted" in err
+
+    def test_print_failures_reports_codex_backend_connectivity_hint(
+        self, tmp_path, capsys
+    ):
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (logs_dir / "batch-1.log").write_text(
+            "\n".join(
+                [
+                    "$ codex ...",
+                    "STDERR:",
+                    "ERROR: stream disconnected before completion:",
+                    "error sending request for url (https://chatgpt.com/backend-api/codex/responses)",
+                ]
+            )
+        )
+
+        runner_helpers_mod.print_failures(
+            failures=[0],
+            packet_path=tmp_path / "packet.json",
+            logs_dir=logs_dir,
+            colorize_fn=lambda text, _style: text,
+        )
+        err = capsys.readouterr().err
+        assert "Environment hints:" in err
+        assert "cannot reach its backend" in err
+        assert "--external-start --external-runner claude" in err
+
+    def test_print_failures_reports_sandbox_hint_for_backend_disconnect(
+        self, tmp_path, capsys
+    ):
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (logs_dir / "batch-1.log").write_text(
+            "\n".join(
+                [
+                    "$ codex ...",
+                    "WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)",
+                    "STDERR:",
+                    "ERROR: stream disconnected before completion:",
+                    "error sending request for url (https://chatgpt.com/backend-api/codex/responses)",
+                ]
+            )
+        )
+
+        runner_helpers_mod.print_failures(
+            failures=[0],
+            packet_path=tmp_path / "packet.json",
+            logs_dir=logs_dir,
+            colorize_fn=lambda text, _style: text,
+        )
+        err = capsys.readouterr().err
+        assert "Sandbox hint:" in err
+        assert "restricted sandbox execution" in err
+
+    def test_run_followup_scan_returns_nonzero_code(self, tmp_path):
+        mock_run = MagicMock(return_value=MagicMock(returncode=9))
+        code = runner_helpers_mod.run_followup_scan(
+            lang_name="typescript",
+            scan_path=str(tmp_path),
+            deps=runner_helpers_mod.FollowupScanDeps(
+                project_root=tmp_path,
+                timeout_seconds=60,
+                python_executable="python",
+                subprocess_run=mock_run,
+                timeout_error=TimeoutError,
+                colorize_fn=lambda text, _: text,
+            ),
+        )
+        assert code == 9
+
+    def test_run_followup_scan_default_respects_queue_gate(self, tmp_path):
+        mock_run = MagicMock(return_value=MagicMock(returncode=0))
+        runner_helpers_mod.run_followup_scan(
+            lang_name="typescript",
+            scan_path=str(tmp_path),
+            deps=runner_helpers_mod.FollowupScanDeps(
+                project_root=tmp_path,
+                timeout_seconds=60,
+                python_executable="python",
+                subprocess_run=mock_run,
+                timeout_error=TimeoutError,
+                colorize_fn=lambda text, _: text,
+            ),
+        )
+
+        cmd = mock_run.call_args.args[0]
+        assert "--force-rescan" not in cmd
+        assert "--attest" not in cmd
+
+    def test_do_run_batches_scan_after_import_exits_on_failed_followup(
+        self, empty_state, tmp_path
+    ):
+        packet = {
+            "command": "review",
+            "mode": "holistic",
+            "language": "typescript",
+            "dimensions": ["high_level_elegance"],
+            "investigation_batches": [
+                {
+                    "name": "Batch A",
+                    "dimensions": ["high_level_elegance"],
+                    "files_to_read": ["src/a.ts"],
+                    "why": "A",
+                }
+            ],
+        }
+        packet_path = tmp_path / "packet.json"
+        packet_path.write_text(json.dumps(packet))
+
+        args = MagicMock()
+        args.path = str(tmp_path)
+        args.dimensions = None
+        args.runner = "codex"
+        args.parallel = False
+        args.dry_run = False
+        args.packet = str(packet_path)
+        args.only_batches = None
+        args.scan_after_import = True
+
+        review_packet_dir = tmp_path / ".desloppify" / "review_packets"
+        runs_dir = tmp_path / ".desloppify" / "subagents" / "runs"
+
+        lang = MagicMock()
+        lang.name = "typescript"
+
+        with (
+            patch(
+                "desloppify.app.commands.review.runtime_paths.PROJECT_ROOT",
+                tmp_path,
+            ),
+            patch(
+                "desloppify.app.commands.review.runtime_paths.REVIEW_PACKET_DIR",
+                review_packet_dir,
+            ),
+            patch(
+                "desloppify.app.commands.review.runtime_paths.SUBAGENT_RUNS_DIR",
+                runs_dir,
+            ),
+            patch(
+                "desloppify.app.commands.review.batch.orchestrator._do_import",
+            ),
+            patch(
+                "desloppify.app.commands.review.batch.orchestrator.execute_batches",
+                return_value=[],
+            ),
+            patch(
+                "desloppify.app.commands.review.batch.orchestrator.collect_batch_results",
+                return_value=(
+                    [{"assessments": {}, "dimension_notes": {}, "issues": []}],
+                    [],
+                ),
+            ),
+            patch(
+                "desloppify.app.commands.review.batch.orchestrator._merge_batch_results",
+                return_value={"assessments": {}, "dimension_notes": {}, "issues": []},
+            ),
+            patch(
+                "desloppify.app.commands.review.batch.orchestrator.run_followup_scan",
+                return_value=7,
+            ),
+        ):
+            with pytest.raises(CommandError) as exc_info:
+                do_run_batches(args, empty_state, lang, "fake_sp", config={})
+
+        assert exc_info.value.exit_code == 7
+
+    def test_do_run_batches_keyboard_interrupt_writes_partial_summary(
+        self, empty_state, tmp_path
+    ):
+        packet = {
+            "command": "review",
+            "mode": "holistic",
+            "language": "typescript",
+            "dimensions": ["high_level_elegance"],
+            "investigation_batches": [
+                {
+                    "name": "Batch A",
+                    "dimensions": ["high_level_elegance"],
+                    "files_to_read": ["src/a.ts"],
+                    "why": "A",
+                }
+            ],
+        }
+        packet_path = tmp_path / "packet.json"
+        packet_path.write_text(json.dumps(packet))
+
+        args = MagicMock()
+        args.path = str(tmp_path)
+        args.dimensions = None
+        args.runner = "codex"
+        args.parallel = False
+        args.dry_run = False
+        args.packet = str(packet_path)
+        args.only_batches = None
+        args.scan_after_import = False
+        args.allow_partial = False
+        args.save_run_log = True
+        args.run_log_file = None
+
+        review_packet_dir = tmp_path / ".desloppify" / "review_packets"
+        runs_dir = tmp_path / ".desloppify" / "subagents" / "runs"
+
+        lang = MagicMock()
+        lang.name = "typescript"
+
+        with (
+            patch(
+                "desloppify.app.commands.review.runtime_paths.PROJECT_ROOT",
+                tmp_path,
+            ),
+            patch(
+                "desloppify.app.commands.review.runtime_paths.REVIEW_PACKET_DIR",
+                review_packet_dir,
+            ),
+            patch(
+                "desloppify.app.commands.review.runtime_paths.SUBAGENT_RUNS_DIR",
+                runs_dir,
+            ),
+            patch(
+                "desloppify.app.commands.review.batch.orchestrator.execute_batches",
+                side_effect=KeyboardInterrupt,
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                do_run_batches(args, empty_state, lang, "fake_sp", config={})
+
+        assert exc_info.value.code == 130
+        summary_files = sorted(runs_dir.glob("*/run_summary.json"))
+        assert len(summary_files) == 1
+        summary_payload = json.loads(summary_files[0].read_text())
+        assert summary_payload["interrupted"] is True
+        assert summary_payload["interruption_reason"] == "keyboard_interrupt"
+        assert summary_payload["successful_batches"] == []
+        assert summary_payload["failed_batches"] == []
+        assert summary_payload["batches"]["1"]["status"] == "interrupted"
+
+        run_log_path = Path(summary_payload["run_log"])
+        run_log_text = run_log_path.read_text()
+        assert "run-interrupted reason=keyboard_interrupt" in run_log_text
+
 
 class TestSetupLang:
     def test_setup_builds_zone_map(self, tmp_path):
@@ -2229,10 +3230,7 @@ class TestSkippedIssues:
         assert diff["new"] == 1
         assert diff["skipped"] == 1
         missing_text = " ".join(diff["skipped_details"][0]["missing"])
-        assert any(
-            f in missing_text
-            for f in ("summary", "suggestion")
-        )
+        assert any(f in missing_text for f in ("summary", "suggestion"))
 
     def test_no_skipped_when_all_valid(self):
         state = build_empty_state()

--- a/desloppify/tests/review/review_commands_runner_cases.py
+++ b/desloppify/tests/review/review_commands_runner_cases.py
@@ -21,7 +21,7 @@ from desloppify.base.exception_sets import CommandError
 runner_helpers_mod = SimpleNamespace(
     BatchExecutionOptions=runner_parallel_mod.BatchExecutionOptions,
     BatchResult=runner_parallel_mod.BatchResult,
-    CodexBatchRunnerDeps=runner_process_mod.CodexBatchRunnerDeps,
+    CodexBatchRunnerDeps=runner_process_mod.BatchRunnerDeps,
     FollowupScanDeps=runner_process_mod.FollowupScanDeps,
     build_batch_import_provenance=runner_packets_mod.build_batch_import_provenance,
     build_blind_packet=runner_packets_mod.build_blind_packet,
@@ -44,7 +44,6 @@ class TestCmdReviewPrepareRunnerHelpers:
     def test_collect_batch_results_recovers_execution_failure_with_valid_output(
         self, tmp_path
     ):
-
         output_file = tmp_path / "batch-1.raw.txt"
         output_file.write_text(
             json.dumps(
@@ -65,7 +64,14 @@ class TestCmdReviewPrepareRunnerHelpers:
 
         def normalize_result(payload, _allowed_dims):
             notes = payload.get("dimension_notes", {})
-            return payload.get("assessments", {}), payload.get("issues", []), notes, {}, {}, {}
+            return (
+                payload.get("assessments", {}),
+                payload.get("issues", []),
+                notes,
+                {},
+                {},
+                {},
+            )
 
         batch_results, failures = runner_helpers_mod.collect_batch_results(
             request=CollectBatchResultsRequest(
@@ -85,7 +91,6 @@ class TestCmdReviewPrepareRunnerHelpers:
     def test_collect_batch_results_skips_full_log_fallback_when_stdout_empty(
         self, tmp_path
     ):
-
         results_dir = tmp_path / "results"
         logs_dir = tmp_path / "logs"
         results_dir.mkdir(parents=True, exist_ok=True)
@@ -140,8 +145,9 @@ class TestCmdReviewPrepareRunnerHelpers:
         assert len(seen_inputs) == 1
         assert "Output schema:" not in seen_inputs[0]
 
-    def test_execute_batches_marks_progress_callback_exceptions_as_failures(self, tmp_path):
-
+    def test_execute_batches_marks_progress_callback_exceptions_as_failures(
+        self, tmp_path
+    ):
         def _broken_progress(*_args, **_kwargs):
             raise RuntimeError("progress callback failed")
 
@@ -162,7 +168,6 @@ class TestCmdReviewPrepareRunnerHelpers:
         assert any("progress callback failed" in msg for _idx, msg in captured)
 
     def test_execute_batches_does_not_mask_internal_progress_typeerror(self):
-
         def _broken_typeerror_progress(event):
             _ = event
             raise TypeError("internal progress bug")
@@ -179,7 +184,6 @@ class TestCmdReviewPrepareRunnerHelpers:
         assert any("internal progress bug" in msg for _idx, msg in captured)
 
     def test_execute_batches_heartbeat_error_log_failure_is_nonfatal(self):
-
         def _heartbeat_only_failure(event):
             if getattr(event, "event", "") == "heartbeat":
                 raise RuntimeError("heartbeat callback failed")
@@ -203,7 +207,6 @@ class TestCmdReviewPrepareRunnerHelpers:
         assert failures == []
 
     def test_print_failures_and_raise_shows_codex_missing_hint(self, tmp_path, capsys):
-
         logs_dir = tmp_path / "logs"
         logs_dir.mkdir(parents=True, exist_ok=True)
         (logs_dir / "batch-1.log").write_text(
@@ -222,7 +225,6 @@ class TestCmdReviewPrepareRunnerHelpers:
         assert "codex CLI not found on PATH" in err
 
     def test_print_failures_and_raise_shows_codex_auth_hint(self, tmp_path, capsys):
-
         logs_dir = tmp_path / "logs"
         logs_dir.mkdir(parents=True, exist_ok=True)
         (logs_dir / "batch-1.log").write_text(
@@ -241,7 +243,6 @@ class TestCmdReviewPrepareRunnerHelpers:
         assert "codex login" in err
 
     def test_print_failures_reports_categories_without_exit(self, tmp_path, capsys):
-
         logs_dir = tmp_path / "logs"
         logs_dir.mkdir(parents=True, exist_ok=True)
         (logs_dir / "batch-1.log").write_text("$ codex ...\nTIMEOUT after 60s\n")
@@ -262,7 +263,6 @@ class TestCmdReviewPrepareRunnerHelpers:
         assert "missing log=1" in err
 
     def test_print_failures_reports_stream_disconnect_category(self, tmp_path, capsys):
-
         logs_dir = tmp_path / "logs"
         logs_dir.mkdir(parents=True, exist_ok=True)
         (logs_dir / "batch-1.log").write_text(
@@ -283,15 +283,12 @@ class TestCmdReviewPrepareRunnerHelpers:
     def test_print_failures_reports_usage_limit_category_with_unicode_apostrophe(
         self, tmp_path, capsys
     ):
-
         logs_dir = tmp_path / "logs"
         logs_dir.mkdir(parents=True, exist_ok=True)
         (logs_dir / "batch-1.log").write_text(
-            
-                "$ codex ...\nSTDERR:\n"
-                "You\u2019ve hit your usage limit. To get more access now, "
-                "send a request to your admin or try again at 8:49 PM.\n"
-            
+            "$ codex ...\nSTDERR:\n"
+            "You\u2019ve hit your usage limit. To get more access now, "
+            "send a request to your admin or try again at 8:49 PM.\n"
         )
 
         runner_helpers_mod.print_failures(
@@ -309,7 +306,6 @@ class TestCmdReviewPrepareRunnerHelpers:
     def test_print_failures_reports_codex_backend_connectivity_hint(
         self, tmp_path, capsys
     ):
-
         logs_dir = tmp_path / "logs"
         logs_dir.mkdir(parents=True, exist_ok=True)
         (logs_dir / "batch-1.log").write_text(
@@ -334,11 +330,9 @@ class TestCmdReviewPrepareRunnerHelpers:
         assert "cannot reach chatgpt.com backend" in err
         assert "--external-start --external-runner claude" in err
 
-
     def test_print_failures_reports_sandbox_hint_for_backend_disconnect(
         self, tmp_path, capsys
     ):
-
         logs_dir = tmp_path / "logs"
         logs_dir.mkdir(parents=True, exist_ok=True)
         (logs_dir / "batch-1.log").write_text(
@@ -364,7 +358,6 @@ class TestCmdReviewPrepareRunnerHelpers:
         assert "restricted sandbox execution" in err
 
     def test_run_followup_scan_returns_nonzero_code(self, tmp_path):
-
         mock_run = MagicMock(return_value=MagicMock(returncode=9))
         code = runner_helpers_mod.run_followup_scan(
             lang_name="typescript",
@@ -381,7 +374,6 @@ class TestCmdReviewPrepareRunnerHelpers:
         assert code == 9
 
     def test_run_followup_scan_default_respects_queue_gate(self, tmp_path):
-
         mock_run = MagicMock(return_value=MagicMock(returncode=0))
         runner_helpers_mod.run_followup_scan(
             lang_name="typescript",

--- a/desloppify/tests/review/test_runner_internals.py
+++ b/desloppify/tests/review/test_runner_internals.py
@@ -22,12 +22,13 @@ from desloppify.app.commands.review.runner_process_impl.attempts import (
 )
 from desloppify.app.commands.review.runner_process_impl.io import (
     _check_stall,
+    _extract_text_from_opencode_json_stream,
     _output_file_has_json_payload,
     _output_file_status_text,
     extract_payload_from_log,
 )
 from desloppify.app.commands.review.runner_process_impl.types import (
-    CodexBatchRunnerDeps,
+    BatchRunnerDeps,
     _ExecutionResult,
 )
 
@@ -35,8 +36,8 @@ from desloppify.app.commands.review.runner_process_impl.types import (
 # ── Helpers ──────────────────────────────────────────────────────
 
 
-def _make_deps(**overrides) -> CodexBatchRunnerDeps:
-    """Build a minimal CodexBatchRunnerDeps with sensible defaults."""
+def _make_deps(**overrides) -> BatchRunnerDeps:
+    """Build a minimal BatchRunnerDeps with sensible defaults."""
     defaults = dict(
         timeout_seconds=60,
         subprocess_run=MagicMock(),
@@ -53,7 +54,7 @@ def _make_deps(**overrides) -> CodexBatchRunnerDeps:
         output_validation_poll_seconds=0.01,
     )
     defaults.update(overrides)
-    return CodexBatchRunnerDeps(**defaults)
+    return BatchRunnerDeps(**defaults)
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -380,7 +381,9 @@ class TestHandleEarlyAttemptReturn:
         assert handle_early_attempt_return(result) is None
 
     def test_returns_early_return_code(self):
-        result = _ExecutionResult(code=0, stdout_text="", stderr_text="", early_return=127)
+        result = _ExecutionResult(
+            code=0, stdout_text="", stderr_text="", early_return=127
+        )
         assert handle_early_attempt_return(result) == 127
 
 
@@ -439,9 +442,7 @@ class TestHandleTimeoutOrStall:
     def test_stall_with_valid_output_recovers(self, tmp_path):
         output_file = tmp_path / "out.json"
         output_file.write_text('{"quality": {}}')
-        result = _ExecutionResult(
-            code=1, stdout_text="", stderr_text="", stalled=True
-        )
+        result = _ExecutionResult(code=1, stdout_text="", stderr_text="", stalled=True)
         deps = _make_deps()
         log_sections: list[str] = []
         ret = handle_timeout_or_stall(
@@ -456,9 +457,7 @@ class TestHandleTimeoutOrStall:
         assert ret == 0
 
     def test_stall_without_output_returns_124(self, tmp_path):
-        result = _ExecutionResult(
-            code=1, stdout_text="", stderr_text="", stalled=True
-        )
+        result = _ExecutionResult(code=1, stdout_text="", stderr_text="", stalled=True)
         deps = _make_deps()
         ret = handle_timeout_or_stall(
             header="ATTEMPT 1/1",
@@ -752,7 +751,326 @@ class TestHandleFailedAttempt:
 
 
 # ═══════════════════════════════════════════════════════════════════
-# runner_parallel.execution.py
+# OpenCode runner support
 # ═══════════════════════════════════════════════════════════════════
 
 
+class TestExtractTextFromOpenCodeJsonStream:
+    """_extract_text_from_opencode_json_stream: extracts assistant text from NDJSON."""
+
+    def test_empty_input_returns_empty(self):
+        assert _extract_text_from_opencode_json_stream("") == ""
+
+    def test_simple_text_event(self):
+        """Single text event should return the text payload."""
+        stream = (
+            '{"type":"step_start","timestamp":1,"sessionID":"s","part":{"type":"step-start"}}\n'
+            '{"type":"text","timestamp":2,"sessionID":"s","part":{"type":"text","text":"hello world"}}\n'
+            '{"type":"step_finish","timestamp":3,"sessionID":"s","part":{"type":"step-finish","reason":"stop"}}\n'
+        )
+        assert _extract_text_from_opencode_json_stream(stream) == "hello world"
+
+    def test_multi_step_with_tool_use(self):
+        """Multi-step run: only the terminal stop-step text is returned."""
+        stream = (
+            '{"type":"step_start","timestamp":1,"sessionID":"s","part":{"type":"step-start"}}\n'
+            '{"type":"text","timestamp":2,"sessionID":"s","part":{"type":"text","text":"planning {\\"assessments\\": {\\"logic_clarity\\": 10}, \\"issues\\": []}"}}\n'
+            '{"type":"tool_use","timestamp":3,"sessionID":"s","part":{"type":"tool","callID":"c1"}}\n'
+            '{"type":"step_finish","timestamp":4,"sessionID":"s","part":{"type":"step-finish","reason":"tool-calls"}}\n'
+            '{"type":"step_start","timestamp":5,"sessionID":"s","part":{"type":"step-start"}}\n'
+            '{"type":"text","timestamp":6,"sessionID":"s","part":{"type":"text","text":"{\\"assessments\\": {}}"}}\n'
+            '{"type":"step_finish","timestamp":7,"sessionID":"s","part":{"type":"step-finish","reason":"stop"}}\n'
+        )
+        result = _extract_text_from_opencode_json_stream(stream)
+        assert result == '{"assessments": {}}'
+
+    def test_tool_call_run_without_terminal_stop_returns_empty(self):
+        """Without a terminal stop step, tool-call runs should not reuse earlier text."""
+        stream = (
+            '{"type":"step_start","timestamp":1,"sessionID":"s","part":{"type":"step-start"}}\n'
+            '{"type":"text","timestamp":2,"sessionID":"s","part":{"type":"text","text":"{\\"assessments\\": {\\"logic_clarity\\": 10}, \\"issues\\": []}"}}\n'
+            '{"type":"step_finish","timestamp":3,"sessionID":"s","part":{"type":"step-finish","reason":"tool-calls"}}\n'
+            '{"type":"step_start","timestamp":4,"sessionID":"s","part":{"type":"step-start"}}\n'
+            '{"type":"text","timestamp":5,"sessionID":"s","part":{"type":"text","text":"{\\"assessments\\": {\\"logic_clarity\\": 90}, \\"issues\\": []}"}}\n'
+        )
+        assert _extract_text_from_opencode_json_stream(stream) == ""
+
+    def test_incomplete_step_without_finish_returns_empty(self):
+        """In-progress step text should not be exposed before step_finish arrives."""
+        stream = (
+            '{"type":"step_start","timestamp":1,"sessionID":"s","part":{"type":"step-start"}}\n'
+            '{"type":"text","timestamp":2,"sessionID":"s","part":{"type":"text","text":"{\\"assessments\\": {\\"logic_clarity\\": 10}, \\"issues\\": []}"}}\n'
+        )
+        assert _extract_text_from_opencode_json_stream(stream) == ""
+
+    def test_multiple_text_events_concatenated(self):
+        """Multiple text events within a step are joined."""
+        stream = (
+            '{"type":"text","timestamp":1,"sessionID":"s","part":{"type":"text","text":"first "}}\n'
+            '{"type":"text","timestamp":2,"sessionID":"s","part":{"type":"text","text":"second"}}\n'
+        )
+        assert _extract_text_from_opencode_json_stream(stream) == "first second"
+
+    def test_invalid_json_lines_skipped(self):
+        """Non-JSON lines are silently skipped."""
+        stream = (
+            "not json at all\n"
+            '{"type":"text","timestamp":1,"sessionID":"s","part":{"type":"text","text":"ok"}}\n'
+            "also not json\n"
+        )
+        assert _extract_text_from_opencode_json_stream(stream) == "ok"
+
+    def test_non_dict_json_skipped(self):
+        """JSON arrays and scalars are skipped."""
+        stream = (
+            "[1, 2, 3]\n"
+            '"just a string"\n'
+            '{"type":"text","timestamp":1,"sessionID":"s","part":{"type":"text","text":"found"}}\n'
+        )
+        assert _extract_text_from_opencode_json_stream(stream) == "found"
+
+    def test_text_event_without_part_text(self):
+        """Text event with missing part.text should contribute empty string."""
+        stream = (
+            '{"type":"text","timestamp":1,"sessionID":"s","part":{"type":"text"}}\n'
+        )
+        assert _extract_text_from_opencode_json_stream(stream) == ""
+
+    def test_non_text_event_types_ignored(self):
+        """Events that are not type=text should not contribute text."""
+        stream = (
+            '{"type":"step_start","timestamp":1,"sessionID":"s","part":{"type":"step-start"}}\n'
+            '{"type":"tool_use","timestamp":2,"sessionID":"s","part":{"type":"tool","text":"ignored"}}\n'
+            '{"type":"step_finish","timestamp":3,"sessionID":"s","part":{"type":"step-finish","reason":"stop"}}\n'
+        )
+        assert _extract_text_from_opencode_json_stream(stream) == ""
+
+    def test_whitespace_only_input(self):
+        assert _extract_text_from_opencode_json_stream("  \n  \n  ") == ""
+
+    def test_real_world_simple_output(self):
+        """Matches the actual captured output from /tmp/opencode_json_output.txt."""
+        stream = (
+            '{"type":"step_start","timestamp":1772656351012,"sessionID":"ses_34572bc8affe2KySIxdu8u4Ojn",'
+            '"part":{"id":"prt_cba8d5721001FNzAaBjUG8rArL","sessionID":"ses_34572bc8affe2KySIxdu8u4Ojn",'
+            '"messageID":"msg_cba8d43e8001BJkygj22hMSi5X","type":"step-start",'
+            '"snapshot":"0afdb0c3b6a4da3fc76439cf1a25ddbe7731c05e"}}\n'
+            '{"type":"text","timestamp":1772656351015,"sessionID":"ses_34572bc8affe2KySIxdu8u4Ojn",'
+            '"part":{"id":"prt_cba8d5723001lZi3eZo4ZuAzIL","sessionID":"ses_34572bc8affe2KySIxdu8u4Ojn",'
+            '"messageID":"msg_cba8d43e8001BJkygj22hMSi5X","type":"text","text":"hello",'
+            '"time":{"start":1772656351013,"end":1772656351013}}}\n'
+            '{"type":"step_finish","timestamp":1772656351046,"sessionID":"ses_34572bc8affe2KySIxdu8u4Ojn",'
+            '"part":{"id":"prt_cba8d5726001wZmrZBvV0R1yaI","sessionID":"ses_34572bc8affe2KySIxdu8u4Ojn",'
+            '"messageID":"msg_cba8d43e8001BJkygj22hMSi5X","type":"step-finish","reason":"stop"}}\n'
+        )
+        assert _extract_text_from_opencode_json_stream(stream) == "hello"
+
+
+class TestOpenCodeBatchCommand:
+    """opencode_batch_command: builds the opencode run command line."""
+
+    def test_basic_command(self, tmp_path, monkeypatch):
+        from desloppify.app.commands.review.runner_process import opencode_batch_command
+
+        monkeypatch.delenv("DESLOPPIFY_OPENCODE_ATTACH", raising=False)
+        cmd = opencode_batch_command(prompt="test prompt", repo_root=tmp_path)
+        assert cmd[0] == "opencode"
+        assert cmd[1] == "run"
+        assert "--format" in cmd
+        assert "json" in cmd
+        assert "--dir" in cmd
+        assert str(tmp_path) in cmd
+        assert cmd[-1] == "test prompt"
+        assert "--attach" not in cmd
+
+    def test_attach_url_from_env(self, tmp_path, monkeypatch):
+        from desloppify.app.commands.review.runner_process import opencode_batch_command
+
+        monkeypatch.setenv("DESLOPPIFY_OPENCODE_ATTACH", "http://localhost:4096")
+        cmd = opencode_batch_command(prompt="test prompt", repo_root=tmp_path)
+        attach_idx = cmd.index("--attach")
+        assert cmd[attach_idx + 1] == "http://localhost:4096"
+
+    def test_empty_attach_url_ignored(self, tmp_path, monkeypatch):
+        from desloppify.app.commands.review.runner_process import opencode_batch_command
+
+        monkeypatch.setenv("DESLOPPIFY_OPENCODE_ATTACH", "  ")
+        cmd = opencode_batch_command(prompt="test prompt", repo_root=tmp_path)
+        assert "--attach" not in cmd
+
+    def test_model_env_var(self, tmp_path, monkeypatch):
+        """DESLOPPIFY_OPENCODE_MODEL env var adds --model flag."""
+        from desloppify.app.commands.review.runner_process import opencode_batch_command
+
+        monkeypatch.delenv("DESLOPPIFY_OPENCODE_ATTACH", raising=False)
+        monkeypatch.setenv("DESLOPPIFY_OPENCODE_MODEL", "claude-sonnet-4-20250514")
+        cmd = opencode_batch_command(prompt="test prompt", repo_root=tmp_path)
+        model_idx = cmd.index("--model")
+        assert cmd[model_idx + 1] == "claude-sonnet-4-20250514"
+
+    def test_model_env_var_empty_ignored(self, tmp_path, monkeypatch):
+        """Empty DESLOPPIFY_OPENCODE_MODEL is ignored."""
+        from desloppify.app.commands.review.runner_process import opencode_batch_command
+
+        monkeypatch.delenv("DESLOPPIFY_OPENCODE_ATTACH", raising=False)
+        monkeypatch.setenv("DESLOPPIFY_OPENCODE_MODEL", "  ")
+        cmd = opencode_batch_command(prompt="test prompt", repo_root=tmp_path)
+        assert "--model" not in cmd
+
+    def test_variant_env_var(self, tmp_path, monkeypatch):
+        """DESLOPPIFY_OPENCODE_VARIANT env var adds --variant flag."""
+        from desloppify.app.commands.review.runner_process import opencode_batch_command
+
+        monkeypatch.delenv("DESLOPPIFY_OPENCODE_ATTACH", raising=False)
+        monkeypatch.delenv("DESLOPPIFY_OPENCODE_MODEL", raising=False)
+        monkeypatch.setenv("DESLOPPIFY_OPENCODE_VARIANT", "high")
+        cmd = opencode_batch_command(prompt="test prompt", repo_root=tmp_path)
+        idx = cmd.index("--variant")
+        assert cmd[idx + 1] == "high"
+
+    def test_variant_env_var_empty_ignored(self, tmp_path, monkeypatch):
+        """Empty DESLOPPIFY_OPENCODE_VARIANT is ignored."""
+        from desloppify.app.commands.review.runner_process import opencode_batch_command
+
+        monkeypatch.delenv("DESLOPPIFY_OPENCODE_ATTACH", raising=False)
+        monkeypatch.delenv("DESLOPPIFY_OPENCODE_MODEL", raising=False)
+        monkeypatch.setenv("DESLOPPIFY_OPENCODE_VARIANT", "  ")
+        cmd = opencode_batch_command(prompt="test prompt", repo_root=tmp_path)
+        assert "--variant" not in cmd
+
+
+class TestValidateRunnerOpenCode:
+    """validate_runner accepts 'opencode' as a valid runner."""
+
+    def test_opencode_accepted(self):
+        from desloppify.app.commands.review.batch.scope import validate_runner
+
+        # Should not raise
+        validate_runner("opencode", colorize_fn=lambda text, color: text)
+
+    def test_codex_still_accepted(self):
+        from desloppify.app.commands.review.batch.scope import validate_runner
+
+        validate_runner("codex", colorize_fn=lambda text, color: text)
+
+    def test_unknown_runner_rejected(self):
+        import pytest
+
+        from desloppify.app.commands.review.batch.scope import validate_runner
+        from desloppify.base.exception_sets import CommandError
+
+        with pytest.raises(CommandError, match="unsupported runner"):
+            validate_runner("unknown", colorize_fn=lambda text, color: text)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# OpenCode failure detection
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestOpenCodeFailureDetection:
+    """runner_failures: _is_runner_missing detects opencode-specific patterns."""
+
+    def test_opencode_not_found_detected(self):
+        from desloppify.app.commands.review.runner_failures import _is_runner_missing
+
+        assert _is_runner_missing("opencode not found") is True
+
+    def test_codex_not_found_still_detected(self):
+        from desloppify.app.commands.review.runner_failures import _is_runner_missing
+
+        assert _is_runner_missing("codex not found") is True
+
+    def test_opencode_errno2_detected(self):
+        from desloppify.app.commands.review.runner_failures import _is_runner_missing
+
+        assert _is_runner_missing("errno 2 opencode") is True
+
+    def test_opencode_no_such_file_detected(self):
+        from desloppify.app.commands.review.runner_failures import _is_runner_missing
+
+        assert _is_runner_missing("no such file or directory $ opencode run") is True
+
+    def test_unrelated_text_not_detected(self):
+        from desloppify.app.commands.review.runner_failures import _is_runner_missing
+
+        assert _is_runner_missing("some other error") is False
+
+    def test_classify_opencode_runner_missing(self):
+        from desloppify.app.commands.review.runner_failures import (
+            classify_runner_failure,
+        )
+
+        assert classify_runner_failure("opencode not found") == "runner_missing"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# OpenCode provenance / import policy
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestOpenCodeProvenanceTrust:
+    """SUPPORTED_BLIND_REVIEW_RUNNERS includes 'opencode' for trusted imports."""
+
+    def test_opencode_in_supported_runners(self):
+        from desloppify.app.commands.review.importing.policy import (
+            SUPPORTED_BLIND_REVIEW_RUNNERS,
+        )
+
+        assert "opencode" in SUPPORTED_BLIND_REVIEW_RUNNERS
+
+    def test_codex_still_in_supported_runners(self):
+        from desloppify.app.commands.review.importing.policy import (
+            SUPPORTED_BLIND_REVIEW_RUNNERS,
+        )
+
+        assert "codex" in SUPPORTED_BLIND_REVIEW_RUNNERS
+
+    def test_claude_still_in_supported_runners(self):
+        from desloppify.app.commands.review.importing.policy import (
+            SUPPORTED_BLIND_REVIEW_RUNNERS,
+        )
+
+        assert "claude" in SUPPORTED_BLIND_REVIEW_RUNNERS
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Runner-agnostic failure hints
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestRunnerAgnosticHints:
+    """_FAILURE_HINT_BY_CATEGORY messages are runner-agnostic."""
+
+    def test_runner_missing_hint_not_codex_specific(self):
+        from desloppify.app.commands.review.runner_failures import (
+            _FAILURE_HINT_BY_CATEGORY,
+        )
+
+        hint = _FAILURE_HINT_BY_CATEGORY["runner_missing"]
+        assert "codex CLI not found" not in hint.lower()
+        assert "runner" in hint.lower()
+
+    def test_runner_auth_hint_not_codex_specific(self):
+        from desloppify.app.commands.review.runner_failures import (
+            _FAILURE_HINT_BY_CATEGORY,
+        )
+
+        hint = _FAILURE_HINT_BY_CATEGORY["runner_auth"]
+        assert "codex runner appears" not in hint.lower()
+
+    def test_usage_limit_hint_not_codex_specific(self):
+        from desloppify.app.commands.review.runner_failures import (
+            _FAILURE_HINT_BY_CATEGORY,
+        )
+
+        hint = _FAILURE_HINT_BY_CATEGORY["usage_limit"]
+        assert "codex usage" not in hint.lower()
+
+    def test_stream_disconnect_hint_not_codex_specific(self):
+        from desloppify.app.commands.review.runner_failures import (
+            _FAILURE_HINT_BY_CATEGORY,
+        )
+
+        hint = _FAILURE_HINT_BY_CATEGORY["stream_disconnect"]
+        assert "codex connectivity" not in hint.lower()

--- a/docs/OPENCODE.md
+++ b/docs/OPENCODE.md
@@ -2,5 +2,34 @@
 
 When installed (via `desloppify update-skill opencode`), OpenCode automatically loads this skill for code quality, technical debt, and health score questions.
 
+### Review workflow
+
+Use the native `--runner opencode` for automated batch reviews:
+
+```
+desloppify review --run-batches --runner opencode --parallel --scan-after-import
+```
+
+This spawns OpenCode subprocesses (`opencode run --format json`) for each batch, extracts results from the NDJSON stream, merges them, and imports as trusted assessments — identical pipeline to the Codex runner but using OpenCode as the execution engine.
+
+#### Warm server mode (optional, recommended for parallel runs)
+
+Start a persistent OpenCode server to avoid MCP cold-start overhead per batch:
+
+```
+opencode serve --port 4096 &
+export DESLOPPIFY_OPENCODE_ATTACH=http://localhost:4096
+desloppify review --run-batches --runner opencode --parallel --scan-after-import
+```
+
+When `DESLOPPIFY_OPENCODE_ATTACH` is set, each batch subprocess attaches to the running server via `--attach <url>` instead of spawning a fresh instance.
+
+#### Preparing a review manually
+
+1. **Prepare**: `desloppify review --prepare` — writes `query.json` and `.desloppify/review_packet_blind.json`.
+2. **Run batches**: `desloppify review --run-batches --runner opencode --parallel --scan-after-import`
+
+The runner handles batch splitting, prompt generation, parallel execution, retry/stall detection, result extraction, merge, and trusted import automatically.
+
 <!-- desloppify-overlay: opencode -->
 <!-- desloppify-end -->


### PR DESCRIPTION
## Problem

The batch review pipeline (`desloppify review --run-batches`) only supports Codex as a runner. There is no way to use OpenCode as the execution engine, even though the infrastructure (NDJSON stream parsing, subprocess management, retry/stall detection) is largely runner-agnostic.

## Fix

Add `--runner opencode` support to the batch review pipeline. When selected, batches are executed via `opencode run --format json` subprocesses instead of Codex, with results extracted from the NDJSON stream and merged through the same trusted-import pipeline.

### Changes

- **`runner_process.py`** (new): `run_opencode_batch` implementation — builds OpenCode CLI invocations, supports warm-server attach via `DESLOPPIFY_OPENCODE_ATTACH`, handles NDJSON result extraction
- **`orchestrator.py`**: wire runner dispatch — `_build_batch_run_deps` now selects `run_opencode_batch` or `run_codex_batch` based on `args.runner`
- **CLI parsing**: add `--runner` argument with `codex`/`opencode` choices
- **`scope.py`**: `validate_runner()` accepts both runner names, `SUPPORTED_BLIND_REVIEW_RUNNERS` updated
- **`runner_process_impl/io.py`**: add `_extract_text_from_opencode_json_stream()` for NDJSON parsing
- **`runner_process_impl/attempts.py`**, **`types.py`**, **`attempt_success.py`**: extend subprocess handling to support OpenCode process lifecycle
- **`runner_failures.py`**: classify OpenCode-specific failure modes
- **`importing/policy.py`**: allow OpenCode runner in blind review import policy
- **`packet/build.py`**, **`prepare.py`**, **`helpers.py`**: minor adjustments for runner-agnostic packet preparation
- **`docs/OPENCODE.md`**: usage documentation covering basic and warm-server modes
- **Tests**: ~1500 lines of new/updated test coverage across `review_commands_cases.py`, `test_runner_internals.py`, `review_commands_runner_cases.py`, and batch split/guard tests

### Usage

```
desloppify review --run-batches --runner opencode --parallel --scan-after-import
```

Optional warm-server mode to avoid MCP cold-start overhead:

```
opencode serve --port 4096 &
export DESLOPPIFY_OPENCODE_ATTACH=http://localhost:4096
desloppify review --run-batches --runner opencode --parallel --scan-after-import
```

## Verification

- `pytest desloppify/tests/review/test_runner_internals.py -q`
- `pytest desloppify/tests/review/review_commands_cases.py -q`
- `pytest desloppify/tests/review/review_commands_runner_cases.py -q`
- `pytest desloppify/tests/commands/review/test_review_process_guards_direct.py -q`
- `pytest desloppify/tests/commands/review/test_review_runner_batch_split_direct.py -q`