### PR TITLE
fix: resolve relative/absolute path mismatch in ts_build_dep_graph + add Ruby test coverage module

### DIFF
--- a/desloppify/languages/_framework/treesitter/imports/graph.py
+++ b/desloppify/languages/_framework/treesitter/imports/graph.py
@@ -75,13 +75,23 @@ def ts_build_dep_graph(
             if resolved is None:
                 continue
 
-            # Normalize to absolute path.
-            if not os.path.isabs(resolved):
-                resolved = os.path.normpath(os.path.join(scan_path, resolved))
-
-            # Only track edges within the scanned file set.
+            # file_set may use relative or absolute paths depending on the
+            # file_finder. Try the resolved path as-is first, then try the
+            # absolute form (for relative resolvers with an absolute file_set)
+            # and the relative form (for absolute resolvers with a relative
+            # file_set).
             if resolved not in file_set:
-                continue
+                if os.path.isabs(resolved):
+                    try:
+                        alt = os.path.relpath(resolved, scan_path)
+                    except ValueError:
+                        alt = resolved
+                else:
+                    alt = os.path.normpath(os.path.join(scan_path, resolved))
+                if alt in file_set:
+                    resolved = alt
+                else:
+                    continue
 
             graph[filepath]["imports"].add(resolved)
             if resolved in graph:

--- a/desloppify/languages/ruby/__init__.py
+++ b/desloppify/languages/ruby/__init__.py
@@ -7,6 +7,7 @@ extraction for duplicate detection and import-graph analysis at no extra cost.
 
 from desloppify.languages._framework.generic_support.core import generic_lang
 from desloppify.languages._framework.treesitter import RUBY_SPEC
+from desloppify.languages.ruby import test_coverage as _test_coverage_mod
 
 generic_lang(
     name="ruby",
@@ -46,6 +47,7 @@ generic_lang(
         "*.gemspec",     # Gem specification — present in library/gem projects
     ],
     treesitter_spec=RUBY_SPEC,
+    test_coverage_module=_test_coverage_mod,
 )
 
 __all__ = [

--- a/desloppify/languages/ruby/test_coverage.py
+++ b/desloppify/languages/ruby/test_coverage.py
@@ -1,0 +1,183 @@
+"""Ruby-specific test coverage heuristics and mappings.
+
+Supports RSpec (_spec.rb) and Minitest (test_*.rb / *_test.rb) naming conventions.
+Handles ``require_relative`` and ``require`` statement parsing for import-based
+coverage mapping, including cross-directory ``require_relative`` paths such as
+``require_relative "../lib/my_module"`` from a ``spec/`` directory.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+# ── Assertion / mock / snapshot patterns ──────────────────────
+
+ASSERT_PATTERNS = [
+    re.compile(p)
+    for p in [
+        r"\bexpect\s*\(",
+        r"\bshould\b",
+        r"\bshould_not\b",
+        r"\bassert\w*\s*\(",
+        r"\brefute\w*\s*\(",
+        r"\.to\s+(?:eq|be|raise_error|have_been_requested|include|match|be_nil|be_truthy|be_falsey)\b",
+        r"\.not_to\s+raise_error",
+    ]
+]
+
+MOCK_PATTERNS = [
+    re.compile(p)
+    for p in [
+        r"\ballow\s*\(",
+        r"\bexpect\s*\(",
+        r"\breceive\s*\(",
+        r"\band_return\b",
+        r"\bstub_request\s*\(",
+        r"\binstance_double\s*\(",
+        r"\bdouble\s*\(",
+        r"\bspy\s*\(",
+    ]
+]
+
+SNAPSHOT_PATTERNS: list[re.Pattern[str]] = []
+
+TEST_FUNCTION_RE = re.compile(
+    r"(?m)"
+    r"(?:"
+    r"^\s*(?:it|describe|context|specify|example)\s+['\"]"  # RSpec blocks
+    r"|^\s*def\s+test_\w+"                                  # Minitest method
+    r")"
+)
+
+# Ruby has no barrel files.
+BARREL_BASENAMES: set[str] = set()
+
+# ── require / require_relative parser ─────────────────────────
+
+_REQUIRE_RE = re.compile(
+    r"""(?m)^\s*require(?:_relative)?\s+['"]([^'"]+)['"]"""
+)
+
+
+def parse_test_import_specs(content: str) -> list[str]:
+    """Extract import specs from Ruby test content.
+
+    Returns the path strings from ``require`` and ``require_relative``
+    statements so the caller can resolve them to production file paths.
+    Standard library modules (no slashes, no ``../``) that look like simple
+    names are also returned — the resolver will discard those that don't match
+    any production file.
+    """
+    return [m.group(1) for m in _REQUIRE_RE.finditer(content)]
+
+
+# ── Testable logic heuristic ─────────────────────────────────
+
+_RUBY_DEF_RE = re.compile(
+    r"(?m)^\s*(?:def\s+\w|class\s+\w|module\s+\w)"
+)
+
+
+def has_testable_logic(filepath: str, content: str) -> bool:
+    """Return True when a Ruby file contains a method, class, or module definition."""
+    del filepath
+    return bool(_RUBY_DEF_RE.search(content))
+
+
+# ── Import spec resolver ──────────────────────────────────────
+
+def resolve_import_spec(
+    spec: str, test_path: str, production_files: set[str]
+) -> str | None:
+    """Resolve a Ruby ``require``/``require_relative`` path to a production file.
+
+    Handles:
+    - Relative paths (``require_relative``): resolved from the test file's dir.
+    - Bare names (``require``): checked as ``<spec>.rb`` and ``lib/<spec>.rb``.
+    """
+    if not spec:
+        return None
+
+    candidates: list[str] = []
+
+    # Relative path (contains "/" or starts with "."): resolve from test_path dir.
+    if "/" in spec or spec.startswith("."):
+        if test_path:
+            test_dir = os.path.dirname(test_path)
+            raw = os.path.normpath(os.path.join(test_dir, spec))
+            candidates.append(raw + ".rb")
+            candidates.append(raw)
+        else:
+            candidates.append(os.path.normpath(spec) + ".rb")
+    else:
+        # Bare name — could be stdlib (json, time, etc.) or a gem.
+        # Check common Ruby project layout locations.
+        candidates.extend([
+            f"{spec}.rb",
+            f"lib/{spec}.rb",
+        ])
+
+    for candidate in candidates:
+        # Normalise separators and leading ./
+        normalised = candidate.replace("\\", "/").lstrip("./")
+        if normalised in production_files:
+            return normalised
+        if candidate in production_files:
+            return candidate
+
+    return None
+
+
+def resolve_barrel_reexports(
+    _filepath: str, _production_files: set[str]
+) -> set[str]:
+    """Ruby has no barrel-file re-export expansion."""
+    return set()
+
+
+# ── Test marker stripping ─────────────────────────────────────
+
+def strip_test_markers(basename: str) -> str | None:
+    """Strip RSpec / Minitest naming markers to derive a source basename.
+
+    ``user_spec.rb``  → ``user.rb``
+    ``test_user.rb``  → ``user.rb``
+    ``user_test.rb``  → ``user.rb``
+    """
+    if basename.endswith("_spec.rb"):
+        return basename[: -len("_spec.rb")] + ".rb"
+    if basename.startswith("test_") and basename.endswith(".rb"):
+        return basename[len("test_"):].strip("_") + ".rb"
+    if basename.endswith("_test.rb"):
+        return basename[: -len("_test.rb")] + ".rb"
+    return None
+
+
+# ── Comment stripping ─────────────────────────────────────────
+
+def strip_comments(content: str) -> str:
+    """Strip Ruby # comments while preserving string literals."""
+    out: list[str] = []
+    for line in content.splitlines():
+        out.append(_strip_ruby_comment(line))
+    return "\n".join(out)
+
+
+def _strip_ruby_comment(line: str) -> str:
+    in_str: str | None = None
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if in_str:
+            if ch == "\\" and i + 1 < len(line):
+                i += 2
+                continue
+            if ch == in_str:
+                in_str = None
+        elif ch in ('"', "'"):
+            in_str = ch
+        elif ch == "#":
+            return line[:i]
+        i += 1
+    return line


### PR DESCRIPTION
## Problem

`ts_build_dep_graph` silently discards all import edges when `file_set` uses relative paths.

**Root cause**: `find_source_files` returns relative paths, so `file_set = set(file_list)` contains entries like `scripts/asc_client.rb`. But the function then normalizes `resolved` to an absolute path via `os.path.normpath(os.path.join(scan_path, resolved))`, making the membership check `if resolved not in file_set` always True — so no edge is ever added.

This affects all language plugins that use tree-sitter dep graph building (TypeScript, PHP, Ruby, etc.) whenever `find_source_files` is used as the file finder.

**Reproduction**: Point desloppify at a Ruby project with `require_relative` imports. The dep graph will always be empty `{}` despite correct tree-sitter parsing.

## Fix

Try the resolved path as-is first, then try the alternative form (absolute ↔ relative) before discarding. This handles both:
- Relative `file_set` + relative `resolved` (most backends via `find_source_files`)
- Absolute `file_set` + relative `resolved` (existing test fixtures)

## Ruby test coverage module

Also adds `desloppify/languages/ruby/test_coverage.py` with the required hooks:
- `parse_test_import_specs`: extracts `require`/`require_relative` paths
- `resolve_import_spec`: resolves relative paths from spec files to production files
- `has_testable_logic`: detects `def`/`class`/`module` definitions
- `strip_test_markers`: strips `_spec.rb`, `test_*.rb`, `*_test.rb` suffixes
- `strip_comments`: strips `#` comments while preserving string literals

Without this module, `get_lang_hook("ruby", "test_coverage")` returned `None`, leaving all Ruby scripts marked as untested regardless of the dep graph state.

And wires it in via `generic_lang(..., test_coverage_module=_test_coverage_mod)` in `ruby/__init__.py`.

## Tests

5543 passed, 153 skipped (1 pre-existing failure in `test_bundled_sync` unrelated to this change).