### PR TITLE
feat(r): air formatter,  test/test coverage patterns, and dimension overrides

### DIFF
--- a/desloppify/languages/_framework/generic_parts/parsers.py
+++ b/desloppify/languages/_framework/generic_parts/parsers.py
@@ -285,6 +285,22 @@ def parse_next_lint(output: str, scan_path: Path) -> tuple[list[dict], dict]:
     return entries, {"potential": potential}
 
 
+def parse_air(output: str, scan_path: Path) -> list[dict]:
+    """Parse air format --check output (``Would reformat: <file>``)."""
+    entries: list[dict] = []
+    for line in output.splitlines():
+        match = re.match(r"^Would reformat:\s+(.+)$", line)
+        if match:
+            entries.append(
+                {
+                    "file": match.group(1).strip(),
+                    "line": 0,
+                    "message": "needs formatting (air)",
+                }
+            )
+    return entries
+
+
 ToolParseResult = list[dict] | tuple[list[dict], dict]
 ToolParser = Callable[[str, Path], ToolParseResult]
 
@@ -299,6 +315,7 @@ PARSERS: dict[str, ToolParser] = {
     "cargo": parse_cargo,
     "eslint": parse_eslint,
     "next_lint": parse_next_lint,
+    "air": parse_air,
 }
 
 
@@ -307,6 +324,7 @@ __all__ = [
     "ToolParserError",
     "ToolParseResult",
     "ToolParser",
+    "parse_air",
     "parse_cargo",
     "parse_credo",
     "parse_eslint",

--- a/desloppify/languages/r/__init__.py
+++ b/desloppify/languages/r/__init__.py
@@ -1,4 +1,4 @@
-"""R language plugin — Jarl, lintr + tree-sitter + R-specific smells."""
+"""R language plugin — air + Jarl + lintr + tree-sitter + R-specific smells."""
 
 from desloppify.languages._framework.base.types import DetectorPhase
 from desloppify.languages._framework.generic_support.core import generic_lang
@@ -10,6 +10,14 @@ generic_lang(
     name="r",
     extensions=[".R", ".r"],
     tools=[
+        {
+            "label": "air",
+            "cmd": "air format --check .",
+            "fmt": "air",
+            "id": "air_format",
+            "tier": 1,
+            "fix_cmd": "air format .",
+        },
         {
             "label": "jarl",
             "cmd": "jarl check .",
@@ -33,6 +41,8 @@ generic_lang(
     depth="shallow",
     detect_markers=["DESCRIPTION", ".Rproj"],
     default_src="R",
+    external_test_dirs=["tests/testthat"],
+    test_file_extensions=[".R", ".r"],
     treesitter_spec=R_SPEC,
     custom_phases=[
         DetectorPhase("R code smells", phase_smells),

--- a/desloppify/languages/r/review_data/__init__.py
+++ b/desloppify/languages/r/review_data/__init__.py
@@ -1,0 +1,1 @@
+"""R review data payloads."""

--- a/desloppify/languages/r/review_data/dimensions.override.json
+++ b/desloppify/languages/r/review_data/dimensions.override.json
@@ -1,0 +1,51 @@
+{
+  "dimension_prompts": {
+    "abstraction_fitness": {
+      "description": "R abstraction fitness: favor direct functions, vectorized operations, and bounded package namespaces over indirection and generic helper surfaces.",
+      "look_for": [
+        "Wrapper functions that only forward arguments to another function without policy or translation",
+        "S4/R6 class hierarchies with one concrete implementation and no extension pressure",
+        "Generic helper modules (utils.R, helpers.R) that accumulate unrelated functions across concerns",
+        "Functions that accept ... to pass through arguments without validation or transformation",
+        "Excessive use of do.call() or Recall() where a direct call would suffice"
+      ],
+      "skip": [
+        "S3/S4 dispatch required by CRAN package architecture or generic/method contracts",
+        "Wrapper functions that add validation, error handling, or logging around base R functions",
+        "Package-level re-exports that stabilize public API surfaces (e.g. @export re-exports from dependencies)",
+        "Shiny module patterns that require server/UI function pairs by framework convention"
+      ]
+    },
+    "test_strategy": {
+      "description": "R testing strategy: testthat 3+ conventions, self-sufficient tests, proper cleanup with withr, snapshot testing, and modern mocking patterns.",
+      "look_for": [
+        "Tests relying on ambient state from earlier test_that() blocks instead of self-sufficient setup",
+        "Deprecated testthat patterns: context(), expect_equivalent(), with_mock() — prefer describe(), expect_equal(ignore_attr=TRUE), local_mocked_bindings()",
+        "Tests writing to the package directory instead of tempdir/withr::local_tempfile()",
+        "Missing withr::local_*() cleanup for tests that modify options, env vars, or working directory",
+        "Snapshot tests without a clear review/accept workflow or snapshot files checked into .Rbuildignore",
+        "Tests using library() or require() inside helper files instead of devtools::load_all() workflow"
+      ],
+      "skip": [
+        "Helper files (helper-*.R) that intentionally set up shared test fixtures before all tests",
+        "Setup files (setup-*.R) that run only during R CMD check by convention",
+        "Snapshot .md files in tests/testthat/_snaps/ that are intentionally tracked"
+      ]
+    },
+    "error_consistency": {
+      "description": "R error consistency: typed errors via rlang, proper condition handling, and consistent error signaling across the package.",
+      "look_for": [
+        "Mixing base stop() with rlang::abort() or cli::cli_abort() without consistent convention",
+        "Error messages that don't include the offending function name or argument",
+        "Catching errors with try() or tryCatch() without re-raising or logging",
+        "Using warning() for conditions that should be errors (e.g., invalid input that produces wrong output)",
+        "Functions that silently return NULL or NA on error instead of signaling a condition"
+      ],
+      "skip": [
+        "Intentional use of base R condition handling for backward compatibility",
+        "S4 method dispatch errors that are controlled by the methods package"
+      ]
+    }
+  },
+  "system_prompt_append": "R anchor checks: T/F instead of TRUE/FALSE, vectorized conditions in if(), library() inside functions, 1:n() instead of seq_len(n), == NA instead of is.na(), and unnecessary return() at end of functions."
+}

--- a/desloppify/languages/r/test_coverage.py
+++ b/desloppify/languages/r/test_coverage.py
@@ -33,8 +33,17 @@ ASSERT_PATTERNS = [
         r"\bverify_output\s*\(",
     ]
 ]
-MOCK_PATTERNS: list[re.Pattern[str]] = []
-SNAPSHOT_PATTERNS: list[re.Pattern[str]] = []
+MOCK_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\blocal_mocked_bindings\s*\("),
+    re.compile(r"\bwith_mocked_bindings\s*\("),
+    re.compile(r"\bwith_mock\s*\("),
+]
+SNAPSHOT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\bexpect_snapshot_value\s*\("),
+    re.compile(r"\bexpect_snapshot_file\s*\("),
+    re.compile(r"\bexpect_snapshot\s*\("),
+    re.compile(r"\bsnapshot_review\s*\("),
+]
 TEST_FUNCTION_RE = re.compile(r"(?m)^\s*test_that\s*\(")
 BARREL_BASENAMES: set[str] = set()
 

--- a/desloppify/languages/r/tests/test_r_air.py
+++ b/desloppify/languages/r/tests/test_r_air.py
@@ -1,4 +1,4 @@
-"""Regression tests for R tooling integration (air, lintr, goodpractice, covr, R CMD check).
+"""Regression tests for R air formatter integration and plugin registration.
 
 Ensures:
 1. The air format --check parser handles reformat output.

--- a/desloppify/languages/r/tests/test_r_lintr.py
+++ b/desloppify/languages/r/tests/test_r_lintr.py
@@ -1,0 +1,109 @@
+"""Regression tests for R tooling integration (air, lintr, goodpractice, covr, R CMD check).
+
+Ensures:
+1. The air format --check parser handles reformat output.
+2. The R language plugin registers correctly with all tool phases.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from desloppify.languages import get_lang
+from desloppify.languages._framework.generic_parts.parsers import parse_air
+
+
+# ---------------------------------------------------------------------------
+# parse_air parser tests
+# ---------------------------------------------------------------------------
+
+class TestParseAir:
+    def test_would_reformat_single_file(self):
+        output = "Would reformat: R/transform.R\n"
+        entries = parse_air(output, Path("/project"))
+        assert len(entries) == 1
+        assert entries[0]["file"] == "R/transform.R"
+        assert entries[0]["line"] == 0
+        assert "air" in entries[0]["message"]
+
+    def test_would_reformat_multiple_files(self):
+        output = (
+            "Would reformat: R/transform.R\n"
+            "Would reformat: R/utils.R\n"
+            "Would reformat: R/plot.R\n"
+        )
+        entries = parse_air(output, Path("/project"))
+        assert len(entries) == 3
+
+    def test_no_reformat_needed(self):
+        entries = parse_air("", Path("/project"))
+        assert entries == []
+
+    def test_ignores_non_reformat_lines(self):
+        output = "1 file would be reformatted\nSome other output\n"
+        entries = parse_air(output, Path("/project"))
+        assert entries == []
+
+
+# ---------------------------------------------------------------------------
+# review_data/dimensions.override.json
+# ---------------------------------------------------------------------------
+
+class TestRDimensionsOverride:
+    def test_override_file_exists_and_is_valid_json(self):
+        import desloppify.languages.r
+        r_dir = Path(desloppify.languages.r.__file__).resolve().parent
+        override_path = r_dir / "review_data" / "dimensions.override.json"
+        assert override_path.is_file()
+        data = json.loads(override_path.read_text(encoding="utf-8"))
+        assert isinstance(data, dict)
+        assert "dimension_prompts" in data
+        assert "system_prompt_append" in data
+
+    def test_override_has_r_specific_dimensions(self):
+        import desloppify.languages.r
+        r_dir = Path(desloppify.languages.r.__file__).resolve().parent
+        override_path = r_dir / "review_data" / "dimensions.override.json"
+        data = json.loads(override_path.read_text(encoding="utf-8"))
+        dims = data.get("dimension_prompts", {})
+        assert "abstraction_fitness" in dims
+        assert "test_strategy" in dims
+
+
+# ---------------------------------------------------------------------------
+# R language plugin registration tests
+# ---------------------------------------------------------------------------
+
+class TestRLangPluginRegistration:
+    def test_config_name(self):
+        cfg = get_lang("r")
+        assert cfg.name == "r"
+
+    def test_config_extensions(self):
+        cfg = get_lang("r")
+        assert ".R" in cfg.extensions
+        assert ".r" in cfg.extensions
+
+    def test_detect_markers(self):
+        cfg = get_lang("r")
+        assert "DESCRIPTION" in cfg.detect_markers
+        assert ".Rproj" in cfg.detect_markers
+
+    def test_has_air_format_phase(self):
+        cfg = get_lang("r")
+        labels = {p.label for p in cfg.phases}
+        assert "air" in labels
+
+    def test_air_format_detect_command(self):
+        cfg = get_lang("r")
+        assert "air_format" in cfg.detect_commands
+
+    def test_external_test_dirs(self):
+        cfg = get_lang("r")
+        assert "tests/testthat" in cfg.external_test_dirs
+
+    def test_test_file_extensions(self):
+        cfg = get_lang("r")
+        assert ".R" in cfg.test_file_extensions
+        assert ".r" in cfg.test_file_extensions

--- a/desloppify/languages/r/tests/test_r_test_coverage.py
+++ b/desloppify/languages/r/tests/test_r_test_coverage.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from desloppify.languages.r.test_coverage import (
     ASSERT_PATTERNS,
+    MOCK_PATTERNS,
+    SNAPSHOT_PATTERNS,
     has_testable_logic,
     map_test_to_source,
     parse_test_import_specs,
@@ -113,3 +115,49 @@ class TestAssertPatterns:
             if pat.search("expect_error(readLines('bad'))"):
                 return
         assert False, "No pattern matched expect_error"
+
+
+class TestMockPatterns:
+    def test_matches_local_mocked_bindings(self):
+        assert any(
+            pat.search("local_mocked_bindings(foo = bar)")
+            for pat in MOCK_PATTERNS
+        )
+
+    def test_matches_with_mocked_bindings(self):
+        assert any(
+            pat.search("with_mocked_bindings(foo = bar, { })")
+            for pat in MOCK_PATTERNS
+        )
+
+    def test_no_match_on_plain_function(self):
+        assert not any(
+            pat.search("my_function(x = 1)")
+            for pat in MOCK_PATTERNS
+        )
+
+
+class TestSnapshotPatterns:
+    def test_matches_expect_snapshot(self):
+        assert any(
+            pat.search("expect_snapshot(result)")
+            for pat in SNAPSHOT_PATTERNS
+        )
+
+    def test_matches_expect_snapshot_value(self):
+        assert any(
+            pat.search("expect_snapshot_value(x)")
+            for pat in SNAPSHOT_PATTERNS
+        )
+
+    def test_matches_expect_snapshot_file(self):
+        assert any(
+            pat.search("expect_snapshot_file('output.md')")
+            for pat in SNAPSHOT_PATTERNS
+        )
+
+    def test_no_match_on_plain_function(self):
+        assert not any(
+            pat.search("expect_equal(x, 1)")
+            for pat in SNAPSHOT_PATTERNS
+        )

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -1,0 +1,101 @@
+# How Scoring Works
+
+Desloppify computes a **health score** from 0 to 100 that measures the overall quality of your codebase. A score of 100 means no known issues; lower scores reflect detected problems weighted by their severity and certainty.
+
+## Two pools: mechanical and subjective
+
+The overall health score blends two independent pools of dimensions:
+
+| Pool | Weight | Source |
+|------|--------|--------|
+| **Mechanical** | 25% | Automated detectors (code smells, duplication, security, etc.) |
+| **Subjective** | 75% | AI code review assessments (architecture, elegance, contracts, etc.) |
+
+If no subjective reviews have been run yet, the score is 100% mechanical. Once subjective dimensions have scores, the 25/75 split applies.
+
+Within each pool, dimensions are averaged using their own configured weights (see below).
+
+## Mechanical dimensions
+
+Mechanical dimensions are scored by automated detectors. Each detector scans your codebase and counts a **potential** (total checks performed) and **failures** (issues found). The dimension score is:
+
+    dimension_score = ((potential - weighted_failures) / potential) * 100
+
+Detectors are grouped into dimensions based on what they measure:
+
+| Dimension | Pool weight | Detectors |
+|-----------|-------------|-----------|
+| **File health** | 2.0 | structural |
+| **Code quality** | 1.0 | unused, logs, exports, smells, orphaned, flat_dirs, naming, single_use, coupling, facade, props, react, nextjs, next_lint, patterns, dict_keys, deprecated, stale_exclude, clippy_warning, cargo_error, rust_import_hygiene, rust_feature_hygiene, rust_api_convention, rust_error_boundary, rust_future_proofing, rust_async_locking, rust_drop_safety, rust_unsafe_api, global_mutable_config, private_imports, layer_violation, responsibility_cohesion |
+| **Duplication** | 1.0 | dupes, boilerplate_duplication |
+| **Test health** | 1.0 | test_coverage, rustdoc_warning, rust_doctest, rust_thread_safety |
+| **Security** | 1.0 | cycles, security |
+
+**Note:** Not every detector listed above will fire in every project. Detectors are language-specific -- Rust detectors only run on Rust codebases, React/Next.js detectors only on TypeScript projects with those frameworks, etc. Only detectors with a non-zero potential (i.e., they found something to check) contribute to a dimension's score.
+
+### Sample dampening
+
+Dimensions with fewer than 200 checks get their weight reduced proportionally. A dimension with 50 checks contributes at 25% of its configured weight. This prevents a dimension with only a handful of checks from having outsized influence.
+
+## Subjective dimensions
+
+Subjective dimensions come from AI code review (`desloppify review`). Each dimension receives a score from 0 to 100 based on the reviewer's assessment.
+
+The subjective dimensions and their weights within the subjective pool:
+
+| Dimension | Weight |
+|-----------|--------|
+| High elegance | 22.0 |
+| Mid elegance | 22.0 |
+| Low elegance | 12.0 |
+| Contracts | 12.0 |
+| Type safety | 12.0 |
+| Design coherence | 10.0 |
+| Abstraction fit | 8.0 |
+| Logic clarity | 6.0 |
+| Structure nav | 5.0 |
+| Error consistency | 3.0 |
+| Naming quality | 2.0 |
+| AI generated debt | 1.0 |
+
+Elegance, contracts, and type safety dominate because they reflect architectural quality and correctness. Naming quality and AI-generated debt are low-weight nudges for polish.
+
+## How confidence affects scoring
+
+Each detected issue has a confidence level that determines how heavily it counts as a failure:
+
+| Confidence | Weight |
+|------------|--------|
+| High | 1.0 |
+| Medium | 0.7 |
+| Low | 0.3 |
+
+A low-confidence issue pulls the score down only 30% as much as a high-confidence one. This means uncertain detections have a lighter touch on your score.
+
+## Lenient vs. strict scoring
+
+Desloppify tracks two score variants:
+
+- **Lenient (default):** `open`, `deferred`, and `triaged_out` issues count as failures. Issues you mark as `wontfix`, `fixed`, `false_positive`, or `auto_resolved` do not penalize the score.
+- **Strict:** `wontfix` and `auto_resolved` issues also count as failures, in addition to everything in lenient. This reveals the "true debt" you have accepted.
+
+The gap between lenient and strict scores shows how much technical debt you are carrying via `wontfix` decisions.
+
+## Zone filtering
+
+Not all files are scored equally. Files are classified into zones, and most non-production zones are excluded from the health score:
+
+- **Production** and **script** zones: scored
+- **Test**, **config**, **generated**, and **vendor** zones: excluded from scoring
+
+Issues in your test files, generated code, or vendored dependencies do not drag down your health score.
+
+## File-based detectors
+
+Some detectors (smells, dict_keys, test_coverage, security, concerns, review, nextjs, next_lint) use file-based scoring. Instead of counting individual issues against a raw potential, failures are capped per file so that a single problematic file cannot overwhelm the score. A file with 1-2 issues contributes up to 1.0 failure units, 3-5 issues up to 1.5, and 6+ issues up to 2.0.
+
+## What the score does NOT measure
+
+- The health score does not measure feature completeness, performance, or user experience.
+- Scores from different codebases are not directly comparable. A score of 85 on a 500-file project means something different than 85 on a 50-file project.
+- The score is a tracking tool for improvement over time, not an absolute quality rating.


### PR DESCRIPTION
## What Changed

- **Added `parse_air` parser** in `parsers.py` to handle `air format --check` output (`Would reformat:
<file>` lines)
- **Registered air as a tier-1 format detector** in the R language plugin (`__init__.py`), with both
detect (`air format --check .`) and fix (`air format .`) commands
- **Added R-specific test coverage patterns** in `test_coverage.py`: mock patterns
(`local_mocked_bindings`, `with_mocked_bindings`, `with_mock`) and snapshot patterns
(`expect_snapshot`, `expect_snapshot_value`, `expect_snapshot_file`, `snapshot_review`)
- **Added `external_test_dirs` and `test_file_extensions`** to the R language config so test coverage
detection correctly identifies `tests/testthat` and `.R`/`.r` test files
- **Created `dimensions.override.json`** with R-specific review dimension overrides for
`abstraction_fitness`, `test_strategy`, and `error_consistency`, plus R anchor checks (`T/F` vs
`TRUE/FALSE`, vectorized `if()`, `1:n()` vs `seq_len(n)`, etc.)

## Why

The R language plugin had no formatter integration — `air` is the modern R code formatter (successor to `styler`) and should be detected and auto-fixed like formatters in other language plugins.

Test coverage analysis for R was missing mock and snapshot pattern recognition, so testthat 3+ mocking (`local_mocked_bindings`) and snapshot testing (`expect_snapshot*`) were invisible to the coverage detector. The `external_test_dirs` and `test_file_extensions` config was also missing, meaning test files in `tests/testthat/` weren't being discovered.

The review dimensions were falling back to generic prompts that don't account for R-specific conventions (S3/S4 dispatch, testthat patterns, rlang error handling, etc.). They are loosely based on https://github.com/posit-dev/skills

## Files Changed

- `desloppify/languages/_framework/generic_parts/parsers.py` — added `parse_air` parser + registry entry
- `desloppify/languages/r/__init__.py` — registered air formatter, added test dir/extension config
- `desloppify/languages/r/test_coverage.py` — populated mock and snapshot pattern lists
- `desloppify/languages/r/review_data/__init__.py` — new package marker
- `desloppify/languages/r/review_data/dimensions.override.json` — R-specific review dimensions
- `desloppify/languages/r/tests/test_r_lintr.py` — new tests for air parser, dimension overrides,
plugin registration
- `desloppify/languages/r/tests/test_r_test_coverage.py` — new tests for mock and snapshot patterns

## Verification

- All new tests cover the air parser (`TestParseAir`), dimension override loading
(`TestRDimensionsOverride`), plugin registration (`TestRLangPluginRegistration`), mock patterns (`TestMockPatterns`), and snapshot patterns (`TestSnapshotPatterns`)
- 7 files changed, +249 −3 lines