### PR TITLE
Fix plan migration dropping uncommitted findings

### DIFF
--- a/desloppify/engine/_plan/schema/__init__.py
+++ b/desloppify/engine/_plan/schema/__init__.py
@@ -289,10 +289,10 @@ def ensure_plan_defaults(plan: dict[str, Any]) -> None:
 
     Runtime contract is v8-only. Legacy payloads are upgraded in-place once.
     """
+    _upgrade_plan_to_v8(plan)
     defaults = empty_plan()
     for key, value in defaults.items():
         plan.setdefault(key, value)
-    _upgrade_plan_to_v8(plan)
     subjective_defer_meta = plan.get("subjective_defer_meta")
     if isinstance(subjective_defer_meta, dict):
         subjective_defer_meta.pop("force_visible_ids", None)

--- a/desloppify/engine/_plan/schema/normalize.py
+++ b/desloppify/engine/_plan/schema/normalize.py
@@ -13,7 +13,7 @@ _HEX_SUFFIX_RE = re.compile(r"^[0-9a-f]{8}$")
 def _rename_key(d: dict, old: str, new: str) -> bool:
     if old not in d:
         return False
-    d.setdefault(new, d.pop(old))
+    d[new] = d.pop(old)
     return True
 
 

--- a/desloppify/tests/plan/test_persistence_runtime_paths.py
+++ b/desloppify/tests/plan/test_persistence_runtime_paths.py
@@ -82,3 +82,17 @@ def test_resolve_plan_load_status_migrates_legacy_lifecycle_in_memory_only(tmp_p
     assert json.loads(plan_file.read_text(encoding="utf-8"))["refresh_state"][
         "lifecycle_phase"
     ] == "workflow"
+
+
+def test_resolve_plan_load_status_preserves_legacy_uncommitted_findings(tmp_path):
+    plan_file = tmp_path / "plan.json"
+    plan_file.write_text(
+        '{"version": 7, "created": "2026-01-01T00:00:00+00:00", "updated": "2026-01-01T00:00:00+00:00", "queue_order": [], "deferred": [], "skipped": {}, "active_cluster": null, "overrides": {}, "clusters": {}, "superseded": {}, "promoted_ids": [], "plan_start_scores": {}, "refresh_state": {}, "execution_log": [], "epic_triage_meta": {}, "commit_log": [], "uncommitted_findings": ["review::a.py::issue-1"], "uncommitted_issues": [], "commit_tracking_branch": null}\n',
+        encoding="utf-8",
+    )
+
+    status = persistence_mod.resolve_plan_load_status(plan_file)
+
+    assert status.plan is not None
+    assert status.plan["uncommitted_issues"] == ["review::a.py::issue-1"]
+    assert "uncommitted_findings" not in status.plan

--- a/desloppify/tests/plan/test_schema_migrations.py
+++ b/desloppify/tests/plan/test_schema_migrations.py
@@ -28,6 +28,21 @@ def test_ensure_container_types_sets_defaults_and_renames_keys() -> None:
     assert plan["commit_tracking_branch"] is None
 
 
+def test_ensure_container_types_rename_overwrites_existing_target_key() -> None:
+    plan = {
+        "epic_triage_meta": {"finding_snapshot_hash": "abc", "issue_snapshot_hash": ""},
+        "uncommitted_findings": ["x"],
+        "uncommitted_issues": [],
+    }
+
+    migrations.ensure_container_types(plan)
+
+    assert plan["epic_triage_meta"]["issue_snapshot_hash"] == "abc"
+    assert "finding_snapshot_hash" not in plan["epic_triage_meta"]
+    assert plan["uncommitted_issues"] == ["x"]
+    assert "uncommitted_findings" not in plan
+
+
 def test_migrate_synthesis_to_triage_renames_ids_meta_and_cluster_fields() -> None:
     plan = {
         "queue_order": ["synthesis::a", "other"],


### PR DESCRIPTION
## Summary
- make `_rename_key()` perform a true overwrite rename so legacy values are not discarded when the target key already exists
- run plan schema upgrades before applying empty-plan defaults so migrations match the state schema flow
- add regression tests for both the helper overwrite case and the runtime `resolve_plan_load_status()` path

## Testing
- `uv run --with pytest python -m pytest desloppify/tests/plan/test_schema_migrations.py desloppify/tests/plan/test_persistence_runtime_paths.py`
