### PR TITLE
fix(bash): filter unused-import detector to source / . only

### DIFF
--- a/desloppify/languages/_framework/treesitter/specs/scripting.py
+++ b/desloppify/languages/_framework/treesitter/specs/scripting.py
@@ -47,9 +47,22 @@ BASH_SPEC = TreeSitterLangSpec(
             body: (compound_statement) @body) @func
     """,
     comment_node_types=frozenset({"comment"}),
+    # Filter to `source <path>` and `. <path>` only. The #match? predicate
+    # must be placed INSIDE the (command ...) pattern (the Julia spec in
+    # functional.py uses #eq? the same way for `include(...)`); placed
+    # outside the closing paren it parses as a separate top-level pattern
+    # and has no filtering effect.
+    #
+    # Without the predicate, the query matched every (command, argument)
+    # pair, so `set -euo pipefail` produced "Unused import: pipefail" and
+    # `curl -fsS https://...` produced "Unused import: -fsS" — every shell
+    # flag was a spurious finding. resolve_bash_source only resolves
+    # source/. invocations, but unused-imports flagging runs on the raw
+    # captured `path` before resolution, so the resolver couldn't save it.
     import_query="""
         (command
             name: (command_name) @_cmd
+            (#match? @_cmd "^(source|\\.)$")
             argument: (word) @path) @import
     """,
     resolve_import=resolve_bash_source,

--- a/desloppify/tests/lang/common/test_bash_unused_imports.py
+++ b/desloppify/tests/lang/common/test_bash_unused_imports.py
@@ -1,0 +1,79 @@
+"""Regression tests for the BASH_SPEC import_query predicate.
+
+The bash import query previously matched every (command, argument) pair as
+an "import", causing every shell flag to be reported as an unused import:
+    set -euo pipefail        →  Unused import: pipefail
+    curl -fsS https://...    →  Unused import: -fsS
+    find . -name '*.tmp'     →  Unused import: -name
+
+The fix adds a `(#match? @_cmd "^(source|\\.)$")` predicate INSIDE the
+(command ...) pattern so only `source <path>` and `. <path>` directives
+are captured. These tests pin both halves of the contract: real source
+imports must still be detected, and shell flags must not.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+
+def _detect(tmp_path, contents: str):
+    from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+        detect_unused_imports,
+    )
+    from desloppify.languages._framework.treesitter.specs.scripting import BASH_SPEC
+
+    script = tmp_path / "script.sh"
+    script.write_text(textwrap.dedent(contents).lstrip())
+    return detect_unused_imports([str(script)], BASH_SPEC)
+
+
+def test_bash_shell_flags_are_not_imports(tmp_path):
+    """`set -euo pipefail`, `curl -fsS ...`, etc. must produce zero findings.
+
+    Without the #match? predicate, every command argument was flagged.
+    """
+    findings = _detect(tmp_path, """
+        #!/bin/bash
+        set -euo pipefail
+        curl -fsS https://example.com >/dev/null
+        find . -name '*.tmp' -delete
+        cut -d: -f2 /etc/passwd
+    """)
+    assert findings == [], (
+        f"shell flags should not be unused imports, got: {findings}"
+    )
+
+
+def test_bash_unused_source_directive_is_flagged(tmp_path):
+    """`source ./helpers.sh` whose basename does not appear elsewhere is unused."""
+    findings = _detect(tmp_path, """
+        #!/bin/bash
+        source ./helpers.sh
+        echo body
+    """)
+    names = [f["name"] for f in findings]
+    assert "helpers" in names, f"expected unused 'helpers', got {findings}"
+
+
+def test_bash_unused_dot_source_directive_is_flagged(tmp_path):
+    """The POSIX `.` form is equivalent to `source` and must be filtered too."""
+    findings = _detect(tmp_path, """
+        #!/bin/bash
+        . ./extras.sh
+        echo body
+    """)
+    names = [f["name"] for f in findings]
+    assert "extras" in names, f"expected unused 'extras', got {findings}"
+
+
+def test_bash_used_source_directive_is_not_flagged(tmp_path):
+    """If the sourced file's basename is referenced later, do not flag it."""
+    findings = _detect(tmp_path, """
+        #!/bin/bash
+        source ./helpers.sh
+        helpers
+    """)
+    assert findings == [], (
+        f"used source should not be flagged, got: {findings}"
+    )


### PR DESCRIPTION
## Problem

`BASH_SPEC.import_query` in `desloppify/languages/_framework/treesitter/specs/scripting.py` captures every `(command, argument)` pair in any bash file as an "import". The unused-import phase then runs on those raw captures, so every shell flag becomes a spurious finding:

| Shell line | Reported as |
|---|---|
| `set -euo pipefail` | Unused import: `pipefail` |
| `curl -fsS https://...` | Unused import: `-fsS` |
| `find . -name '*.tmp'` | Unused import: `-name` |
| `cut -d: -f2` | Unused import: `-d` |

`resolve_bash_source` only resolves `source`/`.` invocations, but the unused-import phase flags on the raw captured `path` *before* resolution, so the resolver can't filter them out.

On a small bash-heavy repo (8 shell scripts) this produced ~80 false-positive `unused::*::unused_import` findings on a clean codebase.

## Fix

Add a `#match?` predicate **inside** the `(command ...)` pattern, restricting the query to `source <path>` and `. <path>`. Mirrors the existing `(#eq? @_fn "include")` pattern Julia's spec uses for `include(...)` calls in `functional.py`.

```diff
 import_query="""
     (command
         name: (command_name) @_cmd
+        (#match? @_cmd "^(source|\\\\.)$")
         argument: (word) @path) @import
 """,
```

Note: the predicate must be placed **inside** the pattern parens — placed outside it parses as a separate top-level pattern with no captures and has no filtering effect.

## Tests

New file `desloppify/tests/lang/common/test_bash_unused_imports.py` — 4 regression tests covering both halves of the contract:

- shell flags (`set -euo`, `curl -fsS`, `find -name`, `cut -d:`) → 0 findings
- unused `source ./helpers.sh` → flagged
- unused `. ./extras.sh` (POSIX form) → flagged
- used `source ./helpers.sh` referenced later → not flagged

```
$ pytest desloppify/tests/lang/common/test_treesitter.py \
         desloppify/tests/lang/common/test_treesitter_complexity_and_integration.py \
         desloppify/tests/lang/common/test_bash_unused_imports.py -q
151 passed, 1 skipped in 1.67s
```

## Verification on a real repo

Same scan target before and after the fix:

|  | Before | After |
|---|---|---|
| `unused::*::unused_import` findings on bash files | ~80 | 0 |
| Coverage of real `source` directives | drowned in noise | preserved |
