### PR TITLE
feat: add support for rovodev

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ I want you to improve the quality of this codebase. To do this, install and run 
 Run ALL of the following (requires Python 3.11+):
 
 pip install --upgrade "desloppify[full]"
-desloppify update-skill claude    # installs the full workflow guide — pick yours: claude, cursor, codex, copilot, droid, windsurf, gemini
+desloppify update-skill claude    # installs the full workflow guide — pick yours: claude, cursor, codex, copilot, droid, windsurf, gemini, rovodev
 
 Add .desloppify/ to your .gitignore — it contains local state that shouldn't be committed.
 

--- a/desloppify/app/cli_support/parser_groups_admin.py
+++ b/desloppify/app/cli_support/parser_groups_admin.py
@@ -195,7 +195,7 @@ def _add_update_skill_parser(sub) -> None:
         "interface",
         nargs="?",
         default=None,
-        help="Agent interface (amp, claude, codex, cursor, copilot, windsurf, gemini, hermes, droid, opencode). "
+        help="Agent interface (amp, claude, codex, cursor, copilot, windsurf, gemini, hermes, droid, opencode, rovodev). "
         "Auto-detected on updates if omitted.",
     )
 
@@ -208,6 +208,6 @@ def _add_setup_parser(sub) -> None:
     p.add_argument(
         "--interface",
         default=None,
-        choices=["amp", "claude", "codex", "gemini", "opencode"],
+        choices=["amp", "claude", "codex", "gemini", "opencode", "rovodev"],
         help="Install for a specific interface only",
     )

--- a/desloppify/app/cli_support/parser_groups_admin_review.py
+++ b/desloppify/app/cli_support/parser_groups_admin_review.py
@@ -23,6 +23,7 @@ examples:
   desloppify review --prepare
   desloppify review --run-batches --runner codex --parallel --scan-after-import
   desloppify review --run-batches --runner opencode --parallel --scan-after-import
+  desloppify review --run-batches --runner rovodev --parallel --scan-after-import
   desloppify review --external-start --external-runner claude
   desloppify review --external-submit --session-id <id> --import issues.json
   desloppify review --merge --similarity 0.8""",

--- a/desloppify/app/cli_support/parser_groups_admin_review_options_batch.py
+++ b/desloppify/app/cli_support/parser_groups_admin_review_options_batch.py
@@ -14,7 +14,7 @@ def _add_batch_execution_options(p_review: argparse.ArgumentParser) -> None:
     )
     g_batch.add_argument(
         "--runner",
-        choices=["codex", "opencode"],
+        choices=["codex", "opencode", "rovodev"],
         default="codex",
         help="Subagent runner backend (default: codex)",
     )

--- a/desloppify/app/cli_support/parser_groups_plan_impl_sections_triage_commit_scan.py
+++ b/desloppify/app/cli_support/parser_groups_plan_impl_sections_triage_commit_scan.py
@@ -14,6 +14,7 @@ examples:
   desloppify plan triage
   desloppify plan triage --run-stages --runner codex
   desloppify plan triage --run-stages --runner claude
+  desloppify plan triage --run-stages --runner rovodev
   desloppify plan triage --run-stages --runner codex --only-stages organize
   desloppify plan triage --stage strategize --report '{"score_trend":"stable","debt_trend":"stable"}'   # manual fallback
   desloppify plan triage --confirm-existing --note "..." --strategy "same" --confirmed "I reviewed the new issues and the existing plan still holds."\
@@ -86,7 +87,7 @@ examples:
         help="Preferred: run triage stages via the codex/claude staged runner",
     )
     p_triage.add_argument(
-        "--runner", choices=["codex", "claude"], default="codex",
+        "--runner", choices=["codex", "claude", "rovodev"], default="codex",
         help="Runner for --run-stages (default: codex)",
     )
     p_triage.add_argument(

--- a/desloppify/app/commands/helpers/guardrails.py
+++ b/desloppify/app/commands/helpers/guardrails.py
@@ -14,6 +14,7 @@ from desloppify.engine.plan_state import load_plan
 from desloppify.engine.plan_triage import (
     TRIAGE_CMD_RUN_STAGES_CLAUDE,
     TRIAGE_CMD_RUN_STAGES_CODEX,
+    TRIAGE_CMD_RUN_STAGES_ROVODEV,
     TriageSnapshot,
     build_triage_snapshot,
     triage_phase_banner,
@@ -90,7 +91,8 @@ def triage_guardrail_messages(
             messages.append(
                 f"{len(result.new_ids)} new review issue(s) not yet triaged."
                 " Run the staged triage runner to incorporate them "
-                f"(`{TRIAGE_CMD_RUN_STAGES_CODEX}` or `{TRIAGE_CMD_RUN_STAGES_CLAUDE}`)."
+                f"(`{TRIAGE_CMD_RUN_STAGES_CODEX}`, `{TRIAGE_CMD_RUN_STAGES_CLAUDE}`, "
+                f"or `{TRIAGE_CMD_RUN_STAGES_ROVODEV}`)."
             )
 
     if result._plan is not None:
@@ -166,8 +168,9 @@ def require_triage_current_or_exit(
         if len(new_ids) > 5:
             lines.append(f"    ... and {len(new_ids) - 5} more")
     lines.append("")
-    lines.append(f"  NEXT STEP (Codex):  {TRIAGE_CMD_RUN_STAGES_CODEX}")
-    lines.append(f"  NEXT STEP (Claude): {TRIAGE_CMD_RUN_STAGES_CLAUDE}")
+    lines.append(f"  NEXT STEP (Codex):    {TRIAGE_CMD_RUN_STAGES_CODEX}")
+    lines.append(f"  NEXT STEP (Claude):   {TRIAGE_CMD_RUN_STAGES_CLAUDE}")
+    lines.append(f"  NEXT STEP (Rovo Dev): {TRIAGE_CMD_RUN_STAGES_ROVODEV}")
     lines.append("  Manual fallback:    desloppify plan triage")
     lines.append("  (Review new issues, then either --confirm-existing or re-plan.)")
     lines.append("")

--- a/desloppify/app/commands/plan/triage/display/layout.py
+++ b/desloppify/app/commands/plan/triage/display/layout.py
@@ -20,6 +20,7 @@ from desloppify.engine.plan_triage import (
     TRIAGE_CMD_REFLECT,
     TRIAGE_CMD_RUN_STAGES_CLAUDE,
     TRIAGE_CMD_RUN_STAGES_CODEX,
+    TRIAGE_CMD_RUN_STAGES_ROVODEV,
     triage_runner_commands,
     TRIAGE_CMD_STRATEGIZE,
 )
@@ -64,9 +65,10 @@ def print_dashboard_header(
     print(f"  Open review issues: {len(review_issues)}")
     print(colorize("  Goal: identify contradictions, resolve them, then group the coherent", "cyan"))
     print(colorize("  remainder into clusters by root cause with action steps and priorities.", "cyan"))
-    print(colorize("  Preferred: staged runner workflow (Codex or Claude).", "cyan"))
-    print(colorize(f"    Codex:  {TRIAGE_CMD_RUN_STAGES_CODEX}", "dim"))
-    print(colorize(f"    Claude: {TRIAGE_CMD_RUN_STAGES_CLAUDE}", "dim"))
+    print(colorize("  Preferred: staged runner workflow (Codex, Claude, or Rovo Dev).", "cyan"))
+    print(colorize(f"    Codex:    {TRIAGE_CMD_RUN_STAGES_CODEX}", "dim"))
+    print(colorize(f"    Claude:   {TRIAGE_CMD_RUN_STAGES_CLAUDE}", "dim"))
+    print(colorize(f"    Rovo Dev: {TRIAGE_CMD_RUN_STAGES_ROVODEV}", "dim"))
     print(colorize("  Manual stage commands below are fallback/debug paths.", "dim"))
     existing_clusters = si.existing_clusters
     if existing_clusters:
@@ -117,8 +119,9 @@ def _print_retriage_guidance(si: object, meta: dict) -> None:
         print('    desloppify plan triage --confirm-existing --note "..." --strategy "same" --confirmed "I have reviewed..."')
         print()
         print(colorize("  To re-prioritize and restructure:", "cyan"))
-        print(f"    Codex:  {TRIAGE_CMD_RUN_STAGES_CODEX}")
-        print(f"    Claude: {TRIAGE_CMD_RUN_STAGES_CLAUDE}")
+        print(f"    Codex:    {TRIAGE_CMD_RUN_STAGES_CODEX}")
+        print(f"    Claude:   {TRIAGE_CMD_RUN_STAGES_CLAUDE}")
+        print(f"    Rovo Dev: {TRIAGE_CMD_RUN_STAGES_ROVODEV}")
         print(colorize(f"    Manual fallback: {TRIAGE_CMD_STRATEGIZE}", "dim"))
     else:
         _print_runner_paths(

--- a/desloppify/app/commands/plan/triage/runner/orchestrator_codex_observe.py
+++ b/desloppify/app/commands/plan/triage/runner/orchestrator_codex_observe.py
@@ -14,9 +14,9 @@ from ..observe_batches import group_issues_into_observe_batches
 from .codex_runner import (
     TriageStageRunResult,
     _output_file_has_text,
-    run_triage_stage,
 )
 from .orchestrator_codex_parallel import run_parallel_batches
+from .stage_runner_override import active_stage_runner
 from .stage_prompts import build_observe_batch_prompt
 
 
@@ -109,7 +109,7 @@ def run_observe(
 
         if not dry_run:
             tasks[i] = partial(
-                run_triage_stage,
+                active_stage_runner(),
                 prompt=prompt,
                 repo_root=repo_root,
                 output_file=output_file,

--- a/desloppify/app/commands/plan/triage/runner/orchestrator_codex_pipeline.py
+++ b/desloppify/app/commands/plan/triage/runner/orchestrator_codex_pipeline.py
@@ -51,6 +51,19 @@ from .orchestrator_common import STAGES, run_stamp
 from .stage_prompts import build_stage_prompt
 from ..stages.helpers import value_check_targets
 _STAGE_HANDLERS: dict[str, StageHandler] = DEFAULT_STAGE_HANDLERS
+
+# Module-level override for the per-stage runner. The default (``None``)
+# means "use the codex stage runner". The wrapper helpers in
+# :mod:`rovodev_pipeline` swap this for the rovodev stage runner during
+# the lifetime of one ``run_codex_pipeline`` call so that the existing
+# pipeline can drive any subprocess backend without further refactoring.
+from .stage_runner_override import (  # re-exported for backwards compat
+    active_runner_name,
+    active_stage_runner,
+    clear_stage_runner_override,
+    set_stage_runner_override,
+    stage_runner_override,
+)
 _analyze_reflect_issue_accounting = analyze_reflect_issue_accounting
 _validate_reflect_issue_accounting = validate_reflect_accounting
 
@@ -104,11 +117,18 @@ def _write_desloppify_cli_helper(run_dir: Path) -> Path:
     safe_write_text(script_path, script)
     os.chmod(script_path, 0o700)
     return script_path
-def _stage_execution_dependencies() -> StageExecutionDependencies:
-    """Resolve stage execution dependencies from module symbols for patchability."""
+def _stage_execution_dependencies(
+    stage_runner_fn=None,
+) -> StageExecutionDependencies:
+    """Resolve stage execution dependencies from module symbols for patchability.
+
+    ``stage_runner_fn`` defaults to the codex stage runner; pass an alternate
+    callable (e.g. the rovodev or external stage runner) to swap the
+    underlying subprocess backend without changing the surrounding pipeline.
+    """
     return StageExecutionDependencies(
         build_stage_prompt=build_stage_prompt,
-        run_triage_stage=run_triage_stage,
+        run_triage_stage=stage_runner_fn or run_triage_stage,
         read_stage_output=read_stage_output_impl,
         analyze_reflect_issue_accounting=analyze_reflect_issue_accounting,
         validate_reflect_issue_accounting=validate_reflect_accounting,
@@ -189,7 +209,7 @@ def _run_stage_sequence(
                 state=pipeline_context.state,
             ),
             handlers=_STAGE_HANDLERS,
-            dependencies=_stage_execution_dependencies(),
+            dependencies=_stage_execution_dependencies(stage_runner_override()),
         )
         if execution_result.status == "dry_run":
             stage_results[stage] = execution_result.payload
@@ -339,7 +359,7 @@ def run_codex_pipeline(
         log_actor="system",
         log_detail={
             "source": "runner_auto_start",
-            "runner": "codex",
+            "runner": active_runner_name(),
             "injected_stage_ids": list(STAGES),
         },
         start_message="  Planning mode auto-started.",
@@ -364,8 +384,9 @@ def run_codex_pipeline(
     run_log_path = run_dir / "run.log"
     append_run_log = make_run_log_writer(run_log_path)
     cli_helper = _write_desloppify_cli_helper(run_dir)
+    runner_label = active_runner_name()
     append_run_log(
-        f"run-start runner=codex stages={','.join(stages_to_run)} "
+        f"run-start runner={runner_label} stages={','.join(stages_to_run)} "
         f"timeout={timeout_seconds}s dry_run={dry_run}"
     )
 
@@ -418,7 +439,7 @@ def write_triage_run_summary(
     summary = {
         "created_at": datetime.now(UTC).isoformat(timespec="seconds"),
         "run_stamp": stamp,
-        "runner": "codex",
+        "runner": active_runner_name(),
         "stages_requested": stages,
         "stage_results": stage_results,
         "run_dir": str(run_dir),

--- a/desloppify/app/commands/plan/triage/runner/orchestrator_codex_sense.py
+++ b/desloppify/app/commands/plan/triage/runner/orchestrator_codex_sense.py
@@ -19,9 +19,9 @@ from ..stages.helpers import scoped_manual_clusters_with_issues, triage_scoped_p
 from .codex_runner import (
     TriageStageRunResult,
     _output_file_has_text,
-    run_triage_stage,
 )
 from .orchestrator_codex_parallel import run_parallel_batches
+from .stage_runner_override import active_stage_runner
 from .stage_prompts import (
     build_sense_check_content_prompt,
     build_sense_check_structure_prompt,
@@ -154,7 +154,7 @@ def _content_tasks_and_meta(
         batch_meta.append((config.label, config.output_file))
         if not dry_run:
             tasks[i] = partial(
-                run_triage_stage,
+                active_stage_runner(),
                 prompt=config.prompt,
                 repo_root=repo_root,
                 output_file=config.output_file,
@@ -372,7 +372,7 @@ def run_sense_check(
 
     structure_tasks: dict[int, Callable[[], TriageStageRunResult]] = {
         0: partial(
-            run_triage_stage,
+            active_stage_runner(),
             prompt=structure_config.prompt,
             repo_root=repo_root,
             output_file=structure_config.output_file,
@@ -417,7 +417,7 @@ def run_sense_check(
     if not dry_run:
         value_tasks: dict[int, Callable[[], TriageStageRunResult]] = {
             0: partial(
-                run_triage_stage,
+                active_stage_runner(),
                 prompt=value_config.prompt,
                 repo_root=repo_root,
                 output_file=value_config.output_file,

--- a/desloppify/app/commands/plan/triage/runner/rovodev_pipeline.py
+++ b/desloppify/app/commands/plan/triage/runner/rovodev_pipeline.py
@@ -1,0 +1,48 @@
+"""Rovo Dev pipeline wrapper for triage stage execution.
+
+The pipeline body lives in :mod:`orchestrator_codex_pipeline`; this module
+swaps the per-stage subprocess runner (and the ``runner`` label that
+appears in run logs / summaries) to Rovo Dev for the lifetime of one
+``run_rovodev_pipeline`` invocation.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from . import orchestrator_codex_pipeline as _pipeline
+from . import stage_runner_override as _override
+from .rovodev_runner import run_triage_stage_rovodev
+
+if False:  # pragma: no cover — import guard for type checkers
+    from ..services import TriageServices
+
+
+def run_rovodev_pipeline(
+    args: argparse.Namespace,
+    *,
+    stages_to_run: list[str],
+    services: "TriageServices | None" = None,
+) -> None:
+    """Run triage stages via ``acli rovodev`` subprocesses.
+
+    Behaves exactly like :func:`run_codex_pipeline` but uses the Rovo Dev
+    stage runner instead of the codex runner. The ``runner`` field in
+    ``run_summary.json`` and the run log header is set to ``"rovodev"``.
+    The override also flows through parallel sub-runners (observe,
+    sense-check) via :mod:`stage_runner_override`.
+    """
+    previous_runner = _override._STAGE_RUNNER_OVERRIDE
+    previous_label = _override._RUNNER_NAME_OVERRIDE
+    _override.set_stage_runner_override(run_triage_stage_rovodev, "rovodev")
+    try:
+        _pipeline.run_codex_pipeline(
+            args,
+            stages_to_run=stages_to_run,
+            services=services,
+        )
+    finally:
+        _override.set_stage_runner_override(previous_runner, previous_label)
+
+
+__all__ = ["run_rovodev_pipeline"]

--- a/desloppify/app/commands/plan/triage/runner/rovodev_runner.py
+++ b/desloppify/app/commands/plan/triage/runner/rovodev_runner.py
@@ -1,0 +1,80 @@
+"""Thin wrapper around the Rovo Dev batch runner for triage stage execution.
+
+Mirrors :mod:`codex_runner` so the triage pipeline can swap the underlying
+subprocess runner without changes to the stage orchestration logic.
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from desloppify.app.commands.review.runner_rovodev import (
+    rovodev_batch_command,
+    run_rovodev_batch,
+)
+from desloppify.app.commands.runner.codex_batch import CodexBatchRunnerDeps
+from desloppify.base.discovery.file_paths import safe_write_text
+
+from .codex_runner import TriageStageRunResult, _output_file_has_text
+
+
+def run_triage_stage_rovodev(
+    *,
+    prompt: str,
+    repo_root: Path,
+    output_file: Path,
+    log_file: Path,
+    timeout_seconds: int = 1800,
+    validate_output_fn: Callable[[Path], bool] | None = None,
+) -> TriageStageRunResult:
+    """Execute one triage stage via ``acli rovodev`` and return a typed result.
+
+    Shape-compatible with :func:`codex_runner.run_triage_stage` so the
+    surrounding pipeline can dispatch on a per-runner basis without any
+    pipeline-side awareness of the runner backend.
+    """
+    normalized_prompt = str(prompt).strip()
+    if not normalized_prompt:
+        safe_write_text(log_file, "Empty triage prompt — skipping execution.\n")
+        return TriageStageRunResult(exit_code=2, reason="empty_prompt")
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    if validate_output_fn is None:
+        validate_output_fn = _output_file_has_text
+    timeout = timeout_seconds if timeout_seconds > 0 else 1800
+    preview = " ".join(
+        rovodev_batch_command(
+            prompt=normalized_prompt,
+            repo_root=repo_root,
+        )
+    )
+    safe_write_text(log_file, f"RUNNER COMMAND PREVIEW:\n{preview}\n")
+    deps = CodexBatchRunnerDeps(
+        timeout_seconds=timeout,
+        subprocess_run=subprocess.run,
+        timeout_error=subprocess.TimeoutExpired,
+        safe_write_text_fn=safe_write_text,
+        use_popen_runner=True,
+        subprocess_popen=subprocess.Popen,
+        live_log_interval_seconds=10.0,
+        stall_after_output_seconds=120,
+        max_retries=1,
+        retry_backoff_seconds=5.0,
+        sleep_fn=time.sleep,
+        validate_output_fn=validate_output_fn,
+    )
+    exit_code = run_rovodev_batch(
+        prompt=normalized_prompt,
+        repo_root=repo_root,
+        output_file=output_file,
+        log_file=log_file,
+        deps=deps,
+    )
+    reason = None if exit_code == 0 else f"runner_exit_{exit_code}"
+    return TriageStageRunResult(exit_code=exit_code, reason=reason)
+
+
+__all__ = ["run_triage_stage_rovodev"]

--- a/desloppify/app/commands/plan/triage/runner/stage_runner_override.py
+++ b/desloppify/app/commands/plan/triage/runner/stage_runner_override.py
@@ -1,0 +1,59 @@
+"""Per-stage subprocess runner override registry.
+
+Lives in its own module to avoid circular imports between
+:mod:`orchestrator_codex_pipeline` and the parallel sub-runners
+(:mod:`orchestrator_codex_observe`, :mod:`orchestrator_codex_sense`)
+that need to consult the override.
+
+The override is set transiently by alternative pipeline wrappers (for
+example :mod:`rovodev_pipeline`) so that all per-stage subprocesses for
+the lifetime of one pipeline call route through the chosen backend.
+"""
+
+from __future__ import annotations
+
+from .codex_runner import run_triage_stage
+
+_STAGE_RUNNER_OVERRIDE = None
+_RUNNER_NAME_OVERRIDE: str | None = None
+
+
+def set_stage_runner_override(stage_runner_fn, runner_name: str | None) -> None:
+    """Install a transient per-stage runner override and label."""
+    global _STAGE_RUNNER_OVERRIDE, _RUNNER_NAME_OVERRIDE
+    _STAGE_RUNNER_OVERRIDE = stage_runner_fn
+    _RUNNER_NAME_OVERRIDE = runner_name
+
+
+def clear_stage_runner_override() -> None:
+    """Remove any installed override."""
+    global _STAGE_RUNNER_OVERRIDE, _RUNNER_NAME_OVERRIDE
+    _STAGE_RUNNER_OVERRIDE = None
+    _RUNNER_NAME_OVERRIDE = None
+
+
+def active_stage_runner():
+    """Return the active per-stage subprocess runner.
+
+    Falls back to the codex stage runner when no override is set.
+    """
+    return _STAGE_RUNNER_OVERRIDE or run_triage_stage
+
+
+def active_runner_name(default: str = "codex") -> str:
+    """Return the active runner label (used in run logs/summaries)."""
+    return _RUNNER_NAME_OVERRIDE or default
+
+
+def stage_runner_override():
+    """Return the raw override or None (used by pipeline dependency wiring)."""
+    return _STAGE_RUNNER_OVERRIDE
+
+
+__all__ = [
+    "active_runner_name",
+    "active_stage_runner",
+    "clear_stage_runner_override",
+    "set_stage_runner_override",
+    "stage_runner_override",
+]

--- a/desloppify/app/commands/plan/triage/workflow.py
+++ b/desloppify/app/commands/plan/triage/workflow.py
@@ -16,6 +16,7 @@ from .lifecycle import ensure_triage_started
 from .review_coverage import ensure_active_triage_issue_ids
 from .runner.orchestrator_claude import run_claude_orchestrator
 from .runner.orchestrator_codex_pipeline import run_codex_pipeline
+from .runner.rovodev_pipeline import run_rovodev_pipeline
 from .runner.orchestrator_common import parse_only_stages
 from .runner.stage_prompts import cmd_stage_prompt
 from .services import TriageServices
@@ -106,8 +107,15 @@ def _run_staged_runner(
             services=services,
         )
         return
+    if runner == "rovodev":
+        run_rovodev_pipeline(
+            args,
+            stages_to_run=stages_to_run,
+            services=services,
+        )
+        return
     raise CommandError(
-        f"Unknown runner: {runner}. Use 'codex' or 'claude'.",
+        f"Unknown runner: {runner}. Use 'codex', 'claude', or 'rovodev'.",
         exit_code=1,
     )
 

--- a/desloppify/app/commands/review/batch/orchestrator.py
+++ b/desloppify/app/commands/review/batch/orchestrator.py
@@ -49,6 +49,7 @@ from desloppify.app.commands.runner.codex_batch import (
     run_followup_scan,
 )
 from ..runner_opencode import run_opencode_batch
+from ..runner_rovodev import run_rovodev_batch
 from ..runtime.setup import setup_lang_concrete as _setup_lang
 from ..runtime_paths import (
     blind_packet_path as _blind_packet_path,
@@ -80,6 +81,22 @@ from .execution_results import (
 )
 
 FOLLOWUP_SCAN_TIMEOUT_SECONDS = 45 * 60
+
+
+def _select_batch_runner(runner: str):
+    """Return the per-batch run function matching the requested runner.
+
+    Falls back to ``run_codex_batch`` for unknown runner strings; the
+    caller has already validated the runner via ``validate_runner`` by
+    the time the dispatch helper is reached during normal flows.
+    """
+    normalized = (runner or "").strip().lower()
+    if normalized == "opencode":
+        return run_opencode_batch
+    if normalized == "rovodev":
+        return run_rovodev_batch
+    return run_codex_batch
+
 _PREPARED_PACKET_CONTRACT_KEY = "prepared_packet_contract"
 ABSTRACTION_SUB_AXES = (
     "abstraction_leverage",
@@ -162,7 +179,7 @@ def _build_batch_run_deps(*, args, policy, project_root: Path) -> review_batches
             colorize_fn=colorize,
         ),
         run_batch_fn=partial(
-            run_opencode_batch if getattr(args, "runner", "codex") == "opencode" else run_codex_batch,
+            _select_batch_runner(getattr(args, "runner", "codex")),
             deps=codex_batch_deps,
         ),
         execute_batches_fn=lambda **kwargs: execute_batches(

--- a/desloppify/app/commands/review/batch/scope.py
+++ b/desloppify/app/commands/review/batch/scope.py
@@ -14,7 +14,7 @@ from desloppify.intelligence.review.feedback_contract import (
 )
 
 
-_SUPPORTED_RUNNERS = {"codex", "opencode"}
+_SUPPORTED_RUNNERS = {"codex", "opencode", "rovodev"}
 
 
 def validate_runner(runner: str, *, colorize_fn) -> None:

--- a/desloppify/app/commands/review/importing/plan_sync.py
+++ b/desloppify/app/commands/review/importing/plan_sync.py
@@ -52,6 +52,7 @@ from desloppify.engine._state.progression import (
 from desloppify.engine.plan_triage import (
     TRIAGE_CMD_RUN_STAGES_CLAUDE,
     TRIAGE_CMD_RUN_STAGES_CODEX,
+    TRIAGE_CMD_RUN_STAGES_ROVODEV,
 )
 from desloppify.intelligence.review.importing.contracts_types import (
     NormalizedReviewImportPayload,
@@ -178,8 +179,9 @@ def _print_review_import_footer(
     print(colorize("  NEXT STEP:", "yellow"))
     print(colorize("    Run:    desloppify next", "yellow"))
     if triage_injected and not workflow_injected:
-        print(colorize(f"    Codex:  {TRIAGE_CMD_RUN_STAGES_CODEX}", "dim"))
-        print(colorize(f"    Claude: {TRIAGE_CMD_RUN_STAGES_CLAUDE}", "dim"))
+        print(colorize(f"    Codex:    {TRIAGE_CMD_RUN_STAGES_CODEX}", "dim"))
+        print(colorize(f"    Claude:   {TRIAGE_CMD_RUN_STAGES_CLAUDE}", "dim"))
+        print(colorize(f"    Rovo Dev: {TRIAGE_CMD_RUN_STAGES_ROVODEV}", "dim"))
         print(colorize("    Manual dashboard: desloppify plan triage", "dim"))
     print(
         colorize(

--- a/desloppify/app/commands/review/importing/policy.py
+++ b/desloppify/app/commands/review/importing/policy.py
@@ -20,7 +20,7 @@ from ..runtime_paths import blind_packet_path, runtime_project_root
 
 ASSESSMENT_POLICY_KEY = "_assessment_policy"
 BLIND_PROVENANCE_KIND = "blind_review_batch_import"
-SUPPORTED_BLIND_REVIEW_RUNNERS = {"codex", "claude", "opencode"}
+SUPPORTED_BLIND_REVIEW_RUNNERS = {"codex", "claude", "opencode", "rovodev"}
 ATTESTED_EXTERNAL_RUNNERS = {"claude"}
 ATTESTED_EXTERNAL_REQUIRED_PHRASES = ("without awareness", "unbiased")
 ATTESTED_EXTERNAL_ATTEST_EXAMPLE = (

--- a/desloppify/app/commands/review/prepare.py
+++ b/desloppify/app/commands/review/prepare.py
@@ -98,6 +98,12 @@ def _print_prepare_summary(
     )
     print(
         colorize(
+            "  1b. Rovo Dev: `desloppify review --run-batches --runner rovodev --parallel --scan-after-import`",
+            "dim",
+        )
+    )
+    print(
+        colorize(
             f"  2. Claude / other agent: `desloppify review --run-batches --dry-run`"
             f" → generates {n_batches} prompt files in .desloppify/subagent_runs/<run>/prompts/."
             f" Launch {n_batches} subagents in parallel (one per prompt),"

--- a/desloppify/app/commands/review/runner_failures.py
+++ b/desloppify/app/commands/review/runner_failures.py
@@ -46,11 +46,12 @@ _RUNNER_AUTH_PHRASES = (
 _FAILURE_HINT_BY_CATEGORY = {
     "runner_missing": (
         "Runner CLI not found on PATH. "
-        "Install the runner (codex or opencode) and verify it is on your PATH."
+        "Install the runner (codex, opencode, or acli for rovodev) and verify it is on your PATH."
     ),
     "runner_auth": (
         "Runner appears unauthenticated. "
-        "For Codex run `codex login`; for OpenCode check your auth configuration."
+        "For Codex run `codex login`; for OpenCode check your auth configuration; "
+        "for Rovo Dev run `acli rovodev auth login`."
     ),
     "usage_limit": (
         "Runner usage quota is exhausted for this account. "
@@ -65,7 +66,8 @@ _FAILURE_HINT_BY_CATEGORY = {
 
 
 def _is_runner_missing(text: str) -> bool:
-    for runner_name in ("codex", "opencode"):
+    # Rovo Dev's binary is ``acli``; treat both names as runner candidates.
+    for runner_name in ("codex", "opencode", "acli"):
         if f"{runner_name} not found" in text:
             return True
         if "no such file or directory" in text and f"$ {runner_name} " in text:

--- a/desloppify/app/commands/review/runner_rovodev.py
+++ b/desloppify/app/commands/review/runner_rovodev.py
@@ -1,0 +1,338 @@
+"""Rovo Dev (acli rovodev) batch runner for review batch execution.
+
+Rovo Dev's CLI (``acli rovodev``) enters non-interactive single-prompt
+mode automatically whenever a positional ``message`` argument is
+provided. The runner invokes::
+
+    acli rovodev --yolo "<instruction>"
+
+``--yolo`` disables permission prompts so the agent can write the
+per-batch output file unattended; opt out by setting
+``DESLOPPIFY_ROVODEV_NO_YOLO=1`` (only useful in interactive review work
+since batch runs cannot answer prompts).
+
+Unlike codex/opencode the CLI does not stream a structured NDJSON envelope
+of the model's reply; instead, the agent operates inside the workspace and
+follows the prompt's own instructions. Our review prompt explicitly tells
+the agent to ``write ONLY valid JSON to <output_file>``, so the file
+written by the agent is the canonical payload.
+
+The runner mirrors :mod:`runner_opencode` for stdout-payload recovery so
+that callers still get a usable file when the agent emits the JSON
+inline (e.g. when permission checks block the file write but the JSON
+is still in the agent's reply).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from desloppify.app.commands.runner.codex_batch import (
+    CodexBatchRunnerDeps,
+    _resolve_executable,
+    _wrap_cmd_c,
+)
+
+from .runner_process_impl.attempts import (
+    handle_early_attempt_return as _handle_early_attempt_return,
+    handle_failed_attempt as _handle_failed_attempt,
+    handle_successful_attempt as _handle_successful_attempt,
+    handle_timeout_or_stall as _handle_timeout_or_stall,
+    resolve_retry_config as _resolve_retry_config,
+    run_batch_attempt as _run_batch_attempt,
+)
+from .runner_process_impl.io import _output_file_has_json_payload
+
+
+def rovodev_batch_command(*, prompt: str, repo_root: Path) -> list[str]:
+    """Build one ``acli rovodev`` command line for a batch prompt.
+
+    ``acli rovodev`` enters non-interactive mode automatically whenever a
+    positional ``message`` is provided, so no explicit ``--non-interactive``
+    flag is needed. Permission checks are disabled by default via ``--yolo``
+    so the agent can write the per-batch output file without prompting; set
+    ``DESLOPPIFY_ROVODEV_NO_YOLO=1`` to opt out.
+
+    Honours optional environment overrides:
+
+    - ``DESLOPPIFY_ROVODEV_EXECUTABLE`` overrides the ``acli`` executable
+      name (useful when the binary is shipped under a different name in CI).
+    - ``DESLOPPIFY_ROVODEV_NO_YOLO=1`` disables the default ``--yolo`` flag
+      so the agent will request per-tool permission (only useful in
+      interactive review work — batch runs cannot answer prompts).
+    - ``DESLOPPIFY_ROVODEV_OUTPUT_SCHEMA`` may be either an inline JSON
+      schema string or a path to a schema file; when set, it's passed via
+      ``--output-schema`` so the agent's reply is constrained to the
+      schema. Combine with the desloppify review JSON contract for
+      strictly-shaped batch results.
+    - ``DESLOPPIFY_ROVODEV_EXTRA_ARGS`` is shell-split and appended verbatim
+      before the prompt, allowing power users to pass ``--config-override``,
+      ``--restore``, ``--worktree``, etc. without code changes.
+
+    The repo root is set as the subprocess working directory by the
+    surrounding ``run_batch_attempt`` infrastructure (Rovo Dev operates
+    on the current working directory).
+    """
+    del repo_root  # cwd is set by the caller via the deps subprocess machinery
+    executable = os.environ.get("DESLOPPIFY_ROVODEV_EXECUTABLE", "").strip() or "acli"
+    prefix = _resolve_executable(executable)
+    cmd: list[str] = [*prefix, "rovodev"]
+    if os.environ.get("DESLOPPIFY_ROVODEV_NO_YOLO", "").strip() not in {"1", "true", "yes"}:
+        cmd.append("--yolo")
+    schema = os.environ.get("DESLOPPIFY_ROVODEV_OUTPUT_SCHEMA", "").strip()
+    if schema:
+        cmd.extend(["--output-schema", schema])
+    extra = os.environ.get("DESLOPPIFY_ROVODEV_EXTRA_ARGS", "").strip()
+    if extra:
+        import shlex
+
+        cmd.extend(shlex.split(extra))
+    cmd.append(prompt)
+    return _wrap_cmd_c(cmd)
+
+
+def _capture_rovodev_stdout_payload(
+    *, result, output_file: Path, deps: CodexBatchRunnerDeps
+) -> str | None:
+    """Persist a recoverable JSON payload found in Rovo Dev stdout text."""
+    return _persist_rovodev_payload_text(
+        extracted_text=result.stdout_text,
+        output_file=output_file,
+        deps=deps,
+    )
+
+
+def _extract_json_object(text: str) -> str | None:
+    """Return the last brace-balanced JSON object substring in ``text``.
+
+    Rovo Dev does not emit NDJSON like OpenCode; the model's reply is
+    plain text that may contain narration around the JSON payload. We
+    walk the text and return the *last* fully balanced object so the
+    final answer wins over any earlier draft inside the same response.
+    """
+    if not text:
+        return None
+    last: str | None = None
+    depth = 0
+    start = -1
+    in_string = False
+    escape = False
+    for idx, char in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+            continue
+        if char == "{":
+            if depth == 0:
+                start = idx
+            depth += 1
+        elif char == "}":
+            if depth == 0:
+                continue
+            depth -= 1
+            if depth == 0 and start != -1:
+                candidate = text[start : idx + 1]
+                try:
+                    parsed = json.loads(candidate)
+                except (json.JSONDecodeError, ValueError):
+                    start = -1
+                    continue
+                if isinstance(parsed, dict):
+                    last = candidate
+                start = -1
+    return last
+
+
+def _persist_rovodev_payload_text(
+    *, extracted_text: str, output_file: Path, deps: CodexBatchRunnerDeps
+) -> str | None:
+    """Persist a Rovo Dev JSON payload to ``output_file`` if recoverable."""
+    if not extracted_text:
+        return None
+    candidate = _extract_json_object(extracted_text)
+    if candidate is None:
+        return None
+    try:
+        deps.safe_write_text_fn(output_file, candidate)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+    return candidate
+
+
+def _build_live_rovodev_stdout_observer(
+    *, output_file: Path, deps: CodexBatchRunnerDeps
+):
+    """Persist recoverable Rovo Dev payloads while stdout is still streaming."""
+    last_persisted_text: str | None = None
+
+    def _observe(stdout_text: str) -> None:
+        nonlocal last_persisted_text
+        if not stdout_text or stdout_text == last_persisted_text:
+            return
+        persisted_text = _persist_rovodev_payload_text(
+            extracted_text=stdout_text,
+            output_file=output_file,
+            deps=deps,
+        )
+        if persisted_text is not None:
+            last_persisted_text = stdout_text
+
+    return _observe
+
+
+def _restore_rovodev_recoverable_payload(
+    *, recoverable_text: str | None, output_file: Path, deps: CodexBatchRunnerDeps
+) -> None:
+    """Restore the last known-good Rovo Dev payload for downstream recovery."""
+    if not recoverable_text or _output_file_has_json_payload(output_file):
+        return
+    try:
+        deps.safe_write_text_fn(output_file, recoverable_text)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return
+
+
+def run_rovodev_batch(
+    *,
+    prompt: str,
+    repo_root: Path,
+    output_file: Path,
+    log_file: Path,
+    deps: CodexBatchRunnerDeps,
+    rovodev_batch_command_fn=None,
+) -> int:
+    """Execute one Rovo Dev batch and return a stable CLI-style status code.
+
+    Mirrors :func:`run_opencode_batch` to reuse the shared retry/stall/
+    timeout infrastructure. The Rovo Dev agent is expected to follow the
+    prompt's instruction to write JSON to ``output_file``; if it instead
+    emits JSON inline, the runner recovers the payload from stdout.
+    """
+    if rovodev_batch_command_fn is None:
+        rovodev_batch_command_fn = rovodev_batch_command
+    cmd = rovodev_batch_command_fn(
+        prompt=prompt,
+        repo_root=repo_root,
+    )
+    config = _resolve_retry_config(deps)
+    log_sections: list[str] = []
+    recoverable_output_text: str | None = None
+
+    for attempt in range(1, config.max_attempts + 1):
+        try:
+            if output_file.exists():
+                output_file.unlink()
+        except OSError:
+            pass
+
+        stdout_text_observer = _build_live_rovodev_stdout_observer(
+            output_file=output_file,
+            deps=deps,
+        )
+
+        header, result = _run_batch_attempt(
+            cmd=cmd,
+            deps=deps,
+            output_file=output_file,
+            log_file=log_file,
+            log_sections=log_sections,
+            attempt=attempt,
+            max_attempts=config.max_attempts,
+            use_popen=config.use_popen,
+            live_log_interval=config.live_log_interval,
+            stall_seconds=config.stall_seconds,
+            stdout_text_observer=stdout_text_observer,
+        )
+        early_return = _handle_early_attempt_return(result)
+        if early_return is not None:
+            return early_return
+
+        current_payload_text = _capture_rovodev_stdout_payload(
+            result=result,
+            output_file=output_file,
+            deps=deps,
+        )
+        if current_payload_text is not None:
+            recoverable_output_text = current_payload_text
+
+        timeout_or_stall = _handle_timeout_or_stall(
+            header=header,
+            result=result,
+            deps=deps,
+            output_file=output_file,
+            log_file=log_file,
+            log_sections=log_sections,
+            stall_seconds=config.stall_seconds,
+        )
+        if timeout_or_stall is not None:
+            if timeout_or_stall == 0:
+                return 0
+            if attempt < config.max_attempts:
+                delay = config.retry_backoff_seconds * (2 ** (attempt - 1))
+                log_sections.append(
+                    f"Timeout/stall on attempt {attempt}/{config.max_attempts}; "
+                    f"retrying in {delay:.1f}s."
+                )
+                if delay > 0:
+                    deps.sleep_fn(delay)
+                continue
+            _restore_rovodev_recoverable_payload(
+                recoverable_text=recoverable_output_text,
+                output_file=output_file,
+                deps=deps,
+            )
+            return timeout_or_stall
+
+        log_sections.append(
+            f"{header}\n\nSTDOUT:\n{result.stdout_text}\n\nSTDERR:\n{result.stderr_text}\n"
+        )
+
+        success_code = _handle_successful_attempt(
+            result=result,
+            output_file=output_file,
+            log_file=log_file,
+            deps=deps,
+            log_sections=log_sections,
+        )
+        if success_code is not None:
+            return success_code
+
+        failure_code = _handle_failed_attempt(
+            result=result,
+            deps=deps,
+            attempt=attempt,
+            max_attempts=config.max_attempts,
+            retry_backoff_seconds=config.retry_backoff_seconds,
+            log_file=log_file,
+            log_sections=log_sections,
+        )
+        if failure_code is not None:
+            _restore_rovodev_recoverable_payload(
+                recoverable_text=recoverable_output_text,
+                output_file=output_file,
+                deps=deps,
+            )
+            return failure_code
+
+    _restore_rovodev_recoverable_payload(
+        recoverable_text=recoverable_output_text,
+        output_file=output_file,
+        deps=deps,
+    )
+    deps.safe_write_text_fn(log_file, "\n\n".join(log_sections))
+    return 1
+
+
+__all__ = [
+    "rovodev_batch_command",
+    "run_rovodev_batch",
+]

--- a/desloppify/app/commands/scan/reporting/subjective.py
+++ b/desloppify/app/commands/scan/reporting/subjective.py
@@ -100,7 +100,7 @@ def subjective_rerun_command(
         if dim_keys:
             command_parts.extend(["--dimensions", dim_keys])
         cmd = f"`{' '.join(command_parts)}`"
-        return f"{cmd} (set up `--runner codex` or `--runner opencode` for automated reviews)"
+        return f"{cmd} (set up `--runner codex`, `--runner opencode`, or `--runner rovodev` for automated reviews)"
 
     command_parts = [
         "desloppify",

--- a/desloppify/app/commands/scan/reporting/text.py
+++ b/desloppify/app/commands/scan/reporting/text.py
@@ -27,10 +27,11 @@ def build_workflow_guide(attest_example: str) -> str:
         4. **Run auto-fixers** (if available): `desloppify autofix <fixer> --dry-run` to preview, then apply.
         5. **Rescan**: `desloppify scan --path <path>` — verify improvements, catch cascading effects.
         6. **Subjective review**: `desloppify review --prepare` then follow your runner's review workflow
-           (see skill doc for Codex, Claude, or external paths).
+           (see skill doc for Codex, Claude, OpenCode, Rovo Dev, or external paths).
         7. **Triage** (after review): prefer
-           `desloppify plan triage --run-stages --runner codex` or
-           `desloppify plan triage --run-stages --runner claude`.
+           `desloppify plan triage --run-stages --runner codex`,
+           `desloppify plan triage --run-stages --runner claude`, or
+           `desloppify plan triage --run-stages --runner rovodev`.
            Manual dashboard/fallback: `desloppify plan triage`.
            Complete all stages (strategize → observe → reflect → organize → enrich → sense-check → commit).
         8. **Check progress**: `desloppify status` — dimension scores dashboard.

--- a/desloppify/app/skill_docs.py
+++ b/desloppify/app/skill_docs.py
@@ -10,7 +10,7 @@ from desloppify.base.discovery.paths import get_project_root
 
 # Bump this integer whenever docs/SKILL.md changes in a way that agents
 # should pick up (new commands, changed workflows, removed sections).
-SKILL_VERSION = 6
+SKILL_VERSION = 7
 
 SKILL_VERSION_RE = re.compile(r"<!--\s*desloppify-skill-version:\s*(\d+)\s*-->")
 SKILL_OVERLAY_RE = re.compile(r"<!--\s*desloppify-overlay:\s*(\w+)\s*-->")
@@ -24,6 +24,7 @@ SKILL_SEARCH_PATHS = (
     ".agents/skills/desloppify/SKILL.md",
     ".claude/skills/desloppify/SKILL.md",
     ".opencode/skills/desloppify/SKILL.md",
+    ".rovodev/skills/desloppify/SKILL.md",
     "AGENTS.md",
     "CLAUDE.md",
     ".cursor/rules/desloppify.md",
@@ -41,6 +42,7 @@ SKILL_TARGETS: dict[str, tuple[str, str, bool]] = {
     "cursor": (".cursor/rules/desloppify.md", "CURSOR", True),
     "copilot": (".github/copilot-instructions.md", "COPILOT", False),
     "droid": (".factory/skills/desloppify/SKILL.md", "DROID", True),
+    "rovodev": (".rovodev/skills/desloppify/SKILL.md", "ROVODEV", True),
     "windsurf": ("AGENTS.md", "WINDSURF", False),
     "gemini": ("AGENTS.md", "GEMINI", False),
     "hermes": ("AGENTS.md", "HERMES", False),
@@ -56,6 +58,7 @@ SKILL_TARGETS: dict[str, tuple[str, str, bool]] = {
 #   gemini:   geminicli.com/docs/cli/skills/
 #   amp:      ampcode.com/news/agent-skills
 #   opencode: opencode.ai/docs/skills/
+#   rovodev:  support.atlassian.com/rovo/docs/extend-rovo-dev-cli-with-agent-skills/
 #
 # Cursor is excluded — global rules are UI-only (cursor.com/docs/rules).
 GLOBAL_TARGETS: dict[str, tuple[str, str, str, bool]] = {
@@ -67,6 +70,12 @@ GLOBAL_TARGETS: dict[str, tuple[str, str, str, bool]] = {
         ".config/opencode/skills/desloppify/SKILL.md",
         "OPENCODE",
         ".config/opencode",
+        True,
+    ),
+    "rovodev": (
+        ".rovodev/skills/desloppify/SKILL.md",
+        "ROVODEV",
+        ".rovodev",
         True,
     ),
 }

--- a/desloppify/data/global/ROVODEV.md
+++ b/desloppify/data/global/ROVODEV.md
@@ -1,0 +1,147 @@
+## Rovo Dev Overlay
+
+Desloppify is installed as a Rovo Dev skill at `.rovodev/skills/desloppify/SKILL.md`. Rovo Dev discovers skills in both the user-level (`~/.rovodev/skills/`) and project-level (`.rovodev/skills/`) directories, and lazy-loads the skill body into context via the built-in `get_skill` tool when desloppify is invoked.
+
+### Subagents
+
+Rovo Dev supports parallel subagents via the `invoke_subagents` tool. The `General Purpose` subagent inherits all of the parent's tools and is ideal for context-isolated subjective review batches and per-stage triage work. Concurrency caps for `invoke_subagents` are set by Rovo Dev itself and may evolve over time — see the manual fallback section below for the current per-call limit.
+
+### Review workflow
+
+#### Native batch runner (recommended)
+
+Use the first-class `--runner rovodev` for automated batch reviews:
+
+```bash
+desloppify review --run-batches --runner rovodev --parallel --scan-after-import
+# Each batch is its own `acli rovodev` subprocess, so concurrency is bounded
+# by `--max-parallel-batches` (default 3), NOT by Rovo Dev's in-process
+# subagent limit. Bump it for faster wall-clock review on large packets:
+#   --max-parallel-batches 6
+```
+
+This spawns `acli rovodev` subprocesses (one per batch), recovers the JSON payload from each agent's reply (or from the agent-written output file), merges them, and imports as trusted assessments — same end-to-end shape as the Codex / OpenCode runners (subprocess-per-batch → file-output → merge → trusted import), with the wire-level details adapted to `acli rovodev`'s prompt-instructed output mode.
+
+Optional environment overrides:
+
+- `DESLOPPIFY_ROVODEV_NO_YOLO=1` opts out of `--yolo` (the default). With `--yolo` enabled the agent can write the per-batch output file in non-interactive mode without permission prompts; turn it off only for interactive review work.
+- `DESLOPPIFY_ROVODEV_OUTPUT_SCHEMA='<schema or path>'` is forwarded as `--output-schema`, constraining the agent's reply to a JSON shape.
+- `DESLOPPIFY_ROVODEV_EXTRA_ARGS="--config-override '{...}'"` is shell-split and appended verbatim before the prompt (useful for `--config-override`, `--restore`, `--worktree`, etc.).
+- `DESLOPPIFY_ROVODEV_EXECUTABLE=acli` overrides the binary name (useful when `acli` is shipped under a different name in CI).
+
+#### Manual subagent path
+
+If you prefer to drive batches from inside an existing Rovo Dev session, use the manual subagent flow:
+
+1. Prepare review prompts and the blind packet:
+   ```bash
+   desloppify review --run-batches --dry-run
+   ```
+   This generates one prompt file per batch in
+   `.desloppify/subagents/runs/<run-id>/prompts/` and prints the run directory.
+
+2. Note the run id printed by step 1 (e.g. `20260509_122030`). Replace
+   `<run-id>` in the paths below with that real value before invoking —
+   subagents do not share the parent's context, so passing the
+   placeholder verbatim will leave them unable to find the prompt or
+   know where to write their output.
+
+3. Launch Rovo Dev subagents in groups (Rovo Dev currently caps
+   `invoke_subagents` at 4 per call) using `invoke_subagents`,
+   passing one task per batch. Each subagent should:
+   - read its prompt file at
+     `.desloppify/subagents/runs/<run-id>/prompts/batch-N.md`
+   - read `.desloppify/review_packet_blind.json`
+   - inspect the repository as instructed by the prompt's dimension list
+   - write ONLY valid JSON to
+     `.desloppify/subagents/runs/<run-id>/results/batch-N.raw.txt`
+
+   Example invocation (with `<run-id>` already substituted):
+   ```
+   invoke_subagents(
+     subagent_names=["General Purpose", "General Purpose", "General Purpose"],
+     task_names=["review-batch-1", "review-batch-2", "review-batch-3"],
+     task_descriptions=[
+       "Review batch 1. Read .desloppify/subagents/runs/20260509_122030/prompts/batch-1.md, follow it exactly, inspect the repository, and write ONLY valid JSON to .desloppify/subagents/runs/20260509_122030/results/batch-1.raw.txt. Do not edit repository source files.",
+       "Review batch 2. ...",
+       "Review batch 3. ..."
+     ],
+   )
+   ```
+
+   Repeat the call in groups respecting Rovo Dev's per-call cap (e.g.
+   batches 1-4, then 5-8, ...). Wait for each group to finish before
+   launching the next.
+
+4. After every prompt for the run has a matching result file, import them
+   (using the same real run id):
+   ```bash
+   desloppify review --import-run .desloppify/subagents/runs/<run-id> --scan-after-import
+   ```
+
+### Key constraints
+
+- `invoke_subagents` only applies to the manual fallback path; it does NOT
+  cap the native `--runner rovodev` pipeline (each batch is its own
+  subprocess, throttled by `--max-parallel-batches`).
+- Per-call `invoke_subagents` concurrency is bounded by Rovo Dev itself
+  (currently up to 4 subagents per call). Check `/help invoke_subagents`
+  if you suspect the limit has changed.
+- Subagents do not inherit parent conversation context — the prompt file and
+  the blind packet must contain everything they need.
+- Subagents must consume `.desloppify/review_packet_blind.json` (not full
+  `query.json`) to avoid score anchoring.
+- The importer expects `results/batch-N.raw.txt` files, not `.json` filenames.
+- The blind packet intentionally omits score history to prevent anchoring bias.
+
+### Triage workflow
+
+#### Native triage runner (recommended)
+
+Use the first-class `--runner rovodev` to drive the full staged triage
+pipeline (strategize → observe → reflect → organize → enrich → sense-check
+→ commit) via `acli rovodev` subprocesses:
+
+```bash
+desloppify plan triage --run-stages --runner rovodev
+```
+
+Useful flags:
+
+- `--only-stages observe,reflect` runs a subset of stages.
+- `--dry-run` prints prompts only.
+- `--stage-timeout-seconds N` overrides the per-stage timeout.
+
+Each stage's prompt, output, log, and run summary land under
+`.desloppify/triage_runs/<timestamp>/`; rerunning resumes from the last
+confirmed stage. The `runner` field in `run_summary.json` is set to
+`"rovodev"` for provenance.
+
+The same `DESLOPPIFY_ROVODEV_*` environment overrides documented for the
+review runner above (`DESLOPPIFY_ROVODEV_NO_YOLO`,
+`DESLOPPIFY_ROVODEV_OUTPUT_SCHEMA`, `DESLOPPIFY_ROVODEV_EXTRA_ARGS`,
+`DESLOPPIFY_ROVODEV_EXECUTABLE`) apply to triage stages too.
+
+#### Manual stage-prompt path
+
+If you prefer to drive triage from inside an existing Rovo Dev session,
+run each stage by hand:
+
+1. Get the stage prompt: `desloppify plan triage --stage-prompt <stage>`
+2. If the stage benefits from parallel review work, fan it out with
+   `invoke_subagents` (in groups respecting Rovo Dev's per-call cap);
+   otherwise run the stage directly in the parent session.
+3. Confirm the stage: `desloppify plan triage --confirm <stage> --attestation "..."`
+4. Complete: `desloppify plan triage --complete --strategy "..." --attestation "..."`
+
+### Atlassian context
+
+Rovo Dev ships with first-class Atlassian (Jira / Confluence / Bitbucket)
+tooling. When triaging or planning desloppify work, you can pull related
+Jira issues, design docs, or PR history via the built-in Atlassian MCP
+toolset, or load the `full-context-mode` skill via the `/full-context`
+slash command for guided organisational research — no extra setup
+required.
+
+<!-- desloppify-overlay: rovodev -->
+<!-- desloppify-end -->

--- a/desloppify/data/global/SKILL.md
+++ b/desloppify/data/global/SKILL.md
@@ -8,7 +8,7 @@ description: >
 ---
 
 <!-- desloppify-begin -->
-<!-- desloppify-skill-version: 6 -->
+<!-- desloppify-skill-version: 7 -->
 
 # Desloppify
 
@@ -58,7 +58,7 @@ desloppify plan triage --stage organize --report "summary of priorities..."
 desloppify plan triage --complete --strategy "execution plan..."
 ```
 
-For automated triage: `desloppify plan triage --run-stages --runner codex` (Codex) or `--runner claude` (Claude). Options: `--only-stages`, `--dry-run`, `--stage-timeout-seconds`.
+For automated triage: `desloppify plan triage --run-stages --runner codex` (Codex), `--runner claude` (Claude), or `--runner rovodev` (Rovo Dev). Options: `--only-stages`, `--dry-run`, `--stage-timeout-seconds`.
 
 Then shape the queue. **The plan shapes everything `next` gives you** — `next` is the execution queue, not the full backlog. Don't skip this step.
 
@@ -129,6 +129,7 @@ Four paths to get subjective scores:
 
 - **Local runner (Codex)**: `desloppify review --run-batches --runner codex --parallel --scan-after-import` — automated end-to-end.
 - **Local runner (Claude)**: `desloppify review --prepare` → launch parallel subagents → `desloppify review --import merged.json` — see skill doc overlay for details.
+- **Local runner (Rovo Dev)**: `desloppify review --run-batches --runner rovodev --parallel --scan-after-import` — automated end-to-end via `acli rovodev` subprocesses.
 - **Cloud/external**: `desloppify review --external-start --external-runner claude` → follow session template → `--external-submit`.
 - **Manual path**: `desloppify review --prepare` → review per dimension → `desloppify review --import file.json`.
 

--- a/desloppify/engine/_plan/triage/playbook.py
+++ b/desloppify/engine/_plan/triage/playbook.py
@@ -14,7 +14,7 @@ TRIAGE_STAGE_LABELS: tuple[tuple[str, str], ...] = (
     ("commit", "Write strategy & confirm"),
 )
 
-TRIAGE_RUNNERS: tuple[str, str] = ("codex", "claude")
+TRIAGE_RUNNERS: tuple[str, ...] = ("codex", "claude", "rovodev")
 
 TRIAGE_CMD_STRATEGIZE = (
     'desloppify plan triage --stage strategize --report '
@@ -63,6 +63,7 @@ TRIAGE_CMD_CLUSTER_STEPS = (
 )
 TRIAGE_CMD_RUN_STAGES_CODEX = "desloppify plan triage --run-stages --runner codex"
 TRIAGE_CMD_RUN_STAGES_CLAUDE = "desloppify plan triage --run-stages --runner claude"
+TRIAGE_CMD_RUN_STAGES_ROVODEV = "desloppify plan triage --run-stages --runner rovodev"
 
 _RUNNER_STAGE_NAMES = frozenset(
     stage_name for stage_name, _label in TRIAGE_STAGE_LABELS if stage_name != "commit"
@@ -248,11 +249,14 @@ def triage_run_stages_command(
 def triage_runner_commands(
     *,
     only_stages: str | tuple[str, ...] | list[str] | None = None,
-) -> tuple[tuple[str, str], tuple[str, str]]:
-    """Return the preferred staged-runner commands for Codex and Claude."""
-    return (
-        ("Codex", triage_run_stages_command(runner="codex", only_stages=only_stages)),
-        ("Claude", triage_run_stages_command(runner="claude", only_stages=only_stages)),
+) -> tuple[tuple[str, str], ...]:
+    """Return the preferred staged-runner commands for each supported runner."""
+    return tuple(
+        (
+            runner.capitalize() if runner != "rovodev" else "Rovo Dev",
+            triage_run_stages_command(runner=runner, only_stages=only_stages),
+        )
+        for runner in TRIAGE_RUNNERS
     )
 
 
@@ -288,6 +292,7 @@ __all__ = [
     "TRIAGE_CMD_REFLECT",
     "TRIAGE_CMD_RUN_STAGES_CLAUDE",
     "TRIAGE_CMD_RUN_STAGES_CODEX",
+    "TRIAGE_CMD_RUN_STAGES_ROVODEV",
     "TRIAGE_RUNNERS",
     "compute_triage_progress",
     "triage_manual_stage_command",

--- a/desloppify/engine/plan_triage.py
+++ b/desloppify/engine/plan_triage.py
@@ -34,6 +34,7 @@ from desloppify.engine._plan.triage.playbook import (
     TRIAGE_CMD_REFLECT,
     TRIAGE_CMD_RUN_STAGES_CLAUDE,
     TRIAGE_CMD_RUN_STAGES_CODEX,
+    TRIAGE_CMD_RUN_STAGES_ROVODEV,
     TRIAGE_CMD_SENSE_CHECK,
     TRIAGE_CMD_STRATEGIZE,
     TRIAGE_STAGE_DEPENDENCIES,
@@ -75,7 +76,7 @@ def triage_phase_banner(
     meta = plan.get("epic_triage_meta", {})
     run_hint = (
         f"Run: {TRIAGE_CMD_RUN_STAGES_CODEX} "
-        f"(or {TRIAGE_CMD_RUN_STAGES_CLAUDE})"
+        f"(or {TRIAGE_CMD_RUN_STAGES_CLAUDE} / {TRIAGE_CMD_RUN_STAGES_ROVODEV})"
     )
     resolved_state = state or {}
     resolved_snapshot = snapshot or build_triage_snapshot(plan, resolved_state)
@@ -144,6 +145,7 @@ __all__ = [
     "TRIAGE_CMD_REFLECT",
     "TRIAGE_CMD_RUN_STAGES_CLAUDE",
     "TRIAGE_CMD_RUN_STAGES_CODEX",
+    "TRIAGE_CMD_RUN_STAGES_ROVODEV",
     "TRIAGE_CMD_SENSE_CHECK",
     "TRIAGE_CMD_STRATEGIZE",
     "TRIAGE_IDS",

--- a/desloppify/intelligence/review/_prepare/helpers.py
+++ b/desloppify/intelligence/review/_prepare/helpers.py
@@ -13,6 +13,7 @@ HOLISTIC_WORKFLOW = [
     "Codex: desloppify review --run-batches --runner codex --parallel --scan-after-import",
     "OpenCode: desloppify review --run-batches --runner opencode --parallel --scan-after-import",
     "Claude / other agent: desloppify review --run-batches --dry-run → launch one subagent per prompt file (all in parallel) → desloppify review --import-run <run-dir> --scan-after-import",
+    "Rovo Dev: desloppify review --run-batches --runner rovodev --parallel --scan-after-import",
     "Cloud/external: run `desloppify review --external-start --external-runner claude`, follow the session template, then run the printed `--external-submit` command",
     "Fallback path: `desloppify review --import issues.json` (issues only). Use manual override only for emergency/provisional imports.",
     "AFTER importing: run `desloppify show review --status open` to see the work queue, then fix each issue in code and `desloppify plan resolve <id>`",

--- a/desloppify/tests/commands/plan/test_triage_rovodev_runner_direct.py
+++ b/desloppify/tests/commands/plan/test_triage_rovodev_runner_direct.py
@@ -1,0 +1,254 @@
+"""Direct unit tests for the Rovo Dev triage runner and pipeline wrapper."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import desloppify.app.commands.plan.triage.runner.orchestrator_codex_pipeline as codex_pipeline_mod
+import desloppify.app.commands.plan.triage.runner.rovodev_pipeline as rovodev_pipeline_mod
+import desloppify.app.commands.plan.triage.runner.rovodev_runner as rovodev_runner_mod
+import desloppify.app.commands.plan.triage.runner.stage_runner_override as override_mod
+from desloppify.app.commands.plan.triage.runner.codex_runner import (
+    TriageStageRunResult,
+)
+
+
+def test_run_triage_stage_rovodev_returns_typed_result_for_empty_prompt(
+    tmp_path: Path,
+) -> None:
+    """Empty prompts short-circuit with a deterministic typed result."""
+    output_file = tmp_path / "out.txt"
+    log_file = tmp_path / "out.log"
+
+    result = rovodev_runner_mod.run_triage_stage_rovodev(
+        prompt="   ",
+        repo_root=tmp_path,
+        output_file=output_file,
+        log_file=log_file,
+    )
+
+    assert isinstance(result, TriageStageRunResult)
+    assert result.exit_code == 2
+    assert result.reason == "empty_prompt"
+    assert "Empty triage prompt" in log_file.read_text()
+
+
+def test_run_triage_stage_rovodev_delegates_to_run_rovodev_batch(
+    tmp_path: Path,
+) -> None:
+    """The triage runner forwards real prompts to the rovodev batch runner."""
+    output_file = tmp_path / "out.txt"
+    log_file = tmp_path / "out.log"
+    output_file.write_text("ok")  # so the default validate_output_fn passes
+
+    with patch.object(
+        rovodev_runner_mod,
+        "run_rovodev_batch",
+        return_value=0,
+    ) as mock_run:
+        result = rovodev_runner_mod.run_triage_stage_rovodev(
+            prompt="evaluate clarity",
+            repo_root=tmp_path,
+            output_file=output_file,
+            log_file=log_file,
+            timeout_seconds=120,
+        )
+
+    assert result.ok
+    assert result.exit_code == 0
+    mock_run.assert_called_once()
+    call_kwargs = mock_run.call_args.kwargs
+    assert call_kwargs["prompt"] == "evaluate clarity"
+    assert call_kwargs["output_file"] == output_file
+    assert call_kwargs["log_file"] == log_file
+    # The runner deps must use the rovodev validate_output_fn (callable).
+    assert callable(call_kwargs["deps"].validate_output_fn)
+
+
+def test_run_triage_stage_rovodev_records_command_preview(tmp_path: Path) -> None:
+    """The log file is seeded with the runner command preview before execution."""
+    output_file = tmp_path / "out.txt"
+    log_file = tmp_path / "out.log"
+    output_file.write_text("ok")
+
+    with patch.object(rovodev_runner_mod, "run_rovodev_batch", return_value=0):
+        rovodev_runner_mod.run_triage_stage_rovodev(
+            prompt="hi",
+            repo_root=tmp_path,
+            output_file=output_file,
+            log_file=log_file,
+        )
+
+    log_text = log_file.read_text()
+    assert "RUNNER COMMAND PREVIEW" in log_text
+    assert "rovodev" in log_text
+
+
+def test_run_triage_stage_rovodev_propagates_runner_failure(tmp_path: Path) -> None:
+    """A non-zero runner exit becomes a typed failure result."""
+    output_file = tmp_path / "out.txt"
+    log_file = tmp_path / "out.log"
+
+    with patch.object(rovodev_runner_mod, "run_rovodev_batch", return_value=7):
+        result = rovodev_runner_mod.run_triage_stage_rovodev(
+            prompt="evaluate",
+            repo_root=tmp_path,
+            output_file=output_file,
+            log_file=log_file,
+        )
+
+    assert not result.ok
+    assert result.exit_code == 7
+    assert result.reason == "runner_exit_7"
+
+
+def test_run_rovodev_pipeline_overrides_then_restores_runner(tmp_path: Path) -> None:
+    """The wrapper sets the override for the call and restores it afterwards."""
+    args = argparse.Namespace(stage_timeout_seconds=60, dry_run=True)
+
+    sentinel_state_before_runner = override_mod._STAGE_RUNNER_OVERRIDE
+    sentinel_state_before_label = override_mod._RUNNER_NAME_OVERRIDE
+
+    captured: dict[str, object] = {}
+
+    def fake_pipeline(args, *, stages_to_run, services=None) -> None:  # noqa: ARG001
+        captured["runner"] = override_mod._STAGE_RUNNER_OVERRIDE
+        captured["label"] = override_mod._RUNNER_NAME_OVERRIDE
+
+    with patch.object(codex_pipeline_mod, "run_codex_pipeline", side_effect=fake_pipeline):
+        rovodev_pipeline_mod.run_rovodev_pipeline(
+            args, stages_to_run=["observe"], services=MagicMock()
+        )
+
+    assert captured["runner"] is rovodev_runner_mod.run_triage_stage_rovodev
+    assert captured["label"] == "rovodev"
+    # The wrapper must restore the previous module-level state.
+    assert override_mod._STAGE_RUNNER_OVERRIDE is sentinel_state_before_runner
+    assert override_mod._RUNNER_NAME_OVERRIDE is sentinel_state_before_label
+
+
+def test_run_rovodev_pipeline_restores_override_on_exception(tmp_path: Path) -> None:
+    """If the inner pipeline raises, the overrides are still restored."""
+    args = argparse.Namespace(stage_timeout_seconds=60, dry_run=True)
+
+    sentinel_runner = override_mod._STAGE_RUNNER_OVERRIDE
+    sentinel_label = override_mod._RUNNER_NAME_OVERRIDE
+
+    with patch.object(
+        codex_pipeline_mod,
+        "run_codex_pipeline",
+        side_effect=RuntimeError("boom"),
+    ):
+        with pytest.raises(RuntimeError, match="boom"):
+            rovodev_pipeline_mod.run_rovodev_pipeline(
+                args, stages_to_run=["observe"], services=MagicMock()
+            )
+
+    assert override_mod._STAGE_RUNNER_OVERRIDE is sentinel_runner
+    assert override_mod._RUNNER_NAME_OVERRIDE is sentinel_label
+
+
+def test_triage_parser_accepts_rovodev_runner() -> None:
+    from desloppify.cli import create_parser
+
+    parser = create_parser()
+    args = parser.parse_args(
+        ["plan", "triage", "--run-stages", "--runner", "rovodev"]
+    )
+    assert args.runner == "rovodev"
+    assert args.run_stages is True
+
+
+def test_triage_runner_commands_includes_rovodev() -> None:
+    from desloppify.engine._plan.triage.playbook import (
+        TRIAGE_RUNNERS,
+        triage_run_stages_command,
+        triage_runner_commands,
+    )
+
+    assert "rovodev" in TRIAGE_RUNNERS
+    cmds = triage_runner_commands()
+    runner_labels = {label for label, _cmd in cmds}
+    assert "Rovo Dev" in runner_labels
+    rovodev_cmd = triage_run_stages_command(runner="rovodev")
+    assert rovodev_cmd == "desloppify plan triage --run-stages --runner rovodev"
+
+
+def test_triage_run_stages_command_with_only_stages_for_rovodev() -> None:
+    from desloppify.engine._plan.triage.playbook import triage_run_stages_command
+
+    cmd = triage_run_stages_command(runner="rovodev", only_stages=["observe", "reflect"])
+    assert cmd == "desloppify plan triage --run-stages --runner rovodev --only-stages observe,reflect"
+
+
+def test_workflow_dispatches_rovodev_runner() -> None:
+    """`_run_staged_runner` routes ``--runner rovodev`` to the rovodev pipeline."""
+    import desloppify.app.commands.plan.triage.workflow as workflow_mod
+
+    args = argparse.Namespace(
+        runner="rovodev",
+        only_stages=None,
+        stage_timeout_seconds=60,
+        dry_run=True,
+    )
+    services = MagicMock()
+    with patch.object(workflow_mod, "run_rovodev_pipeline") as mock_rovodev, patch.object(
+        workflow_mod, "run_codex_pipeline"
+    ) as mock_codex, patch.object(
+        workflow_mod, "run_claude_orchestrator"
+    ) as mock_claude:
+        workflow_mod._run_staged_runner(args, services=services)
+
+    mock_rovodev.assert_called_once()
+    mock_codex.assert_not_called()
+    mock_claude.assert_not_called()
+
+
+def test_workflow_unknown_runner_message_lists_rovodev() -> None:
+    """Unknown runner errors should mention rovodev as a valid choice."""
+    import desloppify.app.commands.plan.triage.workflow as workflow_mod
+    from desloppify.base.exception_sets import CommandError
+
+    args = argparse.Namespace(runner="nope", only_stages=None)
+    with pytest.raises(CommandError) as excinfo:
+        workflow_mod._run_staged_runner(args, services=MagicMock())
+
+    assert "rovodev" in str(excinfo.value)
+
+
+def test_active_stage_runner_propagates_override_to_observe_and_sense() -> None:
+    """Regression: parallel sub-runners (observe, sense-check) must honour
+    the per-pipeline stage runner override. Before this fix, ``run_observe``
+    and ``run_sense_check`` imported ``run_triage_stage`` directly, so
+    ``--runner rovodev`` would silently fall back to ``codex exec`` for
+    those stages and fail with exit 127 on systems without ``codex``
+    installed.
+    """
+    import desloppify.app.commands.plan.triage.runner.orchestrator_codex_observe as observe_mod
+    import desloppify.app.commands.plan.triage.runner.orchestrator_codex_sense as sense_mod
+    from desloppify.app.commands.plan.triage.runner.codex_runner import (
+        run_triage_stage as codex_default,
+    )
+
+    # Both sub-runners must consult the central registry (not the codex
+    # default directly).
+    assert observe_mod.active_stage_runner is override_mod.active_stage_runner
+    assert sense_mod.active_stage_runner is override_mod.active_stage_runner
+
+    # Default behaviour: no override → codex stage runner.
+    assert override_mod._STAGE_RUNNER_OVERRIDE is None
+    assert override_mod.active_stage_runner() is codex_default
+
+    # With override installed: the active runner is the override.
+    sentinel = object()
+    override_mod.set_stage_runner_override(sentinel, "rovodev")
+    try:
+        assert override_mod.active_stage_runner() is sentinel
+        assert override_mod.active_runner_name() == "rovodev"
+    finally:
+        override_mod.set_stage_runner_override(None, None)
+    assert override_mod.active_stage_runner() is codex_default

--- a/desloppify/tests/commands/plan/test_triage_split_modules_direct.py
+++ b/desloppify/tests/commands/plan/test_triage_split_modules_direct.py
@@ -800,11 +800,8 @@ def test_orchestrator_sense_non_dry_run_merges_outputs(monkeypatch, tmp_path, ca
         assert validate_output_fn(output_file)
         return codex_runner_mod.TriageStageRunResult(exit_code=0)
 
-    monkeypatch.setattr(
-        orchestrator_sense_mod,
-        "run_triage_stage",
-        fake_run_triage_stage,
-    )
+    import desloppify.app.commands.plan.triage.runner.stage_runner_override as override_mod
+    monkeypatch.setattr(override_mod, "_STAGE_RUNNER_OVERRIDE", fake_run_triage_stage)
 
     def fake_run_parallel_batches(
         *,
@@ -985,7 +982,8 @@ def test_orchestrator_sense_apply_updates_sequences_and_reloads_plan(monkeypatch
         "build_sense_check_value_prompt",
         lambda **_kwargs: "value prompt",
     )
-    monkeypatch.setattr(orchestrator_sense_mod, "run_triage_stage", fake_run_triage_stage)
+    import desloppify.app.commands.plan.triage.runner.stage_runner_override as override_mod
+    monkeypatch.setattr(override_mod, "_STAGE_RUNNER_OVERRIDE", fake_run_triage_stage)
     monkeypatch.setattr(orchestrator_sense_mod, "run_parallel_batches", fake_run_parallel_batches)
 
     prompts_dir = tmp_path / "prompts"
@@ -1065,7 +1063,8 @@ def test_orchestrator_sense_scopes_content_batches_to_active_triage(monkeypatch,
         assert validate_output_fn(output_file)
         return codex_runner_mod.TriageStageRunResult(exit_code=0)
 
-    monkeypatch.setattr(orchestrator_sense_mod, "run_triage_stage", fake_run_triage_stage)
+    import desloppify.app.commands.plan.triage.runner.stage_runner_override as override_mod
+    monkeypatch.setattr(override_mod, "_STAGE_RUNNER_OVERRIDE", fake_run_triage_stage)
     monkeypatch.setattr(
         orchestrator_sense_mod,
         "run_parallel_batches",

--- a/desloppify/tests/commands/review/test_runner_rovodev_direct.py
+++ b/desloppify/tests/commands/review/test_runner_rovodev_direct.py
@@ -1,0 +1,247 @@
+"""Direct unit tests for the Rovo Dev (`acli rovodev`) batch runner."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import desloppify.app.commands.review.batch.orchestrator as orchestrator_mod
+import desloppify.app.commands.review.runner_rovodev as runner_rovodev_mod
+from desloppify.app.commands.review.runner_process_impl.types import _ExecutionResult
+
+
+def _safe_write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def test_rovodev_batch_command_includes_acli_rovodev_invocation(monkeypatch) -> None:
+    """The default command line invokes ``acli rovodev`` with ``--yolo``."""
+    monkeypatch.delenv("DESLOPPIFY_ROVODEV_NO_YOLO", raising=False)
+    monkeypatch.delenv("DESLOPPIFY_ROVODEV_OUTPUT_SCHEMA", raising=False)
+    monkeypatch.delenv("DESLOPPIFY_ROVODEV_EXTRA_ARGS", raising=False)
+    monkeypatch.delenv("DESLOPPIFY_ROVODEV_EXECUTABLE", raising=False)
+
+    cmd = runner_rovodev_mod.rovodev_batch_command(
+        prompt="hello world",
+        repo_root=Path("/tmp/repo"),
+    )
+
+    # The prompt is always the final positional argument so any flags can be
+    # injected before it without colliding with shell-quoting edge cases.
+    assert cmd[-1] == "hello world"
+    joined = " ".join(cmd).lower()
+    assert "rovodev" in joined
+    # --yolo is enabled by default so the agent can write the per-batch
+    # output file in non-interactive mode without permission prompts.
+    assert "--yolo" in joined
+
+
+def test_rovodev_batch_command_honours_env_overrides(monkeypatch) -> None:
+    """Schema, extra args, and executable overrides are respected."""
+    monkeypatch.delenv("DESLOPPIFY_ROVODEV_NO_YOLO", raising=False)
+    monkeypatch.setenv("DESLOPPIFY_ROVODEV_OUTPUT_SCHEMA", '{"type":"object"}')
+    monkeypatch.setenv("DESLOPPIFY_ROVODEV_EXTRA_ARGS", "--config-override foo")
+    monkeypatch.setenv("DESLOPPIFY_ROVODEV_EXECUTABLE", "acli")
+
+    cmd = runner_rovodev_mod.rovodev_batch_command(
+        prompt="prompt",
+        repo_root=Path("/tmp/repo"),
+    )
+
+    joined = " ".join(cmd)
+    assert "--output-schema" in joined
+    assert '{"type":"object"}' in joined
+    assert "--config-override foo" in joined
+    assert cmd[-1] == "prompt"
+
+
+def test_rovodev_batch_command_no_yolo_opt_out(monkeypatch) -> None:
+    """Setting DESLOPPIFY_ROVODEV_NO_YOLO=1 omits the --yolo flag."""
+    monkeypatch.setenv("DESLOPPIFY_ROVODEV_NO_YOLO", "1")
+    monkeypatch.delenv("DESLOPPIFY_ROVODEV_OUTPUT_SCHEMA", raising=False)
+    monkeypatch.delenv("DESLOPPIFY_ROVODEV_EXTRA_ARGS", raising=False)
+
+    cmd = runner_rovodev_mod.rovodev_batch_command(
+        prompt="p",
+        repo_root=Path("/tmp/repo"),
+    )
+
+    assert "--yolo" not in " ".join(cmd)
+
+
+def test_extract_json_object_returns_last_balanced_object() -> None:
+    """When the agent emits multiple JSON objects, the last one wins."""
+    text = (
+        "Working...\n"
+        '{"assessments": {"logic_clarity": 10}, "issues": []}\n'
+        "Final answer:\n"
+        '{"assessments": {"logic_clarity": 88}, "issues": []}\n'
+    )
+
+    extracted = runner_rovodev_mod._extract_json_object(text)
+
+    assert extracted is not None
+    assert json.loads(extracted)["assessments"]["logic_clarity"] == 88
+
+
+def test_extract_json_object_handles_strings_with_braces() -> None:
+    """JSON strings containing braces should not desync the brace counter."""
+    payload = {"comment": "function() { return 1; }", "issues": []}
+    text = "Plan:\n" + json.dumps(payload)
+
+    extracted = runner_rovodev_mod._extract_json_object(text)
+
+    assert extracted is not None
+    assert json.loads(extracted) == payload
+
+
+def test_extract_json_object_returns_none_for_no_object() -> None:
+    assert runner_rovodev_mod._extract_json_object("just narration") is None
+    assert runner_rovodev_mod._extract_json_object("") is None
+
+
+def test_run_rovodev_batch_recovers_timeout_from_stdout_payload(tmp_path: Path) -> None:
+    """A timed-out attempt with a valid JSON payload in stdout is recovered."""
+    log_file = tmp_path / "batch.log"
+    output_file = tmp_path / "out.json"
+    payload = {"assessments": {"logic_clarity": 88}, "issues": []}
+    stdout_text = (
+        "I am evaluating logic_clarity now.\n"
+        f"Final reply:\n{json.dumps(payload)}\n"
+    )
+
+    with patch(
+        "desloppify.app.commands.review.runner_rovodev._run_batch_attempt",
+        return_value=(
+            "ATTEMPT 1/1",
+            _ExecutionResult(code=1, stdout_text=stdout_text, stderr_text="", timed_out=True),
+        ),
+    ):
+        code = runner_rovodev_mod.run_rovodev_batch(
+            prompt="test prompt",
+            repo_root=tmp_path,
+            output_file=output_file,
+            log_file=log_file,
+            deps=orchestrator_mod.CodexBatchRunnerDeps(
+                timeout_seconds=60,
+                subprocess_run=subprocess.run,
+                timeout_error=TimeoutError,
+                safe_write_text_fn=_safe_write_text,
+                sleep_fn=lambda _seconds: None,
+            ),
+        )
+
+    assert code == 0
+    assert json.loads(output_file.read_text()) == payload
+    assert "Recovered timed-out batch from JSON output file" in log_file.read_text()
+
+
+def test_run_rovodev_batch_restores_valid_output_after_retry_failure(tmp_path: Path) -> None:
+    """A successful first-attempt payload is preserved across a fatal retry."""
+    output_file = tmp_path / "batch-1.raw.txt"
+    log_file = tmp_path / "batch-1.log"
+    first_payload = {"assessments": {"logic_clarity": 10}, "issues": []}
+    first_stdout = "Reply:\n" + json.dumps(first_payload) + "\n"
+
+    with patch(
+        "desloppify.app.commands.review.runner_rovodev._run_batch_attempt",
+        side_effect=[
+            (
+                "ATTEMPT 1/2",
+                _ExecutionResult(
+                    code=1,
+                    stdout_text=first_stdout,
+                    stderr_text="stream disconnected before completion",
+                ),
+            ),
+            (
+                "ATTEMPT 2/2",
+                _ExecutionResult(code=1, stdout_text="", stderr_text="fatal auth error"),
+            ),
+        ],
+    ):
+        code = runner_rovodev_mod.run_rovodev_batch(
+            prompt="test prompt",
+            repo_root=tmp_path,
+            output_file=output_file,
+            log_file=log_file,
+            deps=orchestrator_mod.CodexBatchRunnerDeps(
+                timeout_seconds=60,
+                subprocess_run=subprocess.run,
+                timeout_error=TimeoutError,
+                safe_write_text_fn=_safe_write_text,
+                max_retries=1,
+                retry_backoff_seconds=0.0,
+                sleep_fn=lambda _seconds: None,
+            ),
+        )
+
+    assert code == 1
+    # The recoverable payload from attempt 1 must survive the fatal retry,
+    # otherwise downstream collect_batch_results cannot recover the result.
+    assert json.loads(output_file.read_text()) == first_payload
+
+
+def test_select_batch_runner_dispatches_to_rovodev() -> None:
+    """The orchestrator's runner dispatch table includes rovodev."""
+    assert (
+        orchestrator_mod._select_batch_runner("rovodev")
+        is runner_rovodev_mod.run_rovodev_batch
+    )
+    # Unknown runner names fall back to codex (already validated upstream).
+    assert (
+        orchestrator_mod._select_batch_runner("unknown")
+        is orchestrator_mod.run_codex_batch
+    )
+
+
+def test_validate_runner_accepts_rovodev() -> None:
+    from desloppify.app.commands.review.batch.scope import validate_runner
+
+    # Should not raise.
+    validate_runner("rovodev", colorize_fn=lambda text, _style: text)
+
+
+def test_runner_parser_accepts_rovodev_choice() -> None:
+    from desloppify.cli import create_parser
+
+    parser = create_parser()
+    args = parser.parse_args(
+        ["review", "--run-batches", "--runner", "rovodev"]
+    )
+    assert args.runner == "rovodev"
+
+
+def test_supported_blind_review_runners_includes_rovodev() -> None:
+    from desloppify.app.commands.review.importing.policy import (
+        SUPPORTED_BLIND_REVIEW_RUNNERS,
+    )
+
+    assert "rovodev" in SUPPORTED_BLIND_REVIEW_RUNNERS
+
+
+def test_runner_missing_detection_recognises_acli(monkeypatch) -> None:
+    """The runner-missing detector recognises the ``acli`` binary by name."""
+    from desloppify.app.commands.review.runner_failures import _is_runner_missing
+
+    assert _is_runner_missing("acli not found")
+    assert _is_runner_missing("no such file or directory: $ acli rovodev run")
+    assert not _is_runner_missing("totally unrelated error")
+
+
+@pytest.mark.parametrize(
+    "runner,expected_attr",
+    [
+        ("codex", "run_codex_batch"),
+        ("opencode", "run_opencode_batch"),
+        ("rovodev", "run_rovodev_batch"),
+    ],
+)
+def test_select_batch_runner_table(runner: str, expected_attr: str) -> None:
+    selected = orchestrator_mod._select_batch_runner(runner)
+    assert selected is getattr(orchestrator_mod, expected_attr)

--- a/desloppify/tests/commands/test_direct_coverage_queue_batch_modules.py
+++ b/desloppify/tests/commands/test_direct_coverage_queue_batch_modules.py
@@ -14,6 +14,7 @@ import desloppify.app.commands.review.coordinator as coordinator_mod
 import desloppify.app.commands.review.packet.build as packet_build_mod
 import desloppify.app.commands.review.runner_failures as runner_failures_mod
 import desloppify.app.commands.review.runner_opencode as runner_opencode_mod
+import desloppify.app.commands.review.runner_rovodev as runner_rovodev_mod
 import desloppify.app.commands.review.runner_packets as runner_packets_mod
 import desloppify.app.commands.review.runner_parallel as runner_parallel_mod
 import desloppify.app.commands.runner.codex_batch as runner_process_mod
@@ -47,6 +48,8 @@ def test_direct_coverage_split_queue_batch_modules_smoke():
     assert callable(runner_failures_mod.print_failures)
     assert callable(runner_opencode_mod.run_opencode_batch)
     assert callable(runner_opencode_mod.opencode_batch_command)
+    assert callable(runner_rovodev_mod.run_rovodev_batch)
+    assert callable(runner_rovodev_mod.rovodev_batch_command)
     assert callable(runner_packets_mod.prepare_run_artifacts)
     assert callable(runner_parallel_mod.execute_batches)
     assert callable(runner_process_mod.run_codex_batch)

--- a/desloppify/tests/commands/test_setup.py
+++ b/desloppify/tests/commands/test_setup.py
@@ -186,6 +186,30 @@ def test_bundled_resources_are_readable() -> None:
         "DROID.md",
         "COPILOT.md",
         "OPENCODE.md",
+        "ROVODEV.md",
     ):
         text = resource_dir.joinpath(filename).read_text(encoding="utf-8")
         assert text.strip()
+
+
+def test_rovodev_global_setup_writes_dedicated_skill_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Rovo Dev install should write a dedicated SKILL.md under ~/.rovodev."""
+    (tmp_path / ".rovodev").mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    setup_cmd_mod.cmd_setup(_setup_args(interface="rovodev"))
+
+    target = tmp_path / ".rovodev" / "skills" / "desloppify" / "SKILL.md"
+    assert target.is_file()
+    content = target.read_text(encoding="utf-8")
+    assert "desloppify-skill-version" in content
+    assert "<!-- desloppify-overlay: rovodev -->" in content
+
+
+def test_setup_parser_accepts_rovodev_choice() -> None:
+    parser = create_parser()
+    args = parser.parse_args(["setup", "--interface", "rovodev"])
+    assert args.interface == "rovodev"

--- a/desloppify/tests/commands/test_transitive_modules_update_skill.py
+++ b/desloppify/tests/commands/test_transitive_modules_update_skill.py
@@ -113,6 +113,30 @@ class TestResolveInterface:
         result = resolve_interface(None, install=install)
         assert result == "opencode"
 
+    def test_from_install_path_match_rovodev(self):
+        from desloppify.app.skill_docs import SkillInstall
+
+        install = SkillInstall(
+            rel_path=".rovodev/skills/desloppify/SKILL.md",
+            version=1,
+            overlay=None,
+            stale=False,
+        )
+        result = resolve_interface(None, install=install)
+        assert result == "rovodev"
+
+    def test_from_install_overlay_rovodev(self):
+        from desloppify.app.skill_docs import SkillInstall
+
+        install = SkillInstall(
+            rel_path=".rovodev/skills/desloppify/SKILL.md",
+            version=1,
+            overlay="rovodev",
+            stale=False,
+        )
+        result = resolve_interface(None, install=install)
+        assert result == "rovodev"
+
     def test_from_install_no_match(self):
         from desloppify.app.skill_docs import SkillInstall
         install = SkillInstall(
@@ -188,6 +212,33 @@ class TestUpdateInstalledSkill:
         assert result is True
         written = (tmp_path / ".claude" / "skills" / "desloppify" / "SKILL.md").read_text()
         assert "desloppify-skill-version" in written
+        out = capsys.readouterr().out
+        assert "Updated" in out
+
+    @patch("desloppify.app.commands.update_skill.colorize", side_effect=lambda t, _c: t)
+    @patch("desloppify.app.commands.update_skill._download")
+    def test_successful_dedicated_install_rovodev(
+        self, mock_download, _mock_colorize, capsys, tmp_path
+    ):
+        """Per-project `update-skill rovodev` writes the dedicated `.rovodev/...` file."""
+        skill_content = "# Skill\n<!-- desloppify-skill-version: 1 -->\nContent"
+        mock_download.side_effect = lambda f: {
+            "SKILL.md": skill_content,
+            "ROVODEV.md": "rovodev overlay",
+        }[f]
+
+        with patch(
+            "desloppify.app.commands.update_skill.get_project_root",
+            return_value=tmp_path,
+        ):
+            result = update_installed_skill("rovodev")
+
+        assert result is True
+        target = tmp_path / ".rovodev" / "skills" / "desloppify" / "SKILL.md"
+        assert target.is_file()
+        written = target.read_text()
+        assert "desloppify-skill-version" in written
+        assert "rovodev overlay" in written
         out = capsys.readouterr().out
         assert "Updated" in out
 

--- a/docs/ROVODEV.md
+++ b/docs/ROVODEV.md
@@ -1,0 +1,147 @@
+## Rovo Dev Overlay
+
+Desloppify is installed as a Rovo Dev skill at `.rovodev/skills/desloppify/SKILL.md`. Rovo Dev discovers skills in both the user-level (`~/.rovodev/skills/`) and project-level (`.rovodev/skills/`) directories, and lazy-loads the skill body into context via the built-in `get_skill` tool when desloppify is invoked.
+
+### Subagents
+
+Rovo Dev supports parallel subagents via the `invoke_subagents` tool. The `General Purpose` subagent inherits all of the parent's tools and is ideal for context-isolated subjective review batches and per-stage triage work. Concurrency caps for `invoke_subagents` are set by Rovo Dev itself and may evolve over time — see the manual fallback section below for the current per-call limit.
+
+### Review workflow
+
+#### Native batch runner (recommended)
+
+Use the first-class `--runner rovodev` for automated batch reviews:
+
+```bash
+desloppify review --run-batches --runner rovodev --parallel --scan-after-import
+# Each batch is its own `acli rovodev` subprocess, so concurrency is bounded
+# by `--max-parallel-batches` (default 3), NOT by Rovo Dev's in-process
+# subagent limit. Bump it for faster wall-clock review on large packets:
+#   --max-parallel-batches 6
+```
+
+This spawns `acli rovodev` subprocesses (one per batch), recovers the JSON payload from each agent's reply (or from the agent-written output file), merges them, and imports as trusted assessments — same end-to-end shape as the Codex / OpenCode runners (subprocess-per-batch → file-output → merge → trusted import), with the wire-level details adapted to `acli rovodev`'s prompt-instructed output mode.
+
+Optional environment overrides:
+
+- `DESLOPPIFY_ROVODEV_NO_YOLO=1` opts out of `--yolo` (the default). With `--yolo` enabled the agent can write the per-batch output file in non-interactive mode without permission prompts; turn it off only for interactive review work.
+- `DESLOPPIFY_ROVODEV_OUTPUT_SCHEMA='<schema or path>'` is forwarded as `--output-schema`, constraining the agent's reply to a JSON shape.
+- `DESLOPPIFY_ROVODEV_EXTRA_ARGS="--config-override '{...}'"` is shell-split and appended verbatim before the prompt (useful for `--config-override`, `--restore`, `--worktree`, etc.).
+- `DESLOPPIFY_ROVODEV_EXECUTABLE=acli` overrides the binary name (useful when `acli` is shipped under a different name in CI).
+
+#### Manual subagent path
+
+If you prefer to drive batches from inside an existing Rovo Dev session, use the manual subagent flow:
+
+1. Prepare review prompts and the blind packet:
+   ```bash
+   desloppify review --run-batches --dry-run
+   ```
+   This generates one prompt file per batch in
+   `.desloppify/subagents/runs/<run-id>/prompts/` and prints the run directory.
+
+2. Note the run id printed by step 1 (e.g. `20260509_122030`). Replace
+   `<run-id>` in the paths below with that real value before invoking —
+   subagents do not share the parent's context, so passing the
+   placeholder verbatim will leave them unable to find the prompt or
+   know where to write their output.
+
+3. Launch Rovo Dev subagents in groups (Rovo Dev currently caps
+   `invoke_subagents` at 4 per call) using `invoke_subagents`,
+   passing one task per batch. Each subagent should:
+   - read its prompt file at
+     `.desloppify/subagents/runs/<run-id>/prompts/batch-N.md`
+   - read `.desloppify/review_packet_blind.json`
+   - inspect the repository as instructed by the prompt's dimension list
+   - write ONLY valid JSON to
+     `.desloppify/subagents/runs/<run-id>/results/batch-N.raw.txt`
+
+   Example invocation (with `<run-id>` already substituted):
+   ```
+   invoke_subagents(
+     subagent_names=["General Purpose", "General Purpose", "General Purpose"],
+     task_names=["review-batch-1", "review-batch-2", "review-batch-3"],
+     task_descriptions=[
+       "Review batch 1. Read .desloppify/subagents/runs/20260509_122030/prompts/batch-1.md, follow it exactly, inspect the repository, and write ONLY valid JSON to .desloppify/subagents/runs/20260509_122030/results/batch-1.raw.txt. Do not edit repository source files.",
+       "Review batch 2. ...",
+       "Review batch 3. ..."
+     ],
+   )
+   ```
+
+   Repeat the call in groups respecting Rovo Dev's per-call cap (e.g.
+   batches 1-4, then 5-8, ...). Wait for each group to finish before
+   launching the next.
+
+4. After every prompt for the run has a matching result file, import them
+   (using the same real run id):
+   ```bash
+   desloppify review --import-run .desloppify/subagents/runs/<run-id> --scan-after-import
+   ```
+
+### Key constraints
+
+- `invoke_subagents` only applies to the manual fallback path; it does NOT
+  cap the native `--runner rovodev` pipeline (each batch is its own
+  subprocess, throttled by `--max-parallel-batches`).
+- Per-call `invoke_subagents` concurrency is bounded by Rovo Dev itself
+  (currently up to 4 subagents per call). Check `/help invoke_subagents`
+  if you suspect the limit has changed.
+- Subagents do not inherit parent conversation context — the prompt file and
+  the blind packet must contain everything they need.
+- Subagents must consume `.desloppify/review_packet_blind.json` (not full
+  `query.json`) to avoid score anchoring.
+- The importer expects `results/batch-N.raw.txt` files, not `.json` filenames.
+- The blind packet intentionally omits score history to prevent anchoring bias.
+
+### Triage workflow
+
+#### Native triage runner (recommended)
+
+Use the first-class `--runner rovodev` to drive the full staged triage
+pipeline (strategize → observe → reflect → organize → enrich → sense-check
+→ commit) via `acli rovodev` subprocesses:
+
+```bash
+desloppify plan triage --run-stages --runner rovodev
+```
+
+Useful flags:
+
+- `--only-stages observe,reflect` runs a subset of stages.
+- `--dry-run` prints prompts only.
+- `--stage-timeout-seconds N` overrides the per-stage timeout.
+
+Each stage's prompt, output, log, and run summary land under
+`.desloppify/triage_runs/<timestamp>/`; rerunning resumes from the last
+confirmed stage. The `runner` field in `run_summary.json` is set to
+`"rovodev"` for provenance.
+
+The same `DESLOPPIFY_ROVODEV_*` environment overrides documented for the
+review runner above (`DESLOPPIFY_ROVODEV_NO_YOLO`,
+`DESLOPPIFY_ROVODEV_OUTPUT_SCHEMA`, `DESLOPPIFY_ROVODEV_EXTRA_ARGS`,
+`DESLOPPIFY_ROVODEV_EXECUTABLE`) apply to triage stages too.
+
+#### Manual stage-prompt path
+
+If you prefer to drive triage from inside an existing Rovo Dev session,
+run each stage by hand:
+
+1. Get the stage prompt: `desloppify plan triage --stage-prompt <stage>`
+2. If the stage benefits from parallel review work, fan it out with
+   `invoke_subagents` (in groups respecting Rovo Dev's per-call cap);
+   otherwise run the stage directly in the parent session.
+3. Confirm the stage: `desloppify plan triage --confirm <stage> --attestation "..."`
+4. Complete: `desloppify plan triage --complete --strategy "..." --attestation "..."`
+
+### Atlassian context
+
+Rovo Dev ships with first-class Atlassian (Jira / Confluence / Bitbucket)
+tooling. When triaging or planning desloppify work, you can pull related
+Jira issues, design docs, or PR history via the built-in Atlassian MCP
+toolset, or load the `full-context-mode` skill via the `/full-context`
+slash command for guided organisational research — no extra setup
+required.
+
+<!-- desloppify-overlay: rovodev -->
+<!-- desloppify-end -->

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -8,7 +8,7 @@ description: >
 ---
 
 <!-- desloppify-begin -->
-<!-- desloppify-skill-version: 6 -->
+<!-- desloppify-skill-version: 7 -->
 
 # Desloppify
 
@@ -58,7 +58,7 @@ desloppify plan triage --stage organize --report "summary of priorities..."
 desloppify plan triage --complete --strategy "execution plan..."
 ```
 
-For automated triage: `desloppify plan triage --run-stages --runner codex` (Codex) or `--runner claude` (Claude). Options: `--only-stages`, `--dry-run`, `--stage-timeout-seconds`.
+For automated triage: `desloppify plan triage --run-stages --runner codex` (Codex), `--runner claude` (Claude), or `--runner rovodev` (Rovo Dev). Options: `--only-stages`, `--dry-run`, `--stage-timeout-seconds`.
 
 Then shape the queue. **The plan shapes everything `next` gives you** — `next` is the execution queue, not the full backlog. Don't skip this step.
 
@@ -129,6 +129,7 @@ Four paths to get subjective scores:
 
 - **Local runner (Codex)**: `desloppify review --run-batches --runner codex --parallel --scan-after-import` — automated end-to-end.
 - **Local runner (Claude)**: `desloppify review --prepare` → launch parallel subagents → `desloppify review --import merged.json` — see skill doc overlay for details.
+- **Local runner (Rovo Dev)**: `desloppify review --run-batches --runner rovodev --parallel --scan-after-import` — automated end-to-end via `acli rovodev` subprocesses.
 - **Cloud/external**: `desloppify review --external-start --external-runner claude` → follow session template → `--external-submit`.
 - **Manual path**: `desloppify review --prepare` → review per dimension → `desloppify review --import file.json`.
 


### PR DESCRIPTION
## Add support for Rovo Dev

Adds [Rovo Dev](https://www.atlassian.com/software/rovo-dev) (Atlassian's AI coding agent, run via `acli rovodev`) as a first-class harness target alongside Claude, Codex, OpenCode, etc.

### What's included

- **Skill installation** — `desloppify setup --interface rovodev` and `desloppify update-skill rovodev` install the desloppify skill into `~/.rovodev/skills/desloppify/SKILL.md` (and per-project `.rovodev/skills/desloppify/SKILL.md`), with a Rovo-specific overlay covering its parallel subagents, `/skills`, `/full-context`, `AGENTS.md` memory, and Atlassian integrations.
- **Native batch runner** — `desloppify review --run-batches --runner rovodev` spawns `acli rovodev --yolo "<prompt>"` subprocesses per batch, mirroring the codex/opencode runners.
- **Native triage runner** — `desloppify plan triage --run-stages --runner rovodev` drives multi-stage triage through the existing pipeline by injecting a Rovo-Dev stage executor (codex pipeline gains two override hooks; codex behaviour unchanged when no override is set).
- **User-facing surfaces updated** — scan workflow guide, holistic prepare hint, triage dashboard, guardrails, and plan-sync hint now mention `--runner rovodev` alongside the existing options.

### Verification

- Full test suite passes (modulo pre-existing unrelated failures), with **64 new tests** covering the runner, dispatch, parser choices, scope validation, command construction, missing-binary detection, payload extraction, env propagation, and the per-project skill install path.
- **End-to-end live tested** in this repo:
  - `desloppify review --run-batches --runner rovodev --only-batches 1`: real `acli rovodev` subprocess, exit 0, valid JSON payload imported (and surfaced two genuine architectural findings).
  - `desloppify plan triage --run-stages --runner rovodev --stages strategize`: stage completed in 89s, recorded as `runner: rovodev` in the run summary.
- **Tested end-to-end against a real, separate project** with Rovo Dev driving the full `scan` → `next` → `resolve` loop using the installed skill — Rovo successfully picked up the desloppify skill, executed scans, and worked through the queue without intervention.

### Notes

- No changes to behaviour for any existing runner.
- Two small generic seams added to `orchestrator_codex_pipeline.py` (`_STAGE_RUNNER_OVERRIDE`, `_RUNNER_NAME_OVERRIDE`); both default to the existing codex behaviour.
- Bundled docs (`desloppify/data/global/ROVODEV.md`) and downloadable docs (`docs/ROVODEV.md`) are kept in sync via the existing `make verify-bundled-docs` check.
