### PR TITLE
feat(r): add test coverage hooks for R testthat convention

### DIFF
--- a/desloppify/languages/r/__init__.py
+++ b/desloppify/languages/r/__init__.py
@@ -4,6 +4,7 @@ from desloppify.languages._framework.base.types import DetectorPhase
 from desloppify.languages._framework.generic_support.core import generic_lang
 from desloppify.languages._framework.treesitter import R_SPEC
 from desloppify.languages.r.phases_smells import phase_smells
+from desloppify.languages.r import test_coverage as r_test_coverage_hooks
 
 generic_lang(
     name="r",
@@ -36,6 +37,7 @@ generic_lang(
     custom_phases=[
         DetectorPhase("R code smells", phase_smells),
     ],
+    test_coverage_module=r_test_coverage_hooks,
 )
 
 __all__ = [

--- a/desloppify/languages/r/test_coverage.py
+++ b/desloppify/languages/r/test_coverage.py
@@ -1,0 +1,167 @@
+"""R-specific test coverage heuristics and mappings.
+
+Maps testthat convention: tests/testthat/test-*.R -> R/*.R
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+ASSERT_PATTERNS = [
+    re.compile(p)
+    for p in [
+        r"\bexpect_\w+\s*\(",
+        r"\bexpect_equal\s*\(",
+        r"\bexpect_identical\s*\(",
+        r"\bexpect_true\s*\(",
+        r"\bexpect_false\s*\(",
+        r"\bexpect_error\s*\(",
+        r"\bexpect_warning\s*\(",
+        r"\bexpect_message\s*\(",
+        r"\bexpect_match\s*\(",
+        r"\bexpect_is\s*\(",
+        r"\bexpect_output\s*\(",
+        r"\bexpect_s3_class\s*\(",
+        r"\bexpect_s4_class\s*\(",
+        r"\bexpect_length\s*\(",
+        r"\bexpect_type\s*\(",
+        r"\bexpect_null\s*\(",
+        r"\bexpect_gt\s*\(",
+        r"\bexpect_lt\s*\(",
+        r"\bexpect_failure\s*\(",
+        r"\bverify_output\s*\(",
+    ]
+]
+MOCK_PATTERNS: list[re.Pattern[str]] = []
+SNAPSHOT_PATTERNS: list[re.Pattern[str]] = []
+TEST_FUNCTION_RE = re.compile(r"(?m)^\s*test_that\s*\(")
+BARREL_BASENAMES: set[str] = set()
+
+_R_LOGIC_RE = re.compile(r"(?m)^\s*\w+\s*<-\s*function\s*\(")
+
+
+def has_testable_logic(filepath: str, content: str) -> bool:
+    """Return True when an R file contains function declarations."""
+    if filepath.endswith(".Rmd"):
+        return False
+    return bool(_R_LOGIC_RE.search(content))
+
+
+def resolve_import_spec(
+    spec: str, test_path: str, production_files: set[str]
+) -> str | None:
+    """Best-effort R library()/require() to local file resolution."""
+    normalized = spec.strip().strip("\"'`")
+
+    if not normalized or normalized in (
+        "base", "stats", "utils", "methods", "graphics",
+        "grDevices", "datasets", "tools",
+    ):
+        return None
+
+    normalized_production = {
+        fp.replace("\\", "/").strip("/"): fp for fp in production_files
+    }
+
+    candidates: list[str] = [
+        f"R/{normalized}.R",
+        f"R/{normalized}.r",
+        normalized.replace(".", "/") + ".R",
+    ]
+
+    test_dir = os.path.dirname(test_path)
+    if test_dir:
+        candidates.append(f"{test_dir}/R/{normalized}.R")
+
+    for candidate in candidates:
+        norm = candidate.replace("\\", "/").strip("/")
+        if norm in normalized_production:
+            return normalized_production[norm]
+
+    return None
+
+
+def resolve_barrel_reexports(_filepath: str, _production_files: set[str]) -> set[str]:
+    return set()
+
+
+def parse_test_import_specs(content: str) -> list[str]:
+    """Extract library/require names from test file content."""
+    specs: list[str] = []
+    for match in re.finditer(r"(?<!\w)(?:library|require)\s*\(\s*(\w[\w.]+)", content):
+        specs.append(match.group(1))
+    return specs
+
+
+def map_test_to_source(test_path: str, production_set: set[str]) -> str | None:
+    """Map a testthat test file to its R/ source counterpart.
+
+    Convention: tests/testthat/test-my_module.R -> R/my_module.R
+    """
+    basename = os.path.basename(test_path)
+    if not basename.startswith("test-") or not basename.endswith((".R", ".r")):
+        return None
+
+    stem = basename[5:-2]  # strip "test-" prefix and ".R"/".r" suffix
+    candidate = f"R/{stem}.R"
+
+    normalized_production = {
+        fp.replace("\\", "/").strip("/"): fp for fp in production_set
+    }
+    norm_candidate = candidate.replace("\\", "/").strip("/")
+    if norm_candidate in normalized_production:
+        return normalized_production[norm_candidate]
+
+    candidate_r = f"R/{stem}.r"
+    norm_candidate_r = candidate_r.replace("\\", "/").strip("/")
+    if norm_candidate_r in normalized_production:
+        return normalized_production[norm_candidate_r]
+
+    return None
+
+
+def strip_test_markers(basename: str) -> str | None:
+    """Strip R testthat naming marker to derive source basename."""
+    if basename.startswith("test-") and basename.endswith(".R"):
+        return f"R/{basename[5:]}"
+    if basename.startswith("test-") and basename.endswith(".r"):
+        return f"R/{basename[5:-2]}.R"
+    return None
+
+
+def strip_comments(content: str) -> str:
+    """Strip R comments (# to end of line) while preserving strings."""
+    out: list[str] = []
+    in_string: str | None = None
+    i = 0
+    while i < len(content):
+        ch = content[i]
+        nxt = content[i + 1] if i + 1 < len(content) else ""
+
+        if in_string is not None:
+            out.append(ch)
+            if ch == "\\" and i + 1 < len(content):
+                out.append(content[i + 1])
+                i += 2
+                continue
+            if ch == in_string:
+                in_string = None
+            i += 1
+            continue
+
+        if ch in ('"', "'"):
+            in_string = ch
+            out.append(ch)
+            i += 1
+            continue
+
+        if ch == "#":
+            while i < len(content) and content[i] != "\n":
+                i += 1
+            continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)

--- a/desloppify/languages/r/tests/test_r_test_coverage.py
+++ b/desloppify/languages/r/tests/test_r_test_coverage.py
@@ -1,0 +1,115 @@
+"""Tests for R test coverage heuristics and mappings."""
+
+from __future__ import annotations
+
+from desloppify.languages.r.test_coverage import (
+    ASSERT_PATTERNS,
+    has_testable_logic,
+    map_test_to_source,
+    parse_test_import_specs,
+    strip_comments,
+    strip_test_markers,
+)
+
+
+class TestHasTestableLogic:
+    def test_function_definition_is_testable(self):
+        content = 'my_func <- function(x) { x + 1 }'
+        assert has_testable_logic("R/my_func.R", content) is True
+
+    def test_pure_script_is_not_testable(self):
+        content = 'x <- 1\ny <- 2\nprint(x + y)\n'
+        assert has_testable_logic("R/script.R", content) is False
+
+    def test_rmd_files_are_not_testable(self):
+        content = '```{r}\nmy_func <- function(x) x\n```\n'
+        assert has_testable_logic("analysis.Rmd", content) is False
+
+
+class TestMapTestToSource:
+    def test_maps_testthat_test_to_r_source(self):
+        production = {"R/transform.R", "R/utils.R"}
+        result = map_test_to_source("tests/testthat/test-transform.R", production)
+        assert result == "R/transform.R"
+
+    def test_returns_none_for_non_testthat_file(self):
+        production = {"R/transform.R"}
+        result = map_test_to_source("R/transform.R", production)
+        assert result is None
+
+    def test_returns_none_if_source_missing(self):
+        production = {"R/other.R"}
+        result = map_test_to_source("tests/testthat/test-missing.R", production)
+        assert result is None
+
+    def test_handles_lowercase_r_extension(self):
+        production = {"R/transform.r"}
+        result = map_test_to_source("tests/testthat/test-transform.r", production)
+        assert result == "R/transform.r"
+
+
+class TestStripTestMarkers:
+    def test_strips_test_prefix(self):
+        assert strip_test_markers("test-transform.R") == "R/transform.R"
+
+    def test_returns_none_for_non_test_file(self):
+        assert strip_test_markers("transform.R") is None
+
+
+class TestParseTestImportSpecs:
+    def test_extracts_library_names(self):
+        content = 'library(dplyr)\nlibrary(testthat)\nx <- 1'
+        specs = parse_test_import_specs(content)
+        assert "dplyr" in specs
+        assert "testthat" in specs
+
+    def test_extracts_require_names(self):
+        content = 'require(data.table)\nrequire(ggplot2)'
+        specs = parse_test_import_specs(content)
+        assert "data.table" in specs
+        assert "ggplot2" in specs
+
+    def test_ignores_base_packages(self):
+        content = 'library(base)\nlibrary(dplyr)'
+        specs = parse_test_import_specs(content)
+        assert "dplyr" in specs
+
+    def test_empty_when_no_imports(self):
+        specs = parse_test_import_specs("x <- 1")
+        assert specs == []
+
+
+class TestStripComments:
+    def test_strips_inline_comments(self):
+        assert strip_comments("x <- 1 # comment") == "x <- 1 "
+
+    def test_preserves_hash_in_strings(self):
+        result = strip_comments('x <- "# not a comment"')
+        assert "# not a comment" in result
+
+    def test_preserves_multiline_code(self):
+        code = "x <- 1\n# comment\ny <- 2"
+        result = strip_comments(code)
+        assert "x <- 1" in result
+        assert "y <- 2" in result
+        assert "# comment" not in result
+
+
+class TestAssertPatterns:
+    def test_matches_expect_equal(self):
+        for pat in ASSERT_PATTERNS:
+            if pat.search("expect_equal(x, 1)"):
+                return
+        assert False, "No pattern matched expect_equal"
+
+    def test_matches_expect_true(self):
+        for pat in ASSERT_PATTERNS:
+            if pat.search("expect_true(x > 0)"):
+                return
+        assert False, "No pattern matched expect_true"
+
+    def test_matches_expect_error(self):
+        for pat in ASSERT_PATTERNS:
+            if pat.search("expect_error(readLines('bad'))"):
+                return
+        assert False, "No pattern matched expect_error"


### PR DESCRIPTION

## Summary

Adds test coverage detection support for R projects following the standard **testthat** convention.

### What this does

- Maps `tests/testthat/test-*.R` → `R/*.R` source files
- Recognizes all `expect_*` assertion patterns from testthat
- Handles `library()`/`require()` imports in test files for dependency resolution
- Strips R comments while preserving string literals

### Changes

```
 desloppify/languages/r/__init__.py            |   2 +
 desloppify/languages/r/test_coverage.py       | 167 ++++++++++++++++++++
 desloppify/languages/r/tests/test_r_test_coverage.py | 115 ++++++++++++++
 3 files changed, 284 insertions(+)
```

### Testing

All 19 tests pass. The module follows the same structure as existing R plugins (test coverage modules for Python, JavaScript, etc.).

This is a focused, standalone addition that does not modify any existing behavior — it only adds the `test_coverage_module` hook to the R language plugin.