### PR TITLE
Guard subjective scoring against null detail

### DIFF
--- a/desloppify/engine/_scoring/subjective/core.py
+++ b/desloppify/engine/_scoring/subjective/core.py
@@ -10,7 +10,7 @@ from desloppify.base.subjective_dimensions import (
 )
 from desloppify.base.text_utils import is_numeric
 from desloppify.engine._scoring.policy.core import SUBJECTIVE_CHECKS
-from desloppify.engine._state.issue_semantics import is_review_work_item
+from desloppify.engine._state.issue_semantics import _detail_dict, is_review_work_item
 
 
 def _display_fallback(dim_name: str) -> str:
@@ -172,7 +172,7 @@ def _subjective_issue_count(
         for issue in issues.values()
         if is_review_work_item(issue)
         and issue.get("status") in failure_set
-        and _normalize_dimension_key(issue.get("detail", {}).get("dimension")) == dim_name
+        and _normalize_dimension_key(_detail_dict(issue).get("dimension")) == dim_name
     )
 
 

--- a/desloppify/tests/scoring/test_scoring_subjective_and_display.py
+++ b/desloppify/tests/scoring/test_scoring_subjective_and_display.py
@@ -251,6 +251,24 @@ class TestSubjectiveScoring:
         assert det["pass_rate"] == 0.7
         assert dim["score"] == 70.0
 
+    def test_assessment_ignores_review_issue_with_detail_none(self):
+        f1 = _issue("review", status="open", file="a.py")
+        f1["detail"] = None
+        f2 = _issue("review", status="open", file="b.py")
+        f2["detail"] = {"dimension": "naming_quality"}
+        issues = _issues_dict(f1, f2)
+        assessments = {"naming_quality": {"score": 70}}
+
+        result = compute_dimension_scores(
+            issues, {}, subjective_assessments=assessments
+        )
+
+        dim = result["Naming quality"]
+        det = dim["detectors"]["subjective_assessment"]
+        assert dim["failing"] == 1
+        assert det["failing"] == 1
+        assert dim["score"] == 70.0
+
     def test_assessment_component_breakdown_propagates_to_detector_metadata(self):
         assessments = {
             "abstraction_fitness": {


### PR DESCRIPTION
## Summary
- use the existing `_detail_dict()` helper when reading review issue dimensions during subjective scoring
- prevent `detail: null` review issues from crashing `_subjective_issue_count()`
- add a regression proving subjective scoring ignores `detail=None` and still counts valid matching issues

## Testing
- `uv run --with pytest python -m pytest desloppify/tests/scoring/test_scoring_subjective_and_display.py`
