### PR TITLE
fix: package viz template in installed builds

### DIFF
--- a/desloppify/app/output/visualize.py
+++ b/desloppify/app/output/visualize.py
@@ -1,6 +1,7 @@
 """Codebase treemap visualization with HTML output and LLM-readable tree text."""
 
 import json
+from importlib import resources
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -111,6 +112,7 @@ def generate_visualization(
 @dataclass
 class TreeTextOptions:
     """Text tree rendering options."""
+
     max_depth: int = 2
     focus: str | None = None
     min_loc: int = 0
@@ -158,4 +160,8 @@ def generate_tree_text(
 
 def _get_html_template() -> str:
     """Read the HTML treemap template from the external file."""
-    return (Path(__file__).parent / "_viz_template.html").read_text()
+    return (
+        resources.files("desloppify.app.output")
+        .joinpath("_viz_template.html")
+        .read_text()
+    )

--- a/desloppify/tests/core/test_pyproject_package_data.py
+++ b/desloppify/tests/core/test_pyproject_package_data.py
@@ -1,0 +1,25 @@
+"""Packaging metadata invariants for required package data."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def _package_data() -> dict[str, list[str]]:
+    pyproject_path = Path(__file__).resolve().parents[3] / "pyproject.toml"
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    package_data = data.get("tool", {}).get("setuptools", {}).get("package-data", {})
+    assert isinstance(package_data, dict), (
+        "tool.setuptools.package-data must be a table"
+    )
+    return package_data
+
+
+def test_visualization_template_is_packaged() -> None:
+    package_data = _package_data()
+    template_files = package_data.get("desloppify.app.output")
+    assert isinstance(template_files, list), (
+        "desloppify.app.output package data must be declared in pyproject.toml"
+    )
+    assert "_viz_template.html" in template_files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ exclude = ["desloppify.tests", "desloppify.tests.*"]
 include-package-data = false
 
 [tool.setuptools.package-data]
+"desloppify.app.output" = ["_viz_template.html"]
 "desloppify.data.global" = ["*.md"]
 "desloppify.languages._framework" = ["review_data/*.json"]
 "desloppify.languages.python" = ["review_data/*.json"]


### PR DESCRIPTION
`desloppify viz` did not work due to missing bundles resources

```bash
❯ desloppify viz
  Excluding (from config): .git, .venv, .pytest_cache, .ruff_cache, site, workspace, .cache, .direnv, .scannerwork, .skylos, docs/htmlcov, src/canvas_code_correction/__pycache__, src/canvas_code_correction/clients/__pycache__, src/canvas_code_correction/prefect_blocks/__pycache__, scripts/__pycache__, .agents, .desloppify, coverage.xml, coverage.json, .coverage, src/.coverage
Collecting file data and building dependency graph...
  Visualization generation failed (error): .desloppify/treemap.html ([Errno 2] No such file or directory: '/home/jsg/.local/share/uv/tools/desloppify/lib/python3.14/site-packages/desloppify/app/output/_viz_template.html')
  ```
  
  The resources has been added and validated with test and manual inspection