### PR TITLE
fix: choose an available tsconfig for TS unused detection

### DIFF
--- a/desloppify/languages/typescript/detectors/unused.py
+++ b/desloppify/languages/typescript/detectors/unused.py
@@ -42,6 +42,14 @@ _detect_unused_fallback = detect_unused_fallback
 _should_use_deno_fallback = should_use_deno_fallback
 
 
+def _select_unused_tsc_base_config(project_root: Path) -> str | None:
+    """Return the best project-local config for a temporary unused-symbol check."""
+    for candidate in ("tsconfig.app.json", "tsconfig.json", "jsconfig.json"):
+        if (project_root / candidate).is_file():
+            return f"./{candidate}"
+    return None
+
+
 def _run_tsc_unused_check(
     project_root: Path,
     tsconfig_path: Path,
@@ -84,18 +92,27 @@ def detect_unused(path: Path, category: str = "all") -> tuple[list[dict], int]:
     if _should_use_deno_fallback(path, ts_files):
         return _detect_unused_fallback(path, category)
 
+    project_root = get_project_root()
+    base_tsconfig = _select_unused_tsc_base_config(project_root)
+    if base_tsconfig is None:
+        logger.debug(
+            "Falling back to source-based unused detection: no tsconfig.app.json/tsconfig.json/jsconfig.json in %s",
+            project_root,
+        )
+        return _detect_unused_fallback(path, category)
+
     tmp_tsconfig = {
-        "extends": "./tsconfig.app.json",
+        "extends": base_tsconfig,
         "compilerOptions": {
             "noUnusedLocals": True,
             "noUnusedParameters": True,
         },
     }
-    tmp_path = get_project_root() / "tsconfig.desloppify.json"
+    tmp_path = project_root / "tsconfig.desloppify.json"
     try:
         safe_write_text(tmp_path, json.dumps(tmp_tsconfig, indent=2))
         try:
-            result = _run_tsc_unused_check(get_project_root(), tmp_path)
+            result = _run_tsc_unused_check(project_root, tmp_path)
         except (_proc_runtime.SubprocessError, OSError) as exc:
             logger.debug("Falling back to source-based unused detection: %s", exc)
             return _detect_unused_fallback(path, category)

--- a/desloppify/languages/typescript/tests/test_ts_unused.py
+++ b/desloppify/languages/typescript/tests/test_ts_unused.py
@@ -4,6 +4,7 @@ Note: detect_unused depends on tsc (TypeScript compiler) and a real project setu
 so we test what is feasible: the helper function _categorize_unused and module imports.
 """
 
+import json
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,7 @@ from desloppify.languages.typescript.detectors.unused import (
     TS6133_RE,
     TS6192_RE,
     _categorize_unused,
+    _select_unused_tsc_base_config,
     detect_unused,
 )
 
@@ -36,6 +38,7 @@ def test_module_imports():
     """Module can be imported without errors."""
     assert callable(detect_unused)
     assert callable(_categorize_unused)
+    assert callable(_select_unused_tsc_base_config)
     assert callable(ts_unused_mod._run_tsc_unused_check)
 
 
@@ -135,6 +138,27 @@ class TestCategorizeUnused:
 
 
 class TestDenoFallback:
+    def test_select_unused_tsc_base_config_prefers_tsconfig_app(self, tmp_path):
+        _write(tmp_path, "tsconfig.app.json", "{}\n")
+        _write(tmp_path, "tsconfig.json", "{}\n")
+
+        assert _select_unused_tsc_base_config(tmp_path) == "./tsconfig.app.json"
+
+    def test_select_unused_tsc_base_config_falls_back_to_tsconfig(self, tmp_path):
+        _write(tmp_path, "tsconfig.json", "{}\n")
+
+        assert _select_unused_tsc_base_config(tmp_path) == "./tsconfig.json"
+
+    def test_select_unused_tsc_base_config_supports_jsconfig(self, tmp_path):
+        _write(tmp_path, "jsconfig.json", "{}\n")
+
+        assert _select_unused_tsc_base_config(tmp_path) == "./jsconfig.json"
+
+    def test_select_unused_tsc_base_config_returns_none_without_project_config(
+        self, tmp_path
+    ):
+        assert _select_unused_tsc_base_config(tmp_path) is None
+
     def test_run_tsc_unused_check_uses_fixed_command(self, tmp_path, monkeypatch):
         class _Result:
             stdout = ""
@@ -164,6 +188,56 @@ class TestDenoFallback:
             ]
         assert recorded["cwd"] == tmp_path
         assert recorded["timeout"] == 120
+
+    def test_detect_unused_extends_project_tsconfig_when_app_config_missing(
+        self, tmp_path, monkeypatch
+    ):
+        _write(tmp_path, "tsconfig.json", "{}\n")
+        _write(tmp_path, "src/app.ts", "const x = 1;\n")
+
+        class _Result:
+            stdout = (
+                "src/app.ts(1,7): error TS6133: 'x' is declared but its value is never read.\n"
+            )
+            stderr = ""
+
+        captured: dict[str, object] = {}
+
+        def _fake_run(project_root, tsconfig_path):
+            captured["project_root"] = project_root
+            captured["tsconfig_path"] = tsconfig_path
+            captured["config"] = json.loads(Path(tsconfig_path).read_text())
+            return _Result()
+
+        monkeypatch.setattr(ts_unused_mod, "_run_tsc_unused_check", _fake_run)
+        entries, total = detect_unused(tmp_path / "src")
+
+        assert total == 1
+        assert entries and entries[0]["name"] == "x"
+        assert captured["project_root"] == tmp_path
+        assert captured["config"] == {
+            "extends": "./tsconfig.json",
+            "compilerOptions": {
+                "noUnusedLocals": True,
+                "noUnusedParameters": True,
+            },
+        }
+
+    def test_detect_unused_falls_back_without_any_project_config(
+        self, tmp_path, monkeypatch
+    ):
+        _write(tmp_path, "src/app.ts", "import { x } from './dep.ts';\nconst unusedLocal = 1;\n")
+        _write(tmp_path, "src/dep.ts", "export const x = 1;\n")
+
+        def _should_not_run(*args, **kwargs):
+            raise AssertionError("tsc subprocess should not run without a project config")
+
+        monkeypatch.setattr(ts_unused_mod, "_run_tsc_unused_check", _should_not_run)
+        entries, total = detect_unused(tmp_path / "src")
+
+        assert total == 2
+        names = {entry["name"] for entry in entries}
+        assert names == {"x", "unusedLocal"}
 
     def test_run_tsc_unused_check_raises_without_npx(self, tmp_path, monkeypatch):
         monkeypatch.setattr(ts_unused_mod.shutil, "which", lambda _name: None)
@@ -224,6 +298,7 @@ class TestDenoFallback:
 
     def test_detect_unused_non_deno_keeps_tsc_path(self, tmp_path, monkeypatch):
         """Regular TypeScript projects should still parse TS6133/TS6192 from tsc."""
+        _write(tmp_path, "tsconfig.json", "{}\n")
         _write(tmp_path, "src/app.ts", "const x = 1;\n")
 
         class _Result:
@@ -254,6 +329,7 @@ class TestDenoFallback:
     ):
         """A repo-level deno.lock alone should not disable tsc-based unused detection."""
         _write(tmp_path, "deno.lock", "{}\n")
+        _write(tmp_path, "tsconfig.json", "{}\n")
         _write(tmp_path, "src/app.ts", "const x = 1;\n")
 
         class _Result:


### PR DESCRIPTION
## Problem
The TypeScript unused detector always generated `tsconfig.desloppify.json` with:

```json
{
  "extends": "./tsconfig.app.json"
}
```

That works for app-style projects, but it breaks or behaves unpredictably for package-style TypeScript projects that only have `tsconfig.json` or `jsconfig.json`.

In a real monorepo package reproduction (`services/api` in WorkOrderGuard), this made the detector brittle because it assumed an app-only config layout instead of choosing an available project config.

## Fix
- add `_select_unused_tsc_base_config()` to choose the first available project-local config from `tsconfig.app.json`, `tsconfig.json`, or `jsconfig.json`
- fall back to the source-based unused detector when none of those config files exist instead of generating an invalid temp config
- keep the existing `tsconfig.app.json` preference for projects that already use that layout
- add regression tests for config selection, `tsconfig.json` fallback, `jsconfig.json` support, and no-config fallback behavior

## Validation
- `/tmp/desloppify-venv/bin/python -m pytest /tmp/desloppify-fix/desloppify/languages/typescript/tests/test_ts_unused.py -q`
- `/tmp/desloppify-venv/bin/python -m pytest /tmp/desloppify-fix/desloppify/languages/typescript/tests/test_ts_unused.py -q -k 'select_unused_tsc_base_config or extends_project_tsconfig or falls_back_without_any_project_config or non_deno_keeps_tsc_path or root_deno_lock'`
- `PATH=/Users/gerarddownes/.nvm/versions/node/v24.13.0/bin:$PATH /tmp/desloppify-venv/bin/desloppify scan --path src --state /tmp/desloppify-objective-services-api-patched.json --profile objective --no-badge --force-rescan --attest "I understand this is not the intended workflow and I am intentionally skipping queue completion"` run from WorkOrderGuard `services/api`
  - reproduced a fresh objective scan successfully with `objective_score: 98.8`
