### PR TITLE
fix: align queue builders with resolved subjective threshold

### DIFF
--- a/desloppify/engine/planning/queue_policy.py
+++ b/desloppify/engine/planning/queue_policy.py
@@ -34,6 +34,23 @@ def _queue_plan_from_options(options: QueueBuildOptions) -> dict | None:
     return options.plan
 
 
+def _resolved_subjective_threshold(
+    state: StateModel,
+    options: QueueBuildOptions,
+) -> float:
+    """Return the effective subjective threshold for queue builders.
+
+    When callers pass a precomputed QueueContext, the queue builder must honor
+    the context's resolved target_strict value; otherwise open-queue surfaces
+    can disagree about whether review findings or subjective dimensions should
+    be visible. Falling back to the state/config-derived target preserves the
+    legacy behavior for plan-only callers.
+    """
+    if options.context is not None:
+        return float(options.context.target_strict)
+    return _subjective_threshold(state)
+
+
 def build_open_plan_queue(
     state: StateModel,
     *,
@@ -46,7 +63,7 @@ def build_open_plan_queue(
     elif opts.status == QueueBuildOptions().status:
         opts = replace(opts, status="open")
     if opts.subjective_threshold == QueueBuildOptions().subjective_threshold:
-        opts = replace(opts, subjective_threshold=_subjective_threshold(state))
+        opts = replace(opts, subjective_threshold=_resolved_subjective_threshold(state, opts))
     return build_work_queue(
         state,
         options=opts,
@@ -65,6 +82,8 @@ def build_execution_queue(
         plan=_queue_plan_from_options(options),
         target_strict=_subjective_threshold(state),
     )
+    if options.subjective_threshold == QueueBuildOptions().subjective_threshold:
+        options = replace(options, subjective_threshold=ctx.target_strict)
     return _build_work_queue_with_visibility(
         state,
         options=replace(options, context=ctx),
@@ -84,6 +103,8 @@ def build_backlog_queue(
         plan=_queue_plan_from_options(options),
         target_strict=_subjective_threshold(state),
     )
+    if options.subjective_threshold == QueueBuildOptions().subjective_threshold:
+        options = replace(options, subjective_threshold=ctx.target_strict)
     return _build_work_queue_with_visibility(
         state,
         options=replace(options, context=ctx),

--- a/desloppify/tests/plan/test_plan_modules_direct.py
+++ b/desloppify/tests/plan/test_plan_modules_direct.py
@@ -176,3 +176,60 @@ def test_build_open_plan_queue_uses_core_options_shape(monkeypatch) -> None:
     assert captured[0].scan_path == "src"
     assert captured[0].status == "open"
     assert captured[0].subjective_threshold == 91.0
+
+
+def test_build_execution_queue_applies_resolved_context_threshold(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    fake_ctx = SimpleNamespace(plan={"queue_order": []}, target_strict=83.0)
+
+    def _build_work_queue_with_visibility(_state, *, options, visibility):
+        captured["options"] = options
+        captured["visibility"] = visibility
+        return {"items": [], "total": 0, "grouped": {}, "new_ids": set()}
+
+    monkeypatch.setattr(queue_policy_mod, "queue_context", lambda *_a, **_k: fake_ctx)
+    monkeypatch.setattr(
+        queue_policy_mod,
+        "_build_work_queue_with_visibility",
+        _build_work_queue_with_visibility,
+    )
+
+    queue_policy_mod.build_execution_queue(
+        {"config": {"target_strict_score": 91}},
+        options=QueueBuildOptions(count=None),
+    )
+
+    options = captured["options"]
+    assert isinstance(options, QueueBuildOptions)
+    assert options.context is fake_ctx
+    assert options.subjective_threshold == 83.0
+    assert captured["visibility"] == queue_policy_mod.QueueVisibility.EXECUTION
+
+
+
+def test_build_backlog_queue_applies_resolved_context_threshold(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    fake_ctx = SimpleNamespace(plan={"queue_order": []}, target_strict=77.0)
+
+    def _build_work_queue_with_visibility(_state, *, options, visibility):
+        captured["options"] = options
+        captured["visibility"] = visibility
+        return {"items": [], "total": 0, "grouped": {}, "new_ids": set()}
+
+    monkeypatch.setattr(queue_policy_mod, "queue_context", lambda *_a, **_k: fake_ctx)
+    monkeypatch.setattr(
+        queue_policy_mod,
+        "_build_work_queue_with_visibility",
+        _build_work_queue_with_visibility,
+    )
+
+    queue_policy_mod.build_backlog_queue(
+        {"config": {"target_strict_score": 91}},
+        options=QueueBuildOptions(count=None),
+    )
+
+    options = captured["options"]
+    assert isinstance(options, QueueBuildOptions)
+    assert options.context is fake_ctx
+    assert options.subjective_threshold == 77.0
+    assert captured["visibility"] == queue_policy_mod.QueueVisibility.BACKLOG


### PR DESCRIPTION
## Problem
`desloppify next` and `desloppify plan queue` could disagree about the live queue when callers relied on the default subjective threshold.

In my repro, `next` passed a resolved target strict score through a `QueueContext`, while `plan queue` relied on the default `QueueBuildOptions.subjective_threshold = 100`. Because `build_execution_queue()` and `build_backlog_queue()` did not propagate the resolved threshold into the queue options, the snapshot builder used different thresholds for subjective visibility and phase selection.

That produced inconsistent queue surfaces for the same plan/state.

## Fix
- add `_resolved_subjective_threshold()` in `engine/planning/queue_policy.py`
- when queue builders synthesize or receive a `QueueContext`, copy the resolved target into `options.subjective_threshold` when the caller did not override it explicitly
- cover the regression with direct tests for both execution and backlog queue builders

## Verification
- `python -m pytest desloppify/tests/plan/test_plan_modules_direct.py -q`
- `python -m pytest desloppify/tests/engine/test_queue_context.py desloppify/tests/review/test_work_queue_plan_order_and_triage.py desloppify/tests/commands/test_next_queue_flow_direct.py -q`
- verified against a real project repro where `next` and `plan queue` previously diverged under the same JS state
