### PR TITLE
fix: cap incompatible tree-sitter language pack

### DIFF
--- a/desloppify/tests/core/test_pyproject_optional_dependencies.py
+++ b/desloppify/tests/core/test_pyproject_optional_dependencies.py
@@ -49,3 +49,17 @@ def test_treesitter_extra_declares_runtime_and_language_pack() -> None:
     package_names = _package_names(treesitter_specs)
     assert "tree-sitter" in package_names
     assert "tree-sitter-language-pack" in package_names
+
+
+def test_treesitter_language_pack_is_capped_below_incompatible_release() -> None:
+    optional = _optional_dependencies()
+    treesitter_specs = optional.get("treesitter")
+    assert isinstance(treesitter_specs, list), "optional extra 'treesitter' must be a list"
+
+    language_pack_specs = [
+        str(spec)
+        for spec in treesitter_specs
+        if str(spec).startswith("tree-sitter-language-pack")
+    ]
+
+    assert language_pack_specs == ["tree-sitter-language-pack>=0.3,<1.8"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Issues = "https://github.com/peteromallet/desloppify/issues"
 [project.optional-dependencies]
 treesitter = [
   "tree-sitter>=0.21",
-  "tree-sitter-language-pack>=0.3",
+  "tree-sitter-language-pack>=0.3,<1.8",
 ]
 csharp-xml = ["defusedxml>=0.7.0"]
 python-security = ["bandit>=1.7.8"]
@@ -45,7 +45,7 @@ plan-yaml = ["PyYAML>=6.0"]
 full = [
   "defusedxml>=0.7.0",
   "tree-sitter>=0.21",
-  "tree-sitter-language-pack>=0.3",
+  "tree-sitter-language-pack>=0.3,<1.8",
   "bandit>=1.7.8",
   "Pillow>=9.0.0",
   "PyYAML>=6.0",


### PR DESCRIPTION
## Problem
Running the latest GitHub install against a TypeScript project can crash in the tree-sitter cohesion phase when pip resolves `tree-sitter-language-pack` 1.8.0. The crash is `TypeError: __new__() argument 1 must be tree_sitter.Language, not builtins.Language`.

## Fix
Cap `tree-sitter-language-pack` below 1.8 in the `treesitter` and `full` extras, and add a packaging regression test for the cap. I verified that 1.6.2 returns `tree_sitter.Language` objects and that the TypeScript scan completes.

## Verification
- `python -m pytest desloppify/tests/core/test_pyproject_optional_dependencies.py -q` passes.
- `python -m desloppify --lang typescript scan --path /Users/gerarddownes/.codex/worktrees/f8b1/workorderguard/infra/core --state /tmp/desloppify-fix-verify-state.json --no-badge` completes without the crash.
- `python -m pytest desloppify/tests/ -q` has one unrelated existing failure: `test_no_extra_bundled_files` reports bundled `scoring.md` has no matching `docs/scoring.md`.