### PR TITLE
Reject orphan cluster step update flags

### DIFF
--- a/desloppify/app/commands/plan/cluster/update_flow.py
+++ b/desloppify/app/commands/plan/cluster/update_flow.py
@@ -105,6 +105,18 @@ def build_request(args) -> ClusterUpdateRequest:
         update_title = add_step
         add_step = None
 
+    if update_title is not None and update_step is None:
+        raise CommandError("--update-title requires --update-step")
+
+    if (
+        getattr(args, "detail", None) is not None
+        or getattr(args, "effort", None) is not None
+        or getattr(args, "issue_refs", None) is not None
+    ) and add_step is None and update_step is None:
+        raise CommandError(
+            "--detail, --effort, and --issue-refs require --add-step or --update-step"
+        )
+
     return ClusterUpdateRequest(
         cluster_name=str(getattr(args, "cluster_name", "")),
         description=getattr(args, "description", None),

--- a/desloppify/tests/commands/plan/test_cluster_ops_direct.py
+++ b/desloppify/tests/commands/plan/test_cluster_ops_direct.py
@@ -36,6 +36,55 @@ def test_cluster_steps_print_step_variants(capsys) -> None:
     assert "2. [x] Done step" in out
 
 
+def test_build_request_rejects_update_title_without_update_step() -> None:
+    args = argparse.Namespace(
+        cluster_name="alpha",
+        description=None,
+        steps=None,
+        steps_file=None,
+        add_step=None,
+        update_title="rename step",
+        detail=None,
+        update_step=None,
+        remove_step=None,
+        done_step=None,
+        undone_step=None,
+        priority=None,
+        effort=None,
+        depends_on=None,
+        issue_refs=None,
+    )
+
+    with pytest.raises(CommandError, match="--update-title requires --update-step"):
+        cluster_update_flow_mod.build_request(args)
+
+
+def test_build_request_rejects_orphan_step_metadata_flags() -> None:
+    args = argparse.Namespace(
+        cluster_name="alpha",
+        description=None,
+        steps=None,
+        steps_file=None,
+        add_step=None,
+        update_title=None,
+        detail="extra detail",
+        update_step=None,
+        remove_step=None,
+        done_step=None,
+        undone_step=None,
+        priority=None,
+        effort="small",
+        depends_on=None,
+        issue_refs=["review::a::b"],
+    )
+
+    with pytest.raises(
+        CommandError,
+        match="--detail, --effort, and --issue-refs require --add-step or --update-step",
+    ):
+        cluster_update_flow_mod.build_request(args)
+
+
 def test_cluster_display_helpers_and_renderers(monkeypatch, capsys) -> None:
     plan = {
         "active_cluster": "alpha",


### PR DESCRIPTION
## Summary
- reject `--update-title` unless `--update-step` is also provided
- reject orphan `--detail`, `--effort`, and `--issue-refs` flags unless paired with `--add-step` or `--update-step`
- add direct regressions for the new request-builder validation

## Testing
- `uv run --with pytest python -m pytest desloppify/tests/commands/plan/test_cluster_ops_direct.py -k "build_request_rejects or cluster_update"`
