### PR TITLE
Preserve hidden path prefixes in exclusions

### DIFF
--- a/desloppify/base/discovery/file_paths.py
+++ b/desloppify/base/discovery/file_paths.py
@@ -21,7 +21,7 @@ def matches_exclusion(rel_path: str, exclusion: str) -> bool:
         # Full-path glob match for patterns with directory separators
         # (e.g. "Wan2GP/**" should match "Wan2GP/models/rf.py").
         if "/" in exclusion or os.sep in exclusion:
-            normalized_path = rel_path.lstrip("./")
+            normalized_path = rel_path.removeprefix("./")
             if fnmatch.fnmatch(normalized_path, exclusion):
                 return True
     if "/" in exclusion or os.sep in exclusion:

--- a/desloppify/tests/core/test_utils.py
+++ b/desloppify/tests/core/test_utils.py
@@ -140,6 +140,12 @@ def test_matches_exclusion_exact_directory_path():
     assert matches_exclusion(".claude/worktrees", ".claude/worktrees") is True
 
 
+def test_matches_exclusion_hidden_dir_globs_preserve_leading_dot():
+    """Hidden directories should not match non-hidden glob prefixes."""
+    assert matches_exclusion(".cache/subdir/file.py", "cache/**") is False
+    assert matches_exclusion(".cache/subdir/file.py", ".cache/**") is True
+
+
 # ── find_source_files() ─────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- replace the exclusion helper's broad `lstrip` normalization with exact `./` prefix removal
- preserve leading dots for hidden paths so `.cache/**` and `cache/**` remain distinct
- add direct regression coverage for hidden-directory glob matching

## Testing
- `uv run --with pytest python -m pytest desloppify/tests/core/test_utils.py -k "matches_exclusion"`
