### PR TITLE
Fix empty if-chain same-line else removal

### DIFF
--- a/desloppify/languages/typescript/fixers/if_chain.py
+++ b/desloppify/languages/typescript/fixers/if_chain.py
@@ -57,12 +57,12 @@ def _find_if_chain_end(lines: list[str], start: int) -> int:
                 if found_brace and brace_depth == 0:
                     rest = line[ci + 1 :].strip()
                     if rest.startswith("else"):
-                        break
+                        continue
                     j = i + 1
                     while j < len(lines) and lines[j].strip() == "":
                         j += 1
                     if j < len(lines) and lines[j].strip().startswith("else"):
-                        break
+                        continue
                     return i
 
     return start

--- a/desloppify/tests/lang/typescript/test_ts_empty_if_chain_fixer_direct.py
+++ b/desloppify/tests/lang/typescript/test_ts_empty_if_chain_fixer_direct.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from desloppify.languages.typescript.fixers.if_chain import fix_empty_if_chain
+
+
+def test_same_line_else_chain_is_removed_completely(tmp_path: Path) -> None:
+    target = tmp_path / "test.ts"
+    target.write_text("if (x) {\n} else {\n}\n", encoding="utf-8")
+
+    result = fix_empty_if_chain(
+        [{"file": str(target), "line": 1}],
+        dry_run=False,
+    )
+
+    assert result.entries == [
+        {"file": str(target), "removed": ["empty_if_chain"], "lines_removed": 3}
+    ]
+    assert target.read_text(encoding="utf-8") == ""


### PR DESCRIPTION
## Summary
- keep scanning `} else {` continuations in `_find_if_chain_end()` so brace depth stays balanced across the full if/else chain
- replace the premature `break` paths with `continue`, allowing the scanner to process the `{` that opens the else block
- add a regression proving the empty-if-chain fixer removes the whole same-line else chain instead of leaving orphaned braces behind

## Testing
- `uv run --with pytest python -m pytest desloppify/tests/lang/typescript/test_ts_empty_if_chain_fixer_direct.py desloppify/tests/lang/typescript/test_typescript_detectors_fixers_and_wrappers_split_direct.py`
