### PR TITLE
fix: fall back to eslint for next lint on Next 16

### DIFF
--- a/desloppify/languages/_framework/frameworks/phases.py
+++ b/desloppify/languages/_framework/frameworks/phases.py
@@ -139,6 +139,7 @@ def _framework_tool_phase(spec: FrameworkSpec, tool: ToolIntegration) -> Detecto
         tool.id,
         tool.tier,
         confidence=tool.confidence,
+        fallback_cmds=tool.fallback_cmds,
     )
     tool_phase.slow = bool(tool.slow)
 

--- a/desloppify/languages/_framework/frameworks/specs/nextjs.py
+++ b/desloppify/languages/_framework/frameworks/specs/nextjs.py
@@ -545,6 +545,7 @@ NEXTJS_SPEC = FrameworkSpec(
             id="next_lint",
             label="next lint",
             cmd="npx --no-install next lint --format json",
+            fallback_cmds=("npx --no-install eslint --format json .",),
             fmt="next_lint",
             tier=2,
             slow=True,

--- a/desloppify/languages/_framework/frameworks/types.py
+++ b/desloppify/languages/_framework/frameworks/types.py
@@ -49,6 +49,7 @@ class ToolIntegration:
     cmd: str
     fmt: str
     tier: int
+    fallback_cmds: tuple[str, ...] = ()
     slow: bool = False
     confidence: str = "medium"
 

--- a/desloppify/languages/_framework/generic_parts/tool_factories.py
+++ b/desloppify/languages/_framework/generic_parts/tool_factories.py
@@ -66,13 +66,20 @@ def make_tool_phase(
     *,
     confidence: str = "medium",
     cwd_fn: Callable[[Path, Any], Path] | None = None,
+    fallback_cmds: tuple[str, ...] = (),
 ) -> DetectorPhase:
     """Create a DetectorPhase that runs an external tool and parses output."""
     parser = PARSERS[fmt]
 
     def run(path: Path, lang: Any) -> tuple[list[dict[str, Any]], dict[str, int]]:
         run_path = cwd_fn(path, lang).resolve() if cwd_fn is not None else path
-        run_result = run_tool_result(cmd, run_path, parser)
+        run_result = None
+        for candidate_cmd in (cmd, *fallback_cmds):
+            run_result = run_tool_result(candidate_cmd, run_path, parser)
+            if run_result.status != "error":
+                break
+        if run_result is None:
+            return [], {}
         if run_result.status == "error":
             _record_tool_failure_coverage(
                 lang,

--- a/desloppify/tests/detectors/test_next_lint.py
+++ b/desloppify/tests/detectors/test_next_lint.py
@@ -138,6 +138,54 @@ def test_next_lint_tool_phase_reports_potential_when_clean(monkeypatch, tmp_path
     assert signals == {"next_lint": 1}
 
 
+def test_next_lint_tool_phase_falls_back_to_eslint_for_next_16(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    scan_path = tmp_path / "apps" / "web"
+    scan_path.mkdir(parents=True, exist_ok=True)
+
+    payload = [
+        {
+            "filePath": "app/page.tsx",
+            "messages": [{"line": 7, "message": "Use a button", "severity": 2}],
+        }
+    ]
+    calls: list[list[str]] = []
+
+    def fake_run(argv, *, shell, cwd, capture_output, text, timeout):
+        del shell, cwd, capture_output, text, timeout
+        calls.append(list(argv))
+        if "next" in argv and "lint" in argv:
+            return subprocess.CompletedProcess(
+                argv,
+                1,
+                stdout="",
+                stderr="Invalid project directory provided, no such directory: /tmp/example/lint",
+            )
+        return subprocess.CompletedProcess(argv, 1, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(tool_runner_mod.subprocess, "run", fake_run)
+
+    phase = make_tool_phase(
+        "next lint",
+        "npx --no-install next lint --format json",
+        "next_lint",
+        "next_lint",
+        2,
+        fallback_cmds=("npx --no-install eslint --format json .",),
+    )
+    lang = SimpleNamespace(detector_coverage={}, coverage_warnings=[])
+
+    issues, signals = phase.run(scan_path, lang)
+    assert len(calls) == 2
+    assert calls[0][-4:] == ["next", "lint", "--format", "json"]
+    assert calls[1][-4:] == ["eslint", "--format", "json", "."]
+    assert signals == {"next_lint": 1}
+    assert len(issues) == 1
+    assert issues[0]["detector"] == "next_lint"
+    assert issues[0]["file"] == "apps/web/app/page.tsx"
+    assert lang.coverage_warnings == []
+
+
 def test_next_lint_tool_phase_records_coverage_warning_on_tool_missing(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
 


### PR DESCRIPTION
## Problem
`desloppify` still shells out to `next lint` for the `next_lint` detector. In Next.js 16, that subcommand was removed, so scans against Next 16 apps report reduced detector coverage even when ESLint is configured and working.

## Fix
- add framework-tool fallback command support
- keep `next lint` as the primary command for older Next apps
- fall back to `npx --no-install eslint --format json .` for Next 16+
- cover the fallback path with a focused detector test

## Verification
- `./.venv/bin/python -m pytest desloppify/tests/detectors/test_next_lint.py -q`
- `./.venv/bin/python -m desloppify --lang typescript scan --path /Users/gerarddownes/dev/codeaim/workorderguard/apps/workorderguard-web`
- `desloppify --lang typescript scan --path ./apps/workorderguard-web` in WorkOrderGuard after installing the patched build, which removed the `Coverage reduced (next_lint)` warning and improved code-quality scoring from 92.8% to 93.8%
