### PR TITLE
Reject non-finite prompt weights

### DIFF
--- a/desloppify/base/text_utils.py
+++ b/desloppify/base/text_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 
 
@@ -102,13 +103,17 @@ def strip_c_style_comments(text: str) -> str:
 
 
 def is_numeric(value: object) -> bool:
-    """Return True if *value* is an int or float but NOT a bool.
+    """Return True if *value* is a finite int or float but NOT a bool.
 
     Python's ``bool`` is a subclass of ``int``, so ``isinstance(True, int)``
     is ``True``.  Many JSON-derived payloads need to distinguish real numbers
     from booleans; this helper centralises that guard.
     """
-    return isinstance(value, int | float) and not isinstance(value, bool)
+    if isinstance(value, bool):
+        return False
+    if not isinstance(value, int | float):
+        return False
+    return math.isfinite(float(value))
 
 
 __all__ = [

--- a/desloppify/tests/review/policy/test_review_dimensions_direct.py
+++ b/desloppify/tests/review/policy/test_review_dimensions_direct.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import math
 from types import SimpleNamespace
 
 import pytest
 
+from desloppify.base.text_utils import is_numeric
 import desloppify.intelligence.review.dimensions.data as dimensions_data_mod
 import desloppify.intelligence.review.dimensions.lang as dimensions_mod
 import desloppify.intelligence.review.dimensions.metadata as dimensions_metadata_mod
@@ -360,6 +362,28 @@ def test_parse_dimensions_payload_supports_meta_enabled_defaults():
     assert prompts["structure_signal"]["meta"]["enabled_by_default"] is True
     assert prompts["structure_signal"]["meta"]["display_name"] == "Structure Signal"
     assert prompts["structure_signal"]["meta"]["weight"] == 4.5
+
+
+def test_is_numeric_rejects_non_finite_floats():
+    assert is_numeric(1) is True
+    assert is_numeric(1.5) is True
+    assert is_numeric(math.inf) is False
+    assert is_numeric(-math.inf) is False
+    assert is_numeric(math.nan) is False
+
+
+def test_validate_prompt_meta_rejects_non_finite_weight():
+    with pytest.raises(ValueError, match=r"prompt\.meta\.weight must be a number"):
+        dimensions_validation_mod.validate_prompt_meta(
+            {"weight": math.inf},
+            context="prompt.meta",
+        )
+
+    with pytest.raises(ValueError, match=r"prompt\.meta\.weight must be a number"):
+        dimensions_validation_mod.validate_prompt_meta(
+            {"weight": math.nan},
+            context="prompt.meta",
+        )
 
 
 def test_load_dimensions_for_lang_meta_enabled_dimension_requires_no_append(


### PR DESCRIPTION
## Summary
- make shared numeric validation reject non-finite floats like `Infinity`, `-Infinity`, and `NaN`
- ensure review dimension prompt metadata rejects non-finite weight values at validation time
- add regressions for both the shared helper and prompt meta validation

## Testing
- `uv run --with pytest python -m pytest desloppify/tests/review/policy/test_review_dimensions_direct.py -k "meta_enabled_defaults or validate_prompt_meta_rejects_non_finite_weight or is_numeric_rejects_non_finite_floats"`
