### PR TITLE
feat: add OpenCode as alternative batch review runner

### DIFF
--- a/desloppify/app/cli_support/parser_groups_admin_review.py
+++ b/desloppify/app/cli_support/parser_groups_admin_review.py
@@ -22,6 +22,7 @@ def _add_review_parser(sub) -> None:
 examples:
   desloppify review --prepare
   desloppify review --run-batches --runner codex --parallel --scan-after-import
+  desloppify review --run-batches --runner opencode --parallel --scan-after-import
   desloppify review --external-start --external-runner claude
   desloppify review --external-submit --session-id <id> --import issues.json
   desloppify review --merge --similarity 0.8""",

--- a/desloppify/app/cli_support/parser_groups_admin_review_options_batch.py
+++ b/desloppify/app/cli_support/parser_groups_admin_review_options_batch.py
@@ -14,7 +14,7 @@ def _add_batch_execution_options(p_review: argparse.ArgumentParser) -> None:
     )
     g_batch.add_argument(
         "--runner",
-        choices=["codex"],
+        choices=["codex", "opencode"],
         default="codex",
         help="Subagent runner backend (default: codex)",
     )

--- a/desloppify/app/commands/review/batch/orchestrator.py
+++ b/desloppify/app/commands/review/batch/orchestrator.py
@@ -48,6 +48,7 @@ from desloppify.app.commands.runner.codex_batch import (
     run_codex_batch,
     run_followup_scan,
 )
+from ..runner_opencode import run_opencode_batch
 from ..runtime.setup import setup_lang_concrete as _setup_lang
 from ..runtime_paths import (
     blind_packet_path as _blind_packet_path,
@@ -105,7 +106,7 @@ def _batch_live_log_interval_seconds(heartbeat_seconds: float) -> float:
     return max(1.0, min(heartbeat_seconds, 10.0))
 
 
-def _build_batch_run_deps(*, policy, project_root: Path) -> review_batches_mod.BatchRunDeps:
+def _build_batch_run_deps(*, args, policy, project_root: Path) -> review_batches_mod.BatchRunDeps:
     """Build the dependency bundle used by prepare/execute/import phases."""
     from desloppify.engine.plan_state import load_policy_result, render_policy_block
 
@@ -161,7 +162,7 @@ def _build_batch_run_deps(*, policy, project_root: Path) -> review_batches_mod.B
             colorize_fn=colorize,
         ),
         run_codex_batch_fn=partial(
-            run_codex_batch,
+            run_opencode_batch if getattr(args, "runner", "codex") == "opencode" else run_codex_batch,
             deps=codex_batch_deps,
         ),
         execute_batches_fn=lambda **kwargs: execute_batches(
@@ -384,6 +385,7 @@ def do_run_batches(args, state, lang, state_file, config: dict | None = None) ->
     subagent_runs_dir = _subagent_runs_dir()
     policy = resolve_batch_run_policy(args)
     batch_deps = _build_batch_run_deps(
+        args=args,
         policy=policy,
         project_root=project_root,
     )

--- a/desloppify/app/commands/review/batch/scope.py
+++ b/desloppify/app/commands/review/batch/scope.py
@@ -14,12 +14,16 @@ from desloppify.intelligence.review.feedback_contract import (
 )
 
 
+_SUPPORTED_RUNNERS = {"codex", "opencode"}
+
+
 def validate_runner(runner: str, *, colorize_fn) -> None:
     """Validate review batch runner."""
-    if runner == "codex":
+    if runner in _SUPPORTED_RUNNERS:
         return
+    supported = ", ".join(sorted(_SUPPORTED_RUNNERS))
     raise CommandError(
-        f"Error: unsupported runner '{runner}' (supported: codex)", exit_code=2
+        f"Error: unsupported runner '{runner}' (supported: {supported})", exit_code=2
     )
 
 

--- a/desloppify/app/commands/review/importing/policy.py
+++ b/desloppify/app/commands/review/importing/policy.py
@@ -20,7 +20,7 @@ from ..runtime_paths import blind_packet_path, runtime_project_root
 
 ASSESSMENT_POLICY_KEY = "_assessment_policy"
 BLIND_PROVENANCE_KIND = "blind_review_batch_import"
-SUPPORTED_BLIND_REVIEW_RUNNERS = {"codex", "claude"}
+SUPPORTED_BLIND_REVIEW_RUNNERS = {"codex", "claude", "opencode"}
 ATTESTED_EXTERNAL_RUNNERS = {"claude"}
 ATTESTED_EXTERNAL_REQUIRED_PHRASES = ("without awareness", "unbiased")
 ATTESTED_EXTERNAL_ATTEST_EXAMPLE = (

--- a/desloppify/app/commands/review/runner_failures.py
+++ b/desloppify/app/commands/review/runner_failures.py
@@ -45,15 +45,19 @@ _RUNNER_AUTH_PHRASES = (
 )
 _FAILURE_HINT_BY_CATEGORY = {
     "runner_missing": (
-        "codex CLI not found on PATH. Install Codex CLI and verify `codex --version`."
+        "Runner CLI not found on PATH. "
+        "Install the runner (codex or opencode) and verify it is on your PATH."
     ),
-    "runner_auth": "codex runner appears unauthenticated. Run `codex login` and retry.",
+    "runner_auth": (
+        "Runner appears unauthenticated. "
+        "For Codex run `codex login`; for OpenCode check your auth configuration."
+    ),
     "usage_limit": (
-        "Codex usage quota is exhausted for this account. "
+        "Runner usage quota is exhausted for this account. "
         "Wait for reset or add credits, then rerun failed batches."
     ),
     "stream_disconnect": (
-        "Transient Codex connectivity issue detected. Retry with "
+        "Transient runner connectivity issue detected. Retry with "
         "`--batch-max-retries 2 --batch-retry-backoff-seconds 2` and, if needed, "
         "lower concurrency via `--max-parallel-batches 1`."
     ),
@@ -61,12 +65,14 @@ _FAILURE_HINT_BY_CATEGORY = {
 
 
 def _is_runner_missing(text: str) -> bool:
-    return (
-        "codex not found" in text
-        or ("no such file or directory" in text and "$ codex " in text)
-        or ("errno 2" in text and "codex" in text)
-        or ("winerror 2" in text and "codex" in text)
-    )
+    for runner_name in ("codex", "opencode"):
+        if f"{runner_name} not found" in text:
+            return True
+        if "no such file or directory" in text and f"$ {runner_name} " in text:
+            return True
+        if "errno 2" in text and runner_name in text:
+            return True
+    return False
 
 
 def _is_runner_auth_failure(text: str) -> bool:

--- a/desloppify/app/commands/review/runner_opencode.py
+++ b/desloppify/app/commands/review/runner_opencode.py
@@ -1,0 +1,237 @@
+"""OpenCode batch runner for review batch execution."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from desloppify.app.commands.runner.codex_batch import CodexBatchRunnerDeps
+
+from .runner_process_impl.attempts import (
+    handle_early_attempt_return as _handle_early_attempt_return,
+    handle_failed_attempt as _handle_failed_attempt,
+    handle_successful_attempt as _handle_successful_attempt,
+    handle_timeout_or_stall as _handle_timeout_or_stall,
+    resolve_retry_config as _resolve_retry_config,
+    run_batch_attempt as _run_batch_attempt,
+)
+from .runner_process_impl.io import (
+    _extract_text_from_opencode_json_stream,
+    _output_file_has_json_payload,
+)
+
+
+def opencode_batch_command(*, prompt: str, repo_root: Path) -> list[str]:
+    """Build one ``opencode run`` command line for a batch prompt."""
+    cmd = ["opencode", "run", "--format", "json"]
+    model = os.environ.get("DESLOPPIFY_OPENCODE_MODEL", "").strip()
+    if model:
+        cmd.extend(["--model", model])
+    variant = os.environ.get("DESLOPPIFY_OPENCODE_VARIANT", "").strip()
+    if variant:
+        cmd.extend(["--variant", variant])
+    attach_url = os.environ.get("DESLOPPIFY_OPENCODE_ATTACH", "").strip()
+    if attach_url:
+        cmd.extend(["--attach", attach_url])
+    cmd.extend(["--dir", str(repo_root)])
+    cmd.append(prompt)
+    return cmd
+
+
+def _capture_opencode_stdout_payload(
+    *, result, output_file: Path, deps: CodexBatchRunnerDeps
+) -> str | None:
+    """Extract and persist a recoverable OpenCode payload from NDJSON stdout."""
+    extracted_text = _extract_text_from_opencode_json_stream(result.stdout_text)
+    return _persist_opencode_payload_text(
+        extracted_text=extracted_text,
+        output_file=output_file,
+        deps=deps,
+    )
+
+
+def _persist_opencode_payload_text(
+    *, extracted_text: str, output_file: Path, deps: CodexBatchRunnerDeps
+) -> str | None:
+    """Persist OpenCode output only when it is a complete JSON object."""
+    normalized_text = extracted_text.strip()
+    if not normalized_text:
+        return None
+    try:
+        payload = json.loads(normalized_text)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    try:
+        deps.safe_write_text_fn(output_file, normalized_text)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+    return normalized_text
+
+
+def _build_live_opencode_stdout_observer(
+    *, output_file: Path, deps: CodexBatchRunnerDeps
+):
+    """Persist recoverable OpenCode payloads while stdout is still streaming."""
+    last_persisted_text: str | None = None
+
+    def _observe(stdout_text: str) -> None:
+        nonlocal last_persisted_text
+        extracted_text = _extract_text_from_opencode_json_stream(stdout_text)
+        normalized_text = extracted_text.strip()
+        if not normalized_text or normalized_text == last_persisted_text:
+            return
+        persisted_text = _persist_opencode_payload_text(
+            extracted_text=normalized_text,
+            output_file=output_file,
+            deps=deps,
+        )
+        if persisted_text is not None:
+            last_persisted_text = persisted_text
+
+    return _observe
+
+
+def _restore_opencode_recoverable_payload(
+    *, recoverable_text: str | None, output_file: Path, deps: CodexBatchRunnerDeps
+) -> None:
+    """Restore the last known-good OpenCode payload for downstream recovery."""
+    if not recoverable_text or _output_file_has_json_payload(output_file):
+        return
+    try:
+        deps.safe_write_text_fn(output_file, recoverable_text)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return
+
+
+def run_opencode_batch(
+    *,
+    prompt: str,
+    repo_root: Path,
+    output_file: Path,
+    log_file: Path,
+    deps: CodexBatchRunnerDeps,
+    opencode_batch_command_fn=None,
+) -> int:
+    """Execute one OpenCode batch and return a stable CLI-style status code."""
+    if opencode_batch_command_fn is None:
+        opencode_batch_command_fn = opencode_batch_command
+    cmd = opencode_batch_command_fn(
+        prompt=prompt,
+        repo_root=repo_root,
+    )
+    config = _resolve_retry_config(deps)
+    log_sections: list[str] = []
+    recoverable_output_text: str | None = None
+
+    for attempt in range(1, config.max_attempts + 1):
+        try:
+            if output_file.exists():
+                output_file.unlink()
+        except OSError:
+            pass
+
+        stdout_text_observer = _build_live_opencode_stdout_observer(
+            output_file=output_file,
+            deps=deps,
+        )
+
+        header, result = _run_batch_attempt(
+            cmd=cmd,
+            deps=deps,
+            output_file=output_file,
+            log_file=log_file,
+            log_sections=log_sections,
+            attempt=attempt,
+            max_attempts=config.max_attempts,
+            use_popen=config.use_popen,
+            live_log_interval=config.live_log_interval,
+            stall_seconds=config.stall_seconds,
+            stdout_text_observer=stdout_text_observer,
+        )
+        early_return = _handle_early_attempt_return(result)
+        if early_return is not None:
+            return early_return
+
+        current_payload_text = _capture_opencode_stdout_payload(
+            result=result,
+            output_file=output_file,
+            deps=deps,
+        )
+        if current_payload_text is not None:
+            recoverable_output_text = current_payload_text
+
+        timeout_or_stall = _handle_timeout_or_stall(
+            header=header,
+            result=result,
+            deps=deps,
+            output_file=output_file,
+            log_file=log_file,
+            log_sections=log_sections,
+            stall_seconds=config.stall_seconds,
+        )
+        if timeout_or_stall is not None:
+            if timeout_or_stall == 0:
+                return 0
+            if attempt < config.max_attempts:
+                delay = config.retry_backoff_seconds * (2 ** (attempt - 1))
+                log_sections.append(
+                    f"Timeout/stall on attempt {attempt}/{config.max_attempts}; "
+                    f"retrying in {delay:.1f}s."
+                )
+                if delay > 0:
+                    deps.sleep_fn(delay)
+                continue
+            _restore_opencode_recoverable_payload(
+                recoverable_text=recoverable_output_text,
+                output_file=output_file,
+                deps=deps,
+            )
+            return timeout_or_stall
+
+        log_sections.append(
+            f"{header}\n\nSTDOUT:\n{result.stdout_text}\n\nSTDERR:\n{result.stderr_text}\n"
+        )
+
+        success_code = _handle_successful_attempt(
+            result=result,
+            output_file=output_file,
+            log_file=log_file,
+            deps=deps,
+            log_sections=log_sections,
+        )
+        if success_code is not None:
+            return success_code
+
+        failure_code = _handle_failed_attempt(
+            result=result,
+            deps=deps,
+            attempt=attempt,
+            max_attempts=config.max_attempts,
+            retry_backoff_seconds=config.retry_backoff_seconds,
+            log_file=log_file,
+            log_sections=log_sections,
+        )
+        if failure_code is not None:
+            _restore_opencode_recoverable_payload(
+                recoverable_text=recoverable_output_text,
+                output_file=output_file,
+                deps=deps,
+            )
+            return failure_code
+
+    _restore_opencode_recoverable_payload(
+        recoverable_text=recoverable_output_text,
+        output_file=output_file,
+        deps=deps,
+    )
+    deps.safe_write_text_fn(log_file, "\n\n".join(log_sections))
+    return 1
+
+
+__all__ = [
+    "opencode_batch_command",
+    "run_opencode_batch",
+]

--- a/desloppify/app/commands/review/runner_process_impl/attempts.py
+++ b/desloppify/app/commands/review/runner_process_impl/attempts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import subprocess  # nosec
 import threading
 import time
@@ -71,13 +72,18 @@ def _run_via_popen(
     ctx: _AttemptContext,
     interval: float,
     stall_seconds: int,
+    stdout_text_observer: Callable[[str], None] | None = None,
 ) -> _ExecutionResult:
     with _managed_live_writer(state, ctx, interval):
         process_or_error = _start_runner_process(cmd, deps, ctx)
         if isinstance(process_or_error, _ExecutionResult):
             return process_or_error
         process = process_or_error
-        stdout_thread, stderr_thread = _start_stream_threads(process, state)
+        stdout_thread, stderr_thread = _start_stream_threads(
+            process,
+            state,
+            stdout_text_observer=stdout_text_observer,
+        )
         timed_out, stalled, recovered_from_stall = _monitor_runner_process(
             process,
             deps=deps,
@@ -135,10 +141,13 @@ def _start_runner_process(
 def _start_stream_threads(
     process: subprocess.Popen[str],
     state: _RunnerState,
+    *,
+    stdout_text_observer: Callable[[str], None] | None = None,
 ) -> tuple[threading.Thread, threading.Thread]:
     stdout_thread = threading.Thread(
         target=_drain_stream,
         args=(process.stdout, state.stdout_chunks, state),
+        kwargs={"stdout_text_observer": stdout_text_observer},
         daemon=True,
     )
     stderr_thread = threading.Thread(
@@ -333,6 +342,7 @@ def run_batch_attempt(
     use_popen: bool,
     live_log_interval: float,
     stall_seconds: int,
+    stdout_text_observer: Callable[[str], None] | None = None,
 ) -> tuple[str, _ExecutionResult]:
     header = f"ATTEMPT {attempt}/{max_attempts}\n$ {' '.join(cmd)}"
     started_monotonic = time.monotonic()
@@ -355,6 +365,7 @@ def run_batch_attempt(
             ctx,
             live_log_interval,
             stall_seconds,
+            stdout_text_observer,
         )
     else:
         result = _run_via_subprocess(cmd, deps, state, ctx, live_log_interval)

--- a/desloppify/app/commands/review/runner_process_impl/io.py
+++ b/desloppify/app/commands/review/runner_process_impl/io.py
@@ -7,6 +7,7 @@ import logging
 import subprocess  # nosec
 import threading
 import time
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -104,7 +105,12 @@ def _terminate_process(process: subprocess.Popen[str]) -> None:
         return
 
 
-def _drain_stream(stream, sink: list[str], state: _RunnerState) -> None:
+def _drain_stream(
+    stream,
+    sink: list[str],
+    state: _RunnerState,
+    stdout_text_observer: Callable[[str], None] | None = None,
+) -> None:
     """Read lines from *stream* into *sink*, updating activity timestamp."""
     if stream is None:
         return
@@ -112,9 +118,17 @@ def _drain_stream(stream, sink: list[str], state: _RunnerState) -> None:
         for chunk in iter(stream.readline, ""):
             if not chunk:
                 break
+            current_stdout = None
             with state.lock:
                 sink.append(chunk)
                 state.last_stream_activity = time.monotonic()
+                if stdout_text_observer is not None:
+                    current_stdout = "".join(sink)
+            if stdout_text_observer is not None and current_stdout is not None:
+                try:
+                    stdout_text_observer(current_stdout)
+                except (OSError, RuntimeError, TypeError, ValueError):
+                    continue
     except (OSError, ValueError) as exc:  # pragma: no cover - defensive boundary
         with state.lock:
             sink.append(f"\n[stream read error: {exc}]\n")
@@ -209,10 +223,84 @@ def _check_stall(
     return False, prev_sig, prev_stable
 
 
+def _extract_text_from_opencode_json_stream(raw: str) -> str:
+    """Extract assistant text from OpenCode ``--format json`` NDJSON output.
+
+    OpenCode emits newline-delimited JSON events.  Text content lives in
+    events where ``event["type"] == "text"`` under ``event["part"]["text"]``.
+    Only completed assistant steps should be returned.  Earlier planning,
+    pre-tool text, or any other in-progress step content must not be mixed into
+    the final payload, because downstream JSON extraction accepts the first
+    matching review object.
+    """
+    saw_step_events = False
+    saw_tool_calls_step = False
+    step_in_progress = False
+    fallback_text_parts: list[str] = []
+    current_step_parts: list[str] = []
+    last_completed_step_text = ""
+    final_step_text = ""
+
+    for line in raw.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(event, dict):
+            continue
+        event_type = str(event.get("type", "")).strip()
+        part = event.get("part")
+        part_dict = part if isinstance(part, dict) else {}
+
+        if event_type == "step_start":
+            saw_step_events = True
+            step_in_progress = True
+            current_step_parts = []
+            continue
+
+        if event_type == "text":
+            text_value = str(part_dict.get("text", ""))
+            fallback_text_parts.append(text_value)
+            current_step_parts.append(text_value)
+            continue
+
+        if event_type != "step_finish":
+            continue
+
+        saw_step_events = True
+        step_in_progress = False
+        current_step_text = "".join(current_step_parts)
+        reason = str(part_dict.get("reason", "")).strip()
+
+        if reason == "tool-calls":
+            saw_tool_calls_step = True
+            current_step_parts = []
+            continue
+
+        last_completed_step_text = current_step_text
+        current_step_parts = []
+        if reason == "stop":
+            final_step_text = current_step_text
+
+    if final_step_text:
+        return final_step_text
+    if saw_tool_calls_step or step_in_progress:
+        return ""
+    if saw_step_events:
+        if last_completed_step_text:
+            return last_completed_step_text
+        return ""
+    return "".join(fallback_text_parts)
+
+
 __all__ = [
     "_check_stall",
     "_drain_stream",
     "extract_payload_from_log",
+    "_extract_text_from_opencode_json_stream",
     "_output_file_has_json_payload",
     "_output_file_status_text",
     "_start_live_writer",

--- a/desloppify/app/commands/scan/reporting/subjective.py
+++ b/desloppify/app/commands/scan/reporting/subjective.py
@@ -99,7 +99,8 @@ def subjective_rerun_command(
         command_parts = ["desloppify", "review", "--prepare"]
         if dim_keys:
             command_parts.extend(["--dimensions", dim_keys])
-        return f"`{' '.join(command_parts)}`"
+        cmd = f"`{' '.join(command_parts)}`"
+        return f"{cmd} (set up `--runner codex` or `--runner opencode` for automated reviews)"
 
     command_parts = [
         "desloppify",

--- a/desloppify/data/global/OPENCODE.md
+++ b/desloppify/data/global/OPENCODE.md
@@ -2,5 +2,34 @@
 
 When installed (via `desloppify update-skill opencode`), OpenCode automatically loads this skill for code quality, technical debt, and health score questions.
 
+### Review workflow
+
+Use the native `--runner opencode` for automated batch reviews:
+
+```
+desloppify review --run-batches --runner opencode --parallel --scan-after-import
+```
+
+This spawns OpenCode subprocesses (`opencode run --format json`) for each batch, extracts results from the NDJSON stream, merges them, and imports as trusted assessments — identical pipeline to the Codex runner but using OpenCode as the execution engine.
+
+#### Warm server mode (optional, recommended for parallel runs)
+
+Start a persistent OpenCode server to avoid MCP cold-start overhead per batch:
+
+```
+opencode serve --port 4096 &
+export DESLOPPIFY_OPENCODE_ATTACH=http://localhost:4096
+desloppify review --run-batches --runner opencode --parallel --scan-after-import
+```
+
+When `DESLOPPIFY_OPENCODE_ATTACH` is set, each batch subprocess attaches to the running server via `--attach <url>` instead of spawning a fresh instance.
+
+#### Preparing a review manually
+
+1. **Prepare**: `desloppify review --prepare` — writes `query.json` and `.desloppify/review_packet_blind.json`.
+2. **Run batches**: `desloppify review --run-batches --runner opencode --parallel --scan-after-import`
+
+The runner handles batch splitting, prompt generation, parallel execution, retry/stall detection, result extraction, merge, and trusted import automatically.
+
 <!-- desloppify-overlay: opencode -->
 <!-- desloppify-end -->

--- a/desloppify/intelligence/review/_prepare/helpers.py
+++ b/desloppify/intelligence/review/_prepare/helpers.py
@@ -11,6 +11,7 @@ HOLISTIC_WORKFLOW = [
     "IMPORTANT: issues must be defects only — never positive observations. High scores capture quality; issues capture problems.",
     "Write ALL issues to issues.json — do NOT fix code before importing. Import creates tracked state entries that let desloppify correlate fixes to issues.",
     "Codex: desloppify review --run-batches --runner codex --parallel --scan-after-import",
+    "OpenCode: desloppify review --run-batches --runner opencode --parallel --scan-after-import",
     "Claude / other agent: desloppify review --run-batches --dry-run → launch one subagent per prompt file (all in parallel) → desloppify review --import-run <run-dir> --scan-after-import",
     "Cloud/external: run `desloppify review --external-start --external-runner claude`, follow the session template, then run the printed `--external-submit` command",
     "Fallback path: `desloppify review --import issues.json` (issues only). Use manual override only for emergency/provisional imports.",

--- a/desloppify/tests/commands/review/test_review_batch_execution_helpers_direct.py
+++ b/desloppify/tests/commands/review/test_review_batch_execution_helpers_direct.py
@@ -488,3 +488,35 @@ def test_try_load_prepared_packet_rejects_state_scope_mismatch(
 
     assert packet is None
     assert mismatch == "contract field 'state_path' differs"
+
+
+def test_build_batch_run_deps_selects_opencode_runner(tmp_path: Path) -> None:
+    deps = orchestrator_mod._build_batch_run_deps(
+        args=SimpleNamespace(runner="opencode"),
+        policy=SimpleNamespace(
+            batch_timeout_seconds=60,
+            heartbeat_seconds=1.0,
+            stall_kill_seconds=30,
+            batch_max_retries=1,
+            batch_retry_backoff_seconds=0.5,
+        ),
+        project_root=tmp_path,
+    )
+
+    assert deps.run_codex_batch_fn.func is orchestrator_mod.run_opencode_batch
+
+
+def test_build_batch_run_deps_keeps_codex_runner_default(tmp_path: Path) -> None:
+    deps = orchestrator_mod._build_batch_run_deps(
+        args=SimpleNamespace(runner="codex"),
+        policy=SimpleNamespace(
+            batch_timeout_seconds=60,
+            heartbeat_seconds=1.0,
+            stall_kill_seconds=30,
+            batch_max_retries=1,
+            batch_retry_backoff_seconds=0.5,
+        ),
+        project_root=tmp_path,
+    )
+
+    assert deps.run_codex_batch_fn.func is orchestrator_mod.run_codex_batch

--- a/desloppify/tests/commands/review/test_review_process_guards_direct.py
+++ b/desloppify/tests/commands/review/test_review_process_guards_direct.py
@@ -265,6 +265,43 @@ def test_import_attested_external_rejects_non_claude_runner(tmp_path, capsys):
     assert "Hint: if provenance is valid, rerun with" in err
 
 
+def test_import_external_opencode_provenance_still_defaults_to_issues_only(tmp_path):
+    blind_packet = tmp_path / "review_packet_blind.json"
+    blind_packet.write_text(json.dumps({"command": "review", "dimensions": ["naming_quality"]}))
+    packet_hash = hashlib.sha256(blind_packet.read_bytes()).hexdigest()
+
+    payload = {
+        "issues": [
+            {
+                "dimension": "naming_quality",
+                "identifier": "process_data",
+                "summary": "Function name is generic for a payment-reconciliation path.",
+                "related_files": ["src/service.ts"],
+                "evidence": ["Name does not describe side effects or domain operation."],
+                "suggestion": "Rename to reconcile_customer_payment.",
+                "confidence": "high",
+            }
+        ],
+        "assessments": {"naming_quality": 95},
+        "provenance": {
+            "kind": "blind_review_batch_import",
+            "blind": True,
+            "runner": "opencode",
+            "packet_path": str(blind_packet),
+            "packet_sha256": packet_hash,
+        },
+    }
+    issues_path = tmp_path / "issues.json"
+    issues_path.write_text(json.dumps(payload))
+
+    parsed = load_import_issues_data(str(issues_path), config=ImportLoadConfig())
+    assert parsed["assessments"] == {}
+    policy = parsed.get("_assessment_policy", {})
+    assert policy["mode"] == "issues_only"
+    assert policy["trusted"] is False
+    assert "cannot self-attest trust" in policy["reason"]
+
+
 def test_import_attested_external_rejects_allow_partial_combo(tmp_path, capsys):
     payload = {
         "issues": [],

--- a/desloppify/tests/commands/review/test_review_runner_helpers_direct.py
+++ b/desloppify/tests/commands/review/test_review_runner_helpers_direct.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import time
 from pathlib import Path
+from unittest.mock import patch
 
+import desloppify.app.commands.review.batch.orchestrator as orchestrator_mod
 import desloppify.app.commands.review.batch.prompt_template as prompt_template_mod
+import desloppify.app.commands.review.runner_opencode as runner_opencode_mod
 import desloppify.app.commands.review.runner_parallel as runner_helpers_mod
 from desloppify.app.commands.review.batch.execution import CollectBatchResultsRequest
+from desloppify.app.commands.review.runner_process_impl.types import _ExecutionResult
 
 
 def test_execute_batches_parallel_emits_heartbeat_event() -> None:
@@ -140,3 +145,97 @@ def test_render_batch_prompt_loads_context_updates_example() -> None:
     )
 
     assert "context_updates example" in prompt
+
+
+def _safe_write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def test_run_opencode_batch_recovers_timeout_from_stdout_payload(tmp_path: Path) -> None:
+    log_file = tmp_path / "batch.log"
+    output_file = tmp_path / "out.json"
+    stale_payload = {"assessments": {"logic_clarity": 12}, "issues": []}
+    payload = {"assessments": {"logic_clarity": 88}, "issues": []}
+    stdout_text = "\n".join([
+        json.dumps({"type": "step_start", "part": {"type": "step-start"}}),
+        json.dumps({"type": "text", "part": {"type": "text", "text": f"planning {json.dumps(stale_payload)}"}}),
+        json.dumps({"type": "step_finish", "part": {"type": "step-finish", "reason": "tool-calls"}}),
+        json.dumps({"type": "step_start", "part": {"type": "step-start"}}),
+        json.dumps({"type": "text", "part": {"type": "text", "text": json.dumps(payload)}}),
+        json.dumps({"type": "step_finish", "part": {"type": "step-finish", "reason": "stop"}}),
+        "",
+    ])
+
+    with patch(
+        "desloppify.app.commands.review.runner_opencode._run_batch_attempt",
+        return_value=(
+            "ATTEMPT 1/1",
+            _ExecutionResult(code=1, stdout_text=stdout_text, stderr_text="", timed_out=True),
+        ),
+    ):
+        code = runner_opencode_mod.run_opencode_batch(
+            prompt="test prompt",
+            repo_root=tmp_path,
+            output_file=output_file,
+            log_file=log_file,
+            deps=orchestrator_mod.CodexBatchRunnerDeps(
+                timeout_seconds=60,
+                subprocess_run=subprocess.run,
+                timeout_error=TimeoutError,
+                safe_write_text_fn=_safe_write_text,
+                sleep_fn=lambda _seconds: None,
+            ),
+        )
+
+    assert code == 0
+    assert json.loads(output_file.read_text()) == payload
+    assert "Recovered timed-out batch from JSON output file" in log_file.read_text()
+
+
+def test_run_opencode_batch_restores_valid_output_after_retry_failure(tmp_path: Path) -> None:
+    output_file = tmp_path / "batch-1.raw.txt"
+    log_file = tmp_path / "batch-1.log"
+    first_payload = {"assessments": {"logic_clarity": 10}, "issues": []}
+    first_stdout = json.dumps({"type": "text", "part": {"type": "text", "text": json.dumps(first_payload)}}) + "\n"
+
+    with patch(
+        "desloppify.app.commands.review.runner_opencode._run_batch_attempt",
+        side_effect=[
+            ("ATTEMPT 1/2", _ExecutionResult(code=1, stdout_text=first_stdout, stderr_text="stream disconnected before completion")),
+            ("ATTEMPT 2/2", _ExecutionResult(code=1, stdout_text="", stderr_text="fatal auth error")),
+        ],
+    ):
+        code = runner_opencode_mod.run_opencode_batch(
+            prompt="test prompt",
+            repo_root=tmp_path,
+            output_file=output_file,
+            log_file=log_file,
+            deps=orchestrator_mod.CodexBatchRunnerDeps(
+                timeout_seconds=60,
+                subprocess_run=subprocess.run,
+                timeout_error=TimeoutError,
+                safe_write_text_fn=_safe_write_text,
+                max_retries=1,
+                retry_backoff_seconds=0.0,
+                sleep_fn=lambda _seconds: None,
+            ),
+        )
+
+    assert code == 1
+    assert json.loads(output_file.read_text()) == first_payload
+
+    batch_results, failures = runner_helpers_mod.collect_batch_results(
+        request=CollectBatchResultsRequest(
+            selected_indexes=[0],
+            failures=[0],
+            output_files={0: output_file},
+            allowed_dims={"logic_clarity"},
+        ),
+        extract_payload_fn=lambda raw: json.loads(raw),
+        normalize_result_fn=lambda payload, _dims: (payload.get("assessments", {}), payload.get("issues", []), {}, {}, {}, {}),
+    )
+
+    assert len(batch_results) == 1
+    assert failures == []
+    assert batch_results[0].assessments == first_payload["assessments"]

--- a/desloppify/tests/commands/test_direct_coverage_queue_batch_modules.py
+++ b/desloppify/tests/commands/test_direct_coverage_queue_batch_modules.py
@@ -13,6 +13,7 @@ import desloppify.app.commands.review.batches_runtime as batches_runtime_mod
 import desloppify.app.commands.review.coordinator as coordinator_mod
 import desloppify.app.commands.review.packet.build as packet_build_mod
 import desloppify.app.commands.review.runner_failures as runner_failures_mod
+import desloppify.app.commands.review.runner_opencode as runner_opencode_mod
 import desloppify.app.commands.review.runner_packets as runner_packets_mod
 import desloppify.app.commands.review.runner_parallel as runner_parallel_mod
 import desloppify.app.commands.runner.codex_batch as runner_process_mod
@@ -44,6 +45,8 @@ def test_direct_coverage_split_queue_batch_modules_smoke():
     assert callable(packet_build_mod.build_review_packet_payload)
     assert callable(packet_build_mod.write_review_packet_snapshot)
     assert callable(runner_failures_mod.print_failures)
+    assert callable(runner_opencode_mod.run_opencode_batch)
+    assert callable(runner_opencode_mod.opencode_batch_command)
     assert callable(runner_packets_mod.prepare_run_artifacts)
     assert callable(runner_parallel_mod.execute_batches)
     assert callable(runner_process_mod.run_codex_batch)

--- a/desloppify/tests/commands/test_parser_groups_admin_review.py
+++ b/desloppify/tests/commands/test_parser_groups_admin_review.py
@@ -19,6 +19,18 @@ def test_add_review_parser_registers_review_command_with_core_flags() -> None:
     assert args.runner == "codex"
 
 
+def test_add_review_parser_accepts_opencode_runner() -> None:
+    parser = argparse.ArgumentParser(prog="desloppify")
+    sub = parser.add_subparsers(dest="command")
+
+    review_group_mod._add_review_parser(sub)
+
+    args = parser.parse_args(["review", "--prepare", "--runner", "opencode"])
+    assert args.command == "review"
+    assert args.prepare is True
+    assert args.runner == "opencode"
+
+
 def test_add_review_parser_invokes_each_option_group_builder_once(monkeypatch) -> None:
     parser = argparse.ArgumentParser(prog="desloppify")
     sub = parser.add_subparsers(dest="command")

--- a/desloppify/tests/review/review_commands_runner_cases.py
+++ b/desloppify/tests/review/review_commands_runner_cases.py
@@ -219,7 +219,7 @@ class TestCmdReviewPrepareRunnerHelpers:
         assert exc_info.value.exit_code == 1
         err = capsys.readouterr().err
         assert "Environment hints:" in err
-        assert "codex CLI not found on PATH" in err
+        assert "Runner CLI not found on PATH" in err
 
     def test_print_failures_and_raise_shows_codex_auth_hint(self, tmp_path, capsys):
 

--- a/desloppify/tests/review/test_runner_internals.py
+++ b/desloppify/tests/review/test_runner_internals.py
@@ -22,6 +22,7 @@ from desloppify.app.commands.review.runner_process_impl.attempts import (
 )
 from desloppify.app.commands.review.runner_process_impl.io import (
     _check_stall,
+    _extract_text_from_opencode_json_stream,
     _output_file_has_json_payload,
     _output_file_status_text,
     extract_payload_from_log,
@@ -756,3 +757,66 @@ class TestHandleFailedAttempt:
 # ═══════════════════════════════════════════════════════════════════
 
 
+
+
+class TestExtractTextFromOpenCodeJsonStream:
+    """_extract_text_from_opencode_json_stream: extracts terminal assistant text."""
+
+    def test_terminal_stop_step_wins_over_planning_text(self):
+        final_payload = json.dumps({"assessments": {}})
+        planning_payload = json.dumps(
+            {"assessments": {"logic_clarity": 10}, "issues": []}
+        )
+        stream = (
+            '{"type":"step_start","part":{"type":"step-start"}}\n'
+            + json.dumps(
+                {
+                    "type": "text",
+                    "part": {"type": "text", "text": f"planning {planning_payload}"},
+                }
+            )
+            + "\n"
+            + '{"type":"step_finish","part":{"type":"step-finish","reason":"tool-calls"}}\n'
+            + '{"type":"step_start","part":{"type":"step-start"}}\n'
+            + json.dumps(
+                {
+                    "type": "text",
+                    "part": {"type": "text", "text": final_payload},
+                }
+            )
+            + "\n"
+            + '{"type":"step_finish","part":{"type":"step-finish","reason":"stop"}}\n'
+        )
+        assert _extract_text_from_opencode_json_stream(stream) == final_payload
+
+    def test_in_progress_step_returns_empty(self):
+        payload = json.dumps({"assessments": {"logic_clarity": 10}, "issues": []})
+        stream = (
+            '{"type":"step_start","part":{"type":"step-start"}}\n'
+            + json.dumps(
+                {
+                    "type": "text",
+                    "part": {"type": "text", "text": payload},
+                }
+            )
+            + "\n"
+        )
+        assert _extract_text_from_opencode_json_stream(stream) == ""
+
+
+class TestOpenCodeFailureDetection:
+    def test_opencode_runner_missing_patterns_detected(self):
+        from desloppify.app.commands.review.runner_failures import _is_runner_missing
+
+        assert _is_runner_missing("opencode not found") is True
+        assert _is_runner_missing("errno 2 opencode") is True
+        assert _is_runner_missing("no such file or directory $ opencode run") is True
+
+
+class TestOpenCodeProvenanceSupport:
+    def test_supported_blind_review_runners_include_opencode(self):
+        from desloppify.app.commands.review.importing.policy import (
+            SUPPORTED_BLIND_REVIEW_RUNNERS,
+        )
+
+        assert "opencode" in SUPPORTED_BLIND_REVIEW_RUNNERS

--- a/docs/OPENCODE.md
+++ b/docs/OPENCODE.md
@@ -2,5 +2,34 @@
 
 When installed (via `desloppify update-skill opencode`), OpenCode automatically loads this skill for code quality, technical debt, and health score questions.
 
+### Review workflow
+
+Use the native `--runner opencode` for automated batch reviews:
+
+```
+desloppify review --run-batches --runner opencode --parallel --scan-after-import
+```
+
+This spawns OpenCode subprocesses (`opencode run --format json`) for each batch, extracts results from the NDJSON stream, merges them, and imports as trusted assessments — identical pipeline to the Codex runner but using OpenCode as the execution engine.
+
+#### Warm server mode (optional, recommended for parallel runs)
+
+Start a persistent OpenCode server to avoid MCP cold-start overhead per batch:
+
+```
+opencode serve --port 4096 &
+export DESLOPPIFY_OPENCODE_ATTACH=http://localhost:4096
+desloppify review --run-batches --runner opencode --parallel --scan-after-import
+```
+
+When `DESLOPPIFY_OPENCODE_ATTACH` is set, each batch subprocess attaches to the running server via `--attach <url>` instead of spawning a fresh instance.
+
+#### Preparing a review manually
+
+1. **Prepare**: `desloppify review --prepare` — writes `query.json` and `.desloppify/review_packet_blind.json`.
+2. **Run batches**: `desloppify review --run-batches --runner opencode --parallel --scan-after-import`
+
+The runner handles batch splitting, prompt generation, parallel execution, retry/stall detection, result extraction, merge, and trusted import automatically.
+
 <!-- desloppify-overlay: opencode -->
 <!-- desloppify-end -->


### PR DESCRIPTION
## Summary

Add `--runner opencode` support to the batch review pipeline. When selected, batches
are executed via `opencode run --format json` subprocesses instead of Codex, with
results extracted from the NDJSON stream and merged through the same trusted-import
pipeline.

This is a v2 rewrite of #504, addressing all 5 feedback items from that review
(see Notes below).

## What changed

- **`runner_opencode.py`** (new): `run_opencode_batch` — builds OpenCode CLI
  invocations, NDJSON stdout parsing, live observer for streaming payload
  persistence, timeout/retry output recovery
- **`orchestrator.py`**: `_build_batch_run_deps` selects `run_opencode_batch` or
  `run_codex_batch` based on `args.runner`
- **CLI parsing**: add `opencode` to `--runner` choices
- **`scope.py`**: `validate_runner()` accepts both runner names via
  `_SUPPORTED_RUNNERS` set
- **`runner_process_impl/io.py`**: add `_extract_text_from_opencode_json_stream()`
  for NDJSON parsing; thread `stdout_text_observer` through `_drain_stream`
- **`runner_process_impl/attempts.py`**: thread `stdout_text_observer` through
  `_run_via_popen` → `_start_stream_threads` → `run_batch_attempt`
- **`runner_failures.py`**: generalize failure detection and hint text for both
  codex and opencode runners
- **`importing/policy.py`**: add `opencode` to `SUPPORTED_BLIND_REVIEW_RUNNERS`
- **`subjective.py`**, **`helpers.py`**: add opencode to rerun hints and holistic
  workflow instructions
- **`docs/OPENCODE.md`**: usage documentation

## Files changed

20 files changed, 676 insertions(+), 20 deletions(-)

### New
- `desloppify/app/commands/review/runner_opencode.py`
- `docs/OPENCODE.md` / `desloppify/data/global/OPENCODE.md`

### Modified (source)
- `desloppify/app/cli_support/parser_groups_admin_review.py`
- `desloppify/app/cli_support/parser_groups_admin_review_options_batch.py`
- `desloppify/app/commands/review/batch/orchestrator.py`
- `desloppify/app/commands/review/batch/scope.py`
- `desloppify/app/commands/review/importing/policy.py`
- `desloppify/app/commands/review/runner_failures.py`
- `desloppify/app/commands/review/runner_process_impl/attempts.py`
- `desloppify/app/commands/review/runner_process_impl/io.py`
- `desloppify/app/commands/scan/reporting/subjective.py`
- `desloppify/intelligence/review/_prepare/helpers.py`

### Modified (tests)
- `desloppify/tests/commands/review/test_review_batch_execution_helpers_direct.py`
- `desloppify/tests/commands/review/test_review_process_guards_direct.py`
- `desloppify/tests/commands/review/test_review_runner_helpers_direct.py`
- `desloppify/tests/commands/test_direct_coverage_queue_batch_modules.py`
- `desloppify/tests/commands/test_parser_groups_admin_review.py`
- `desloppify/tests/review/review_commands_runner_cases.py`
- `desloppify/tests/review/test_runner_internals.py`

## Usage

```
desloppify review --run-batches --runner opencode --parallel --scan-after-import
```

Optional environment variables:

```
export DESLOPPIFY_OPENCODE_MODEL=claude-sonnet-4-20250514
export DESLOPPIFY_OPENCODE_VARIANT=plan
export DESLOPPIFY_OPENCODE_ATTACH=http://localhost:4096
```

## Test plan

Impacted test suite — **179 passed**:

```
pytest desloppify/tests/review/test_runner_internals.py -q
pytest desloppify/tests/review/review_commands_cases.py -q
pytest desloppify/tests/review/review_commands_runner_cases.py -q
pytest desloppify/tests/commands/review/test_review_process_guards_direct.py -q
pytest desloppify/tests/commands/review/test_review_runner_helpers_direct.py -q
pytest desloppify/tests/commands/review/test_review_batch_execution_helpers_direct.py -q
pytest desloppify/tests/commands/test_parser_groups_admin_review.py -q
pytest desloppify/tests/commands/test_parser_groups_option_sections_direct.py -q
pytest desloppify/tests/commands/test_direct_coverage_queue_batch_modules.py -q
```

`python3 -m py_compile` on all touched `.py` files also passes.

## Notes

Addresses all feedback from the closed #504:

1. **Removed re-export shim** — no `runner_process.py`; OpenCode logic is in
   `runner_opencode.py`, codex imports stay in `codex_batch`
2. **Fixed dead `stdout_text_observer`** — properly threaded through the full
   popen → stream-threads → drain chain
3. **No formatting churn** — every changed line in existing files is a logic change
4. **`prepare.py` untouched** — no `_ORIGINAL` snapshots or monkeypatch detection
5. **`packet/build.py` untouched** — no injectable parameters added

## Dependencies

None — this is an independent feature addition.