### PR TITLE
Mark all emptied resolve clusters done

### DIFF
--- a/desloppify/app/commands/resolve/living_plan.py
+++ b/desloppify/app/commands/resolve/living_plan.py
@@ -45,16 +45,41 @@ class ClusterContext(NamedTuple):
     cluster_remaining: int
 
 
+def _affected_cluster_names(plan: dict, resolved_ids: list[str]) -> list[str]:
+    """Return unique cluster names referenced by the resolved ids."""
+    overrides = plan.get("overrides") or {}
+    seen: set[str] = set()
+    cluster_names: list[str] = []
+    for resolved_id in resolved_ids:
+        override = overrides.get(resolved_id)
+        cluster_name = override.get("cluster") if isinstance(override, dict) else None
+        if not cluster_name or cluster_name in seen:
+            continue
+        seen.add(cluster_name)
+        cluster_names.append(cluster_name)
+    return cluster_names
+
+
+def _completed_cluster_names(plan: dict, resolved_ids: list[str]) -> list[str]:
+    """Return affected clusters whose issues are fully resolved by this command."""
+    clusters = plan.get("clusters") or {}
+    resolved_set = set(resolved_ids)
+    completed: list[str] = []
+    for cluster_name in _affected_cluster_names(plan, resolved_ids):
+        cluster = clusters.get(cluster_name)
+        if not isinstance(cluster, dict):
+            continue
+        current_ids = set(cluster.get("issue_ids") or [])
+        if current_ids - resolved_set:
+            continue
+        completed.append(cluster_name)
+    return completed
+
+
 def capture_cluster_context(plan: dict, resolved_ids: list[str]) -> ClusterContext:
     """Determine cluster membership for resolved issues before purge."""
     clusters = plan.get("clusters") or {}
-    overrides = plan.get("overrides") or {}
-    cluster_name: str | None = None
-    for resolved_id in resolved_ids:
-        override = overrides.get(resolved_id)
-        if override and override.get("cluster"):
-            cluster_name = override["cluster"]
-            break
+    cluster_name = next(iter(_affected_cluster_names(plan, resolved_ids)), None)
     if not cluster_name or cluster_name not in clusters:
         return ClusterContext(
             cluster_name=None, cluster_completed=False, cluster_remaining=0
@@ -87,6 +112,7 @@ def update_living_plan_after_resolve(
             return None, ctx
         plan = load_plan(plan_path)
         ctx = capture_cluster_context(plan, all_resolved)
+        completed_clusters = _completed_cluster_names(plan, all_resolved)
         phase_before = current_lifecycle_phase(plan)
         purged = purge_ids(plan, all_resolved)
         step_messages = auto_complete_steps(plan)
@@ -100,20 +126,21 @@ def update_living_plan_after_resolve(
             note=getattr(args, "note", None),
             detail={"status": args.status, "attestation": attestation},
         )
-        if ctx.cluster_completed and ctx.cluster_name:
-            append_log_entry(
-                plan,
-                "cluster_done",
-                issue_ids=all_resolved,
-                cluster_name=ctx.cluster_name,
-                actor="user",
-            )
-            # Mark cluster as done so cluster_is_active() returns False
-            plan["clusters"][ctx.cluster_name]["execution_status"] = (
-                EXECUTION_STATUS_DONE
-            )
-            # Clear focus when cluster is done
-            if plan.get("active_cluster") == ctx.cluster_name:
+        if completed_clusters:
+            for cluster_name in completed_clusters:
+                append_log_entry(
+                    plan,
+                    "cluster_done",
+                    issue_ids=all_resolved,
+                    cluster_name=cluster_name,
+                    actor="user",
+                )
+                # Mark cluster as done so cluster_is_active() returns False
+                plan["clusters"][cluster_name]["execution_status"] = (
+                    EXECUTION_STATUS_DONE
+                )
+            # Clear focus when the active cluster is done
+            if plan.get("active_cluster") in set(completed_clusters):
                 plan["active_cluster"] = None
         elif ctx.cluster_name and ctx.cluster_remaining > 0:
             # Auto-focus on the cluster while there's still work in it

--- a/desloppify/tests/commands/resolve/test_living_plan_direct.py
+++ b/desloppify/tests/commands/resolve/test_living_plan_direct.py
@@ -29,6 +29,26 @@ def test_capture_cluster_context_returns_remaining_counts() -> None:
     assert done_ctx.cluster_remaining == 0
 
 
+def test_completed_cluster_names_returns_all_empty_clusters() -> None:
+    plan = {
+        "overrides": {
+            "a": {"cluster": "epic/x"},
+            "b": {"cluster": "epic/x"},
+            "c": {"cluster": "epic/y"},
+            "d": {"cluster": "epic/y"},
+        },
+        "clusters": {
+            "epic/x": {"issue_ids": ["a", "b"]},
+            "epic/y": {"issue_ids": ["c", "d"]},
+        },
+    }
+
+    assert living_plan_mod._completed_cluster_names(plan, ["a", "b", "c", "d"]) == [
+        "epic/x",
+        "epic/y",
+    ]
+
+
 def test_update_living_plan_after_resolve_no_living_plan(monkeypatch) -> None:
     monkeypatch.setattr(living_plan_mod, "has_living_plan", lambda _p=None: False)
     plan, ctx = living_plan_mod.update_living_plan_after_resolve(
@@ -81,6 +101,58 @@ def test_update_living_plan_after_resolve_fixed_flow(monkeypatch, capsys) -> Non
     assert "Plan updated: 1 item(s)" in out
     assert calls.count("log") == 2  # resolve + cluster_done
     assert "add" in calls and "clear" in calls and "save" in calls
+
+
+def test_update_living_plan_after_resolve_marks_all_completed_clusters_done(
+    monkeypatch,
+) -> None:
+    plan = {
+        "queue_order": ["a", "b"],
+        "active_cluster": "epic/y",
+        "overrides": {
+            "a": {"cluster": "epic/x"},
+            "b": {"cluster": "epic/y"},
+        },
+        "clusters": {
+            "epic/x": {"issue_ids": ["a"], "execution_status": "active"},
+            "epic/y": {"issue_ids": ["b"], "execution_status": "active"},
+        },
+    }
+    calls: list[tuple[str, str | None]] = []
+
+    monkeypatch.setattr(living_plan_mod, "has_living_plan", lambda _p=None: True)
+    monkeypatch.setattr(living_plan_mod, "load_plan", lambda _p=None: plan)
+    monkeypatch.setattr(living_plan_mod, "purge_ids", lambda _plan, _ids: 2)
+    monkeypatch.setattr(living_plan_mod, "auto_complete_steps", lambda _plan: [])
+    monkeypatch.setattr(
+        living_plan_mod,
+        "append_log_entry",
+        lambda _plan, event, **kwargs: calls.append((event, kwargs.get("cluster_name"))),
+    )
+    monkeypatch.setattr(
+        living_plan_mod, "add_uncommitted_issues", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(
+        living_plan_mod, "invalidate_postflight_scan", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(living_plan_mod, "save_plan", lambda _plan, _p=None: None)
+
+    updated_plan, ctx = living_plan_mod.update_living_plan_after_resolve(
+        args=_args(status="fixed", note="done"),
+        all_resolved=["a", "b"],
+        attestation="attest",
+    )
+
+    assert updated_plan is plan
+    assert ctx.cluster_name == "epic/x"
+    assert updated_plan["clusters"]["epic/x"]["execution_status"] == "done"
+    assert updated_plan["clusters"]["epic/y"]["execution_status"] == "done"
+    assert updated_plan["active_cluster"] is None
+    assert calls == [
+        ("resolve", None),
+        ("cluster_done", "epic/x"),
+        ("cluster_done", "epic/y"),
+    ]
 
 
 def test_update_living_plan_after_resolve_reconciles_when_queue_drains(


### PR DESCRIPTION
## Summary
- track all clusters affected by a multi-pattern resolve instead of only the first matching cluster
- mark every cluster emptied by the resolve as `done` and emit a `cluster_done` log entry for each
- add regressions for multi-cluster completion in the resolve living-plan path

## Testing
- `uv run --with pytest python -m pytest desloppify/tests/commands/resolve/test_living_plan_direct.py`
