### PR TITLE
Exclude observe-auto issues from reflect ledger parsing

### DIFF
--- a/desloppify/app/commands/plan/triage/stages/reflect.py
+++ b/desloppify/app/commands/plan/triage/stages/reflect.py
@@ -153,7 +153,7 @@ def _validate_reflect_submission(
         return None
 
     # Parse structured disposition ledger from Coverage Ledger section
-    disposition_ledger = parse_reflect_dispositions(report, valid_ids)
+    disposition_ledger = parse_reflect_dispositions(report, accounting_ids)
 
     # Validate backlog decisions for auto-clusters (warn, don't block)
     auto_clusters = getattr(triage_input, "auto_clusters", None) or {}

--- a/desloppify/tests/commands/plan/test_triage_stage_flow_observe_reflect_organize_direct.py
+++ b/desloppify/tests/commands/plan/test_triage_stage_flow_observe_reflect_organize_direct.py
@@ -193,3 +193,62 @@ def test_reflect_rejects_incomplete_issue_accounting(monkeypatch, capsys) -> Non
     out = capsys.readouterr().out
     assert "account for every open review issue exactly once" in out
     assert "reflect" not in plan["epic_triage_meta"]["triage_stages"]
+
+
+def test_validate_reflect_submission_excludes_observe_auto_from_disposition_ledger(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    plan = {
+        "epic_triage_meta": {
+            "issue_dispositions": {
+                "review::naming::bbbb2222": {
+                    "decision": "skip",
+                    "target": "duplicate-work",
+                    "decision_source": "observe_auto",
+                }
+            },
+            "triage_stages": {
+                "observe": {
+                    "report": "x" * 120,
+                    "confirmed_at": "2026-03-09T00:00:00Z",
+                }
+            },
+        }
+    }
+    open_issues = {
+        "review::complexity::aaaa1111": {"status": "open"},
+        "review::naming::bbbb2222": {"status": "open"},
+    }
+    services, _saved, _logs = _services(plan, state={"issues": open_issues}, open_issues=open_issues)
+
+    monkeypatch.setattr(reflect_mod, "auto_confirm_observe_if_attested", lambda **_kwargs: True)
+    monkeypatch.setattr(reflect_mod, "validate_stage_report_length", lambda **_kwargs: True)
+    monkeypatch.setattr(reflect_mod, "_validate_recurring_dimension_mentions", lambda **_kwargs: True)
+    monkeypatch.setattr(reflect_mod, "validate_reflect_accounting", lambda **_kwargs: (True, {"review::complexity::aaaa1111"}, [], []))
+    monkeypatch.setattr(reflect_mod, "validate_backlog_decisions", lambda **_kwargs: ([], []))
+    monkeypatch.setattr(reflect_mod, "parse_backlog_decisions", lambda _report: [])
+
+    def _capture_parse(report: str, valid_ids: set[str]):
+        captured["report"] = report
+        captured["valid_ids"] = valid_ids
+        return []
+
+    monkeypatch.setattr(reflect_mod, "parse_reflect_dispositions", _capture_parse)
+
+    result = reflect_mod._validate_reflect_submission(
+        report=(
+            "## Coverage Ledger\n"
+            '- aaaa1111 -> cluster "cluster-alpha"\n'
+            '- bbbb2222 -> skip "duplicate-work"\n'
+            "## Strategy\n"
+        ),
+        plan=plan,
+        state={"issues": open_issues},
+        stages=plan["epic_triage_meta"]["triage_stages"],
+        attestation=None,
+        services=services,
+    )
+
+    assert result is not None
+    assert captured["valid_ids"] == {"review::complexity::aaaa1111"}


### PR DESCRIPTION
## Summary
- use `accounting_ids` rather than `valid_ids` when parsing the reflect coverage ledger
- keep observe-auto issues out of the reflect disposition ledger so their `decision_source` stays preserved
- add a direct reflect-stage regression proving observe-auto issues are excluded from the parser input

## Testing
- `uv run --with pytest python -m pytest desloppify/tests/commands/plan/test_triage_stage_flow_observe_reflect_organize_direct.py -k "reflect_rejects_incomplete_issue_accounting or excludes_observe_auto_from_disposition_ledger"`
