### PR TITLE
fix: propagate ContextVar to prefetch executor workers

### DIFF
--- a/desloppify/languages/_framework/base/shared_phases_review.py
+++ b/desloppify/languages/_framework/base/shared_phases_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import contextvars
 import hashlib
 import logging
 import os
@@ -50,6 +51,20 @@ _FUNCTION_CACHE_ATTR = "_shared_review_function_cache"
 _PREFETCH_BOILERPLATE_KEY = "boilerplate"
 _PREFETCH_SECURITY_KEY = "security_lang"
 _PREFETCH_EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+
+
+def _submit_with_context(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> concurrent.futures.Future[Any]:
+    """Submit *fn* to the prefetch executor, preserving the caller's contextvars.
+
+    ``ThreadPoolExecutor`` does not propagate ``ContextVar`` values to worker
+    threads. Several runtime settings (notably user-configured path exclusions
+    read via ``get_exclusions()``) live in a ContextVar and are only observable
+    from the calling thread. Without this wrapper, detectors launched in the
+    pool (jscpd, security prefetch) see the process-default context and ignore
+    the current scan's configuration.
+    """
+    ctx = contextvars.copy_context()
+    return _PREFETCH_EXECUTOR.submit(ctx.run, fn, *args, **kwargs)
 
 
 def _detector_cache(review_cache: object, detector: str) -> dict[str, object] | None:
@@ -350,7 +365,7 @@ def prewarm_review_phase_detectors(
             else None
         )
         if cached_entries is None and _PREFETCH_BOILERPLATE_KEY not in futures:
-            futures[_PREFETCH_BOILERPLATE_KEY] = _PREFETCH_EXECUTOR.submit(
+            futures[_PREFETCH_BOILERPLATE_KEY] = _submit_with_context(
                 detect_with_jscpd,
                 path,
             )
@@ -377,7 +392,7 @@ def prewarm_review_phase_detectors(
             else None
         )
         if cached_result is None and _PREFETCH_SECURITY_KEY not in futures:
-            futures[_PREFETCH_SECURITY_KEY] = _PREFETCH_EXECUTOR.submit(
+            futures[_PREFETCH_SECURITY_KEY] = _submit_with_context(
                 lang.detect_lang_security_detailed,
                 files,
                 zone_map,

--- a/desloppify/tests/lang/common/test_shared_phases_prefetch_context.py
+++ b/desloppify/tests/lang/common/test_shared_phases_prefetch_context.py
@@ -1,0 +1,45 @@
+"""Regression tests for ContextVar propagation in prefetch executor.
+
+``_PREFETCH_EXECUTOR`` is a ``ThreadPoolExecutor`` that does not automatically
+carry ``ContextVar`` values into worker threads. Runtime settings that live in
+a context variable — most importantly user-configured path exclusions consumed
+via ``get_exclusions()`` — must still be observable from work submitted to the
+pool, otherwise detectors such as jscpd and the security prefetch ignore the
+current scan's configuration.
+"""
+
+from __future__ import annotations
+
+from desloppify.base.discovery.source import get_exclusions, set_exclusions
+from desloppify.base.runtime_state import runtime_scope
+from desloppify.languages._framework.base.shared_phases_review import (
+    _submit_with_context,
+)
+
+
+def test_submit_with_context_preserves_runtime_exclusions() -> None:
+    with runtime_scope():
+        set_exclusions(["tmp", "backend/tmp", ".refs"])
+
+        def _read_exclusions() -> tuple[str, ...]:
+            return get_exclusions()
+
+        future = _submit_with_context(_read_exclusions)
+        assert future.result(timeout=5) == ("tmp", "backend/tmp", ".refs")
+
+
+def test_submit_with_context_isolates_between_scopes() -> None:
+    with runtime_scope():
+        set_exclusions(["scope_a"])
+
+        def _snapshot() -> tuple[str, ...]:
+            return get_exclusions()
+
+        first = _submit_with_context(_snapshot).result(timeout=5)
+
+    with runtime_scope():
+        set_exclusions(["scope_b"])
+        second = _submit_with_context(_snapshot).result(timeout=5)
+
+    assert first == ("scope_a",)
+    assert second == ("scope_b",)


### PR DESCRIPTION
## Problem

Running a scan on a monorepo with large vendored trees under `tmp/`, `.refs/`, and feature worktrees reliably produced:

```
WARNING: Boilerplate duplication detection skipped: jscpd timed out after 120s.
```

…even after the user declared those directories in `config.exclude` via `desloppify exclude`. The same mechanism also silently mis-scopes the security prefetch for any language plugin that uses `lang.detect_lang_security_detailed` through the shared prefetch path.

## Root cause

`_PREFETCH_EXECUTOR` in `desloppify/languages/_framework/base/shared_phases_review.py` is a module-level `concurrent.futures.ThreadPoolExecutor(max_workers=2)` used for jscpd and language-security prefetch tasks.

Python's `ThreadPoolExecutor` does **not** propagate `ContextVar` values into worker threads. Several pieces of runtime state live in a `ContextVar` — most importantly the exclusion patterns set by `_apply_persisted_exclusions` → `set_exclusions(...)` in `cli.py`, which are read back via `get_exclusions()` when `_jscpd_ignore_arg` builds jscpd's `--ignore` list.

Inside the pool worker, the `ContextVar` lookup returned its default (`None`), `current_runtime_context()` fell back to the process-default `_PROCESS_RUNTIME_CONTEXT`, and `get_exclusions()` returned `()`. `_jscpd_ignore_arg` then degraded to `_BASE_IGNORES` only, so jscpd happily walked into `tmp/screenpipe/**`, `.refs/**`, worktree copies, etc. — exactly the directories the user excluded — and burned through its 120 s budget.

I verified the degradation by printing `_jscpd_ignore_arg(Path('.'))` from (a) the CLI context and (b) a `_PREFETCH_EXECUTOR.submit` worker: the worker's ignore list was strictly the `_BASE_IGNORES` set, while the CLI call included all of the user's persisted excludes.

## Fix

Add `_submit_with_context(fn, *args, **kwargs)` that wraps the submitted callable in `contextvars.copy_context().run(...)` before passing it to `_PREFETCH_EXECUTOR.submit(...)`. Route both prefetch submissions (jscpd boilerplate detection and language-security prefetch) through this helper.

The copied context carries the ContextVar bindings present at submit time, so `get_exclusions()` in the worker now sees the per-scan runtime context and `_jscpd_ignore_arg` emits the full ignore list.

## Tests

Added `desloppify/tests/lang/common/test_shared_phases_prefetch_context.py`:

- `test_submit_with_context_preserves_runtime_exclusions` — sets exclusions in a `runtime_scope`, submits a read-back callable through `_submit_with_context`, asserts the worker observes the same tuple. Fails on `main`, passes with the fix.
- `test_submit_with_context_isolates_between_scopes` — two sequential `runtime_scope` blocks with different exclusions must produce different worker-side snapshots (no cross-scope bleed).

Full suite (5532 passed, 153 skipped, 12 deselected) still green. The one deselected failure — `test_no_extra_bundled_files` complaining about `scoring.md` — predates this PR and is unrelated.

## Repro

On a repo with a big directory that is in `config.exclude` but not in `_BASE_IGNORES` (e.g. `tmp/` pointing at 200+ MB of vendored code):

```bash
desloppify exclude tmp
desloppify scan --path .
# → "WARNING: Boilerplate duplication detection skipped: jscpd timed out after 120s."
```

Inspect the running jscpd argv with `ps -eww`:

- Before: `--ignore` lists only `_BASE_IGNORES` (`**/.git/**`, `**/node_modules/**`, …), no `**/tmp/**`.
- After: `--ignore` includes every user-configured exclude basename.