### PR TITLE
fix: resolve absolute Python imports under src/ layout

### DIFF
--- a/desloppify/languages/python/detectors/deps_resolution.py
+++ b/desloppify/languages/python/detectors/deps_resolution.py
@@ -107,19 +107,45 @@ def resolve_relative_import(module_path: str, source_dir: Path) -> str | None:
 
 
 def resolve_absolute_import(module_path: str, scan_root: Path) -> str | None:
-    """Resolve an absolute import within scan root first, then project root."""
-    parts = module_path.split(".")
-    target_base = scan_root.resolve()
-    for part in parts:
-        target_base = target_base / part
-    resolved = try_resolve_path(target_base)
-    if resolved:
-        return resolved
+    """Resolve an absolute import within scan root first, then project root.
 
-    target_base = get_project_root()
-    for part in parts:
-        target_base = target_base / part
-    return try_resolve_path(target_base)
+    Probes four candidate roots in order, supporting both flat layouts and
+    the common ``src/``-layout (PEP 621 / Hatchling / setuptools) where the
+    actual package lives at ``<project>/src/<pkg>/...``:
+
+    1. ``<scan_root>/<dotted/path>``
+    2. ``<project_root>/<dotted/path>``
+    3. ``<scan_root>/src/<dotted/path>``
+    4. ``<project_root>/src/<dotted/path>``
+
+    The ``src/`` probes catch the case where ``desloppify scan --path .``
+    runs at the project root but the imported package only exists under
+    ``src/``. Without them every file beneath ``src/<pkg>/`` looks unimported
+    and the orphan-file detector emits false positives.
+    """
+    parts = module_path.split(".")
+    project_root = get_project_root()
+    scan_root_resolved = scan_root.resolve()
+
+    candidate_roots: list[Path] = [scan_root_resolved, project_root]
+    src_scan_root = scan_root_resolved / "src"
+    src_project_root = project_root / "src"
+    # Only add the src-prefixed candidates when those directories actually
+    # exist. This keeps behavior unchanged for flat-layout projects while
+    # adding the resolution path needed for src-layout projects.
+    if src_scan_root.is_dir() and src_scan_root not in candidate_roots:
+        candidate_roots.append(src_scan_root)
+    if src_project_root.is_dir() and src_project_root not in candidate_roots:
+        candidate_roots.append(src_project_root)
+
+    for root in candidate_roots:
+        target_base = root
+        for part in parts:
+            target_base = target_base / part
+        resolved = try_resolve_path(target_base)
+        if resolved:
+            return resolved
+    return None
 
 
 def try_resolve_path(target_base: Path) -> str | None:

--- a/desloppify/languages/python/tests/test_py_deps_src_layout.py
+++ b/desloppify/languages/python/tests/test_py_deps_src_layout.py
@@ -1,0 +1,140 @@
+"""Tests for src-layout absolute-import resolution in the Python deps detector.
+
+Covers the case where a project uses the ``src/`` layout (sources under
+``<project_root>/src/<pkg>/...``) and is scanned with ``--path .`` so the
+scan root is the project root itself, not ``src/``. Without the src-prefix
+fallback in :func:`resolve_absolute_import`, every file under ``src/<pkg>/``
+would appear unimported and the orphan-file detector would emit false
+positives for entire production packages.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from desloppify.languages.python.detectors.deps import build_dep_graph
+from desloppify.languages.python.detectors.deps_resolution import (
+    resolve_absolute_import,
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content))
+
+
+class TestResolveAbsoluteImportSrcLayout:
+    """Unit-level tests for the resolver helper itself."""
+
+    def test_resolves_module_under_src(self, tmp_path: Path, monkeypatch) -> None:
+        """``from pkg.mod import x`` should resolve to ``<root>/src/pkg/mod.py``."""
+        _write(tmp_path / "src" / "pkg" / "__init__.py", "")
+        _write(tmp_path / "src" / "pkg" / "mod.py", "VAL = 1\n")
+        monkeypatch.setenv("DESLOPPIFY_ROOT", str(tmp_path))
+
+        resolved = resolve_absolute_import("pkg.mod", tmp_path)
+        assert resolved is not None
+        assert resolved.endswith("src/pkg/mod.py")
+
+    def test_resolves_package_init_under_src(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """``from pkg import x`` should resolve to ``<root>/src/pkg/__init__.py``."""
+        _write(tmp_path / "src" / "pkg" / "__init__.py", "X = 1\n")
+        monkeypatch.setenv("DESLOPPIFY_ROOT", str(tmp_path))
+
+        resolved = resolve_absolute_import("pkg", tmp_path)
+        assert resolved is not None
+        assert resolved.endswith("src/pkg/__init__.py")
+
+    def test_resolves_nested_module_under_src(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Deeply nested ``from pkg.a.b.c import x`` should resolve."""
+        _write(tmp_path / "src" / "pkg" / "__init__.py", "")
+        _write(tmp_path / "src" / "pkg" / "a" / "__init__.py", "")
+        _write(tmp_path / "src" / "pkg" / "a" / "b" / "__init__.py", "")
+        _write(tmp_path / "src" / "pkg" / "a" / "b" / "c.py", "x = 1\n")
+        monkeypatch.setenv("DESLOPPIFY_ROOT", str(tmp_path))
+
+        resolved = resolve_absolute_import("pkg.a.b.c", tmp_path)
+        assert resolved is not None
+        assert resolved.endswith("src/pkg/a/b/c.py")
+
+    def test_flat_layout_still_resolves(self, tmp_path: Path, monkeypatch) -> None:
+        """Flat layout (no ``src/``) must keep working exactly as before."""
+        _write(tmp_path / "pkg" / "__init__.py", "")
+        _write(tmp_path / "pkg" / "mod.py", "X = 1\n")
+        monkeypatch.setenv("DESLOPPIFY_ROOT", str(tmp_path))
+
+        resolved = resolve_absolute_import("pkg.mod", tmp_path)
+        assert resolved is not None
+        assert resolved.endswith("pkg/mod.py")
+        # And it must NOT have been mis-routed through a non-existent src/.
+        assert "/src/" not in resolved
+
+    def test_unresolvable_returns_none(self, tmp_path: Path, monkeypatch) -> None:
+        """A missing module returns None even when ``src/`` exists."""
+        (tmp_path / "src").mkdir()
+        monkeypatch.setenv("DESLOPPIFY_ROOT", str(tmp_path))
+
+        assert resolve_absolute_import("nonexistent.module", tmp_path) is None
+
+    def test_flat_layout_preferred_over_src_when_both_exist(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """When both ``<root>/pkg`` and ``<root>/src/pkg`` exist, the flat one wins.
+
+        This preserves the original probe order: scan_root / project_root come
+        before the src-prefixed fallbacks.
+        """
+        _write(tmp_path / "pkg" / "__init__.py", "")
+        _write(tmp_path / "pkg" / "mod.py", "FLAT = 1\n")
+        _write(tmp_path / "src" / "pkg" / "__init__.py", "")
+        _write(tmp_path / "src" / "pkg" / "mod.py", "SRC = 1\n")
+        monkeypatch.setenv("DESLOPPIFY_ROOT", str(tmp_path))
+
+        resolved = resolve_absolute_import("pkg.mod", tmp_path)
+        assert resolved is not None
+        assert resolved.endswith("pkg/mod.py")
+        assert "/src/" not in resolved
+
+
+class TestBuildDepGraphSrcLayout:
+    """End-to-end: build_dep_graph counts importers across src-layout files."""
+
+    def test_importer_count_under_src_layout(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A module under ``src/pkg/`` imported via absolute path is tracked.
+
+        Reproduces the original bug: ``src/getaccept_worker/entities/activity.py``
+        was imported by 21 files but appeared as ``importer_count == 0`` because
+        the resolver never probed ``src/`` when the scan root was the project root.
+        """
+        _write(tmp_path / "src" / "pkg" / "__init__.py", "")
+        _write(tmp_path / "src" / "pkg" / "shared.py", "VAL = 1\n")
+        _write(
+            tmp_path / "src" / "pkg" / "a.py",
+            "from pkg.shared import VAL\n",
+        )
+        _write(
+            tmp_path / "src" / "pkg" / "b.py",
+            "from pkg.shared import VAL\n",
+        )
+        monkeypatch.setenv("DESLOPPIFY_ROOT", str(tmp_path))
+
+        # Scan root == project root (not src/) — this is the bug scenario.
+        graph = build_dep_graph(tmp_path)
+
+        shared_key = next(
+            (k for k in graph if k.endswith("src/pkg/shared.py")), None
+        )
+        assert shared_key is not None, (
+            f"shared.py not in graph; keys: {list(graph.keys())}"
+        )
+        assert graph[shared_key]["importer_count"] >= 2, (
+            f"Expected shared.py to have >= 2 importers, "
+            f"got {graph[shared_key]['importer_count']}"
+        )


### PR DESCRIPTION
## Problem

For a project using the standard PEP 621 `src/` layout — sources under
`<project_root>/src/<pkg>/...` — scanning with `desloppify scan --path .`
from the project root never resolves any of the project's own absolute
imports.

`resolve_absolute_import` in
`desloppify/languages/python/detectors/deps_resolution.py` currently
probes only:

1. `<scan_root>/<dotted/path>`
2. `<project_root>/<dotted/path>`

For a file like `src/getaccept_worker/entities/activity.py` imported as
`from getaccept_worker.entities.activity import Activity`, both candidates
miss (the file lives under `src/getaccept_worker/...`, not under the root
or scan root directly). The resolver returns `None`, so every file under
`src/<pkg>/` ends up with `importer_count == 0` and the orphan-file
detector emits false-positive findings for entire production packages.

### Repro

In a src-layout project (e.g. one with
`[tool.hatch.build.targets.wheel] packages = ["src/getaccept_worker", "tools"]`
in `pyproject.toml`):

```
src/getaccept_worker/entities/activity.py  # imported by 21 files
```

```
$ desloppify scan --path .
$ desloppify show orphaned --status open
# activity.py and friends flagged as orphans
```

Direct check on this project:

```python
from desloppify.languages.python.detectors.deps_resolution import resolve_absolute_import
from pathlib import Path
# old behavior:
resolve_absolute_import("getaccept_worker.entities.activity", Path("."))
# -> None  (bug)
```

## Fix

Extend `resolve_absolute_import` to additionally probe `src/`-prefixed
paths under both the scan root and project root. New probe order:

1. `<scan_root>/<dotted/path>`
2. `<project_root>/<dotted/path>`
3. `<scan_root>/src/<dotted/path>`      (only when `src/` exists)
4. `<project_root>/src/<dotted/path>`   (only when `src/` exists)

`src/` candidates are appended only when those directories actually exist,
so flat-layout behavior is identical. The existing `scan_root` /
`project_root` probes still run first, so flat layouts win when both
exist.

This is the conservative fix described as "the simple src-fallback" and
matches the layout declared by both Hatchling (`packages = ["src/<pkg>"]`)
and setuptools (`[tool.setuptools.packages.find] where = ["src"]`).
A follow-up could parse those declarations explicitly, but the simple
fallback is enough to fix the common case.

After the fix on the repro project, `activity.py` correctly reports
`importer_count == 21` and the false-positive orphan findings are gone.

## Tests

New file: `desloppify/languages/python/tests/test_py_deps_src_layout.py`

Covers:

- module resolution under `src/pkg/mod.py`
- package `__init__.py` resolution under `src/pkg/`
- deeply nested resolution under `src/pkg/a/b/c.py`
- flat layout still resolves (no spurious `/src/` in result)
- unresolvable modules still return `None`
- flat layout is preferred when both `<root>/pkg` and `<root>/src/pkg` exist
- `build_dep_graph` end-to-end: shared module under `src/pkg/` correctly
  records `importer_count >= 2` (the original bug scenario)

7 new tests; all 287 tests in `desloppify/languages/python/tests/` and
all 5810 tests in `desloppify/tests/` still pass.