### PR TITLE
Fix tree-sitter dependency graph path mismatch

### DIFF
--- a/desloppify/languages/_framework/treesitter/imports/graph.py
+++ b/desloppify/languages/_framework/treesitter/imports/graph.py
@@ -31,14 +31,20 @@ def ts_build_dep_graph(
     query = _make_query(language, spec.import_query)
 
     scan_path = str(path.resolve())
-    file_set = set(file_list)
+    abs_file_list = [
+        filepath
+        if os.path.isabs(filepath)
+        else os.path.normpath(os.path.join(scan_path, filepath))
+        for filepath in file_list
+    ]
+    file_set = set(abs_file_list)
     graph: dict[str, dict[str, Any]] = {}
 
     # Initialize all files in the graph.
-    for f in file_list:
+    for f in abs_file_list:
         graph[f] = {"imports": set(), "importers": set()}
 
-    for filepath in file_list:
+    for filepath in abs_file_list:
         cached = get_or_parse_tree(filepath, parser, spec.grammar)
         if cached is None:
             continue

--- a/desloppify/tests/lang/common/test_treesitter_imports_direct.py
+++ b/desloppify/tests/lang/common/test_treesitter_imports_direct.py
@@ -39,7 +39,11 @@ def test_graph_helpers_build_internal_edges_and_builder(monkeypatch, tmp_path: P
     source_file.parent.mkdir(parents=True)
     source_file.write_text("<?php\n", encoding="utf-8")
     dep_file.write_text("<?php\n", encoding="utf-8")
-    file_list = [str(source_file), str(dep_file)]
+    relative_file_list = [
+        str(source_file.relative_to(tmp_path)),
+        str(dep_file.relative_to(tmp_path)),
+    ]
+    absolute_file_list = [str(source_file), str(dep_file)]
 
     monkeypatch.setattr(graph_mod, "_get_parser", lambda _grammar: ("parser", "language"))
     monkeypatch.setattr(graph_mod, "_make_query", lambda _language, source: source)
@@ -67,18 +71,18 @@ def test_graph_helpers_build_internal_edges_and_builder(monkeypatch, tmp_path: P
         ),
     )
 
-    graph = graph_mod.ts_build_dep_graph(tmp_path, spec, file_list)
+    graph = graph_mod.ts_build_dep_graph(tmp_path, spec, relative_file_list)
     assert graph[str(source_file)]["imports"] == {str(dep_file)}
     assert graph[str(dep_file)]["importers"] == {str(source_file)}
     assert graph[str(source_file)]["import_count"] == 1
     assert graph[str(dep_file)]["importer_count"] == 1
 
-    builder = graph_mod.make_ts_dep_builder(spec, lambda _path: file_list)
+    builder = graph_mod.make_ts_dep_builder(spec, lambda _path: relative_file_list)
     assert builder(tmp_path)[str(source_file)]["imports"] == {str(dep_file)}
     assert graph_mod.ts_build_dep_graph(
         tmp_path,
         SimpleNamespace(import_query=None, resolve_import=None),
-        file_list,
+        absolute_file_list,
     ) == {}
 
 


### PR DESCRIPTION
## Summary
- normalize tree-sitter dep-graph `file_list` entries to absolute paths before parsing, graph initialization, and in-repo edge checks
- align graph keys with the absolute-path contract used by other dependency graph builders
- add regression coverage for production-style relative file lists returned by `find_source_files`

## Testing
- `uv run --with pytest python -m pytest desloppify/tests/lang/common/test_treesitter_imports_direct.py desloppify/tests/lang/common/test_treesitter.py`
