### PR TITLE
fix: cap tree-sitter language pack compatibility

### DIFF
--- a/desloppify/tests/core/test_pyproject_optional_dependencies.py
+++ b/desloppify/tests/core/test_pyproject_optional_dependencies.py
@@ -62,4 +62,4 @@ def test_treesitter_language_pack_is_capped_below_incompatible_release() -> None
         if str(spec).startswith("tree-sitter-language-pack")
     ]
 
-    assert language_pack_specs == ["tree-sitter-language-pack>=0.3,<1.8"]
+    assert language_pack_specs == ["tree-sitter-language-pack>=0.3,<1.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Issues = "https://github.com/peteromallet/desloppify/issues"
 [project.optional-dependencies]
 treesitter = [
   "tree-sitter>=0.21",
-  "tree-sitter-language-pack>=0.3,<1.8",
+  "tree-sitter-language-pack>=0.3,<1.0",
 ]
 csharp-xml = ["defusedxml>=0.7.0"]
 python-security = ["bandit>=1.7.8"]
@@ -45,7 +45,7 @@ plan-yaml = ["PyYAML>=6.0"]
 full = [
   "defusedxml>=0.7.0",
   "tree-sitter>=0.21",
-  "tree-sitter-language-pack>=0.3,<1.8",
+  "tree-sitter-language-pack>=0.3,<1.0",
   "bandit>=1.7.8",
   "Pillow>=9.0.0",
   "PyYAML>=6.0",


### PR DESCRIPTION
## Problem

Running `desloppify scan` against a TypeScript project can crash during the Tree-sitter responsibility cohesion phase when `tree-sitter-language-pack` resolves to `1.8.x`:

```text
TypeError: __new__() argument 1 must be tree_sitter.Language, not builtins.Language
```

I hit this while scanning `/Users/gerarddownes/dev/codeaim/workorderguard/libs/web-components` with `desloppify 0.9.15`. `tree-sitter-language-pack 1.8.0` returns native `builtins.Language` / `builtins.Parser` objects, while the scanner code path still constructs `tree_sitter.Query` against `tree_sitter.Language` objects.

## Fix

Cap `tree-sitter-language-pack` below `1.0` for the `treesitter` and `full` extras. I verified `0.13.0` returns compatible `tree_sitter.Language` and `tree_sitter.Parser` objects and allows the scan to complete.

## Verification

- `/tmp/desloppify-fix/.venv/bin/python -m pytest desloppify/tests/core/test_pyproject_optional_dependencies.py -q`
- `/tmp/desloppify-fix/.venv/bin/python -m pytest desloppify/tests/ -q`
- `/tmp/desloppify-fix/.venv/bin/python -m desloppify --lang typescript scan --path /Users/gerarddownes/dev/codeaim/workorderguard/libs/web-components`