### PR TITLE
fix: resolve disappeared test coverage issues

### DIFF
--- a/desloppify/engine/_state/merge_issues.py
+++ b/desloppify/engine/_state/merge_issues.py
@@ -148,10 +148,20 @@ def verify_disappeared(
                 file_deleted = not os.path.exists(
                     os.path.join(project_root, file_path)
                 )
+            detector = previous.get("detector", "")
+            if detector == "test_coverage":
+                # Coverage gaps are a detector-owned fact, not a manual judgment
+                # call. If the detector ran and a previous open issue disappeared,
+                # the scan has direct evidence that the file now has mapped tests.
+                previous["status"] = "auto_resolved"
+                previous["resolved_at"] = now
+                previous["note"] = "Auto-resolved: test coverage gap absent from latest scan"
+                resolved_detectors.add(detector or "unknown")
+                resolved += 1
+                continue
             # Auto-resolve if zone policy now says this detector should be
             # skipped for this file's zone (e.g. test_coverage on test files).
             # Bug reported by @claytona500 in PR #478.
-            detector = previous.get("detector", "")
             if zone_map and file_path and should_skip_issue(zone_map, file_path, detector):
                 previous["status"] = "auto_resolved"
                 previous["resolved_at"] = now

--- a/desloppify/tests/state/test_state.py
+++ b/desloppify/tests/state/test_state.py
@@ -681,7 +681,7 @@ class TestWontfixAutoResolution:
     """Wontfix issues stay authoritative when the detector produces no findings."""
 
     def test_wontfix_stays_wontfix_when_detector_ran(self):
-        """Wontfix issues stay wontfix and gain scan verification."""
+        """Open test coverage issues auto-resolve while wontfix stays authoritative."""
         st = empty_state()
         # Pre-populate 3 open + 2 wontfix test_coverage issues
         for i in range(3):
@@ -707,7 +707,11 @@ class TestWontfixAutoResolution:
         diff = merge_scan(
             st, [], MergeScanOptions(lang="python", potentials={"test_coverage": 50, "smells": 100})
         )
-        assert diff["auto_resolved"] == 2
+        assert diff["auto_resolved"] == 5
+        assert (
+            st["issues"]["test_coverage::mod0.py::untested_module"]["status"]
+            == "auto_resolved"
+        )
         assert (
             st["issues"]["test_coverage::mod3.py::untested_module"]["status"]
             == "wontfix"
@@ -715,10 +719,6 @@ class TestWontfixAutoResolution:
         assert (
             st["issues"]["test_coverage::mod4.py::untested_module"]["resolution_attestation"]["scan_verified"]
             is True
-        )
-        assert (
-            st["issues"]["test_coverage::mod0.py::untested_module"]["status"]
-            == "open"
         )
 
     def test_wontfix_not_resolved_when_detector_suspect(self):
@@ -804,6 +804,30 @@ class TestWontfixAutoResolution:
         assert (
             st["issues"]["test_coverage::mod3.py::untested_module"]["status"]
             == "open"
+        )
+
+    def test_open_test_coverage_issues_auto_resolve_when_detector_runs_clean(self):
+        """Disappeared open coverage issues should not linger as stale debt."""
+        st = empty_state()
+        issue = _make_raw_issue(
+            "test_coverage::mod.py::untested_module",
+            detector="test_coverage",
+            file="mod.py",
+            lang="python",
+        )
+        st["issues"][issue["id"]] = issue
+
+        diff = merge_scan(
+            st,
+            [],
+            MergeScanOptions(lang="python", potentials={"test_coverage": 10}),
+        )
+
+        assert diff["auto_resolved"] == 1
+        assert st["issues"][issue["id"]]["status"] == "auto_resolved"
+        assert (
+            st["issues"][issue["id"]]["note"]
+            == "Auto-resolved: test coverage gap absent from latest scan"
         )
 
     def test_empty_potentials_dict_not_treated_as_none(self):


### PR DESCRIPTION
## Problem
Running `desloppify --lang typescript scan --path libs/api-client` after adding tests can report `test coverage: clean`, but previously open `test_coverage` issues stay open and continue dragging the score.

In my repro on a TypeScript project, the detector cleared 54 coverage issues and objective score jumped from 69.6 to 95.2, but the stale open issues stayed in state because `verify_disappeared()` preserves open issues even when `test_coverage` ran cleanly.

## Fix
- auto-resolve disappeared open `test_coverage` issues when the detector actually ran and returned no matching issue
- keep existing `wontfix` coverage decisions manual and scan-verified
- add state tests covering the new behavior and preserve the suspect-detector safety case

## Verification
- `python -m pytest desloppify/tests/state/test_state.py -q`
- `python -m pytest desloppify/tests/commands/test_queue_count_consistency.py -q`
- `python -m pytest desloppify/tests/state/test_state.py desloppify/tests/commands/test_queue_count_consistency.py -q`
- verified against a real TypeScript repo where patched `desloppify` resolved 54 stale `test_coverage` issues and moved `Test health` from 14.1% to 100.0% while objective score moved from 69.6 to 95.2
