### PR TITLE
fix(go): support golangci-lint v2 json output

### DIFF
--- a/desloppify/languages/go/__init__.py
+++ b/desloppify/languages/go/__init__.py
@@ -19,6 +19,7 @@ from desloppify.languages._framework.registry.registration import register_full_
 from desloppify.languages._framework.registry.state import register_lang_hooks
 from desloppify.languages._framework.treesitter.phases import all_treesitter_phases
 from desloppify.languages.go import test_coverage as go_test_coverage_hooks
+from desloppify.languages.go._zones import GO_ZONE_RULES
 from desloppify.languages.go.commands import get_detect_commands
 from desloppify.languages.go.detectors.deps import build_dep_graph as build_go_dep_graph
 from desloppify.languages.go.extractors import (
@@ -36,8 +37,6 @@ from desloppify.languages.go.review import (
     api_surface,
     module_patterns,
 )
-
-from desloppify.languages.go._zones import GO_ZONE_RULES
 
 GO_ENTRY_PATTERNS = ["/main.go", "/cmd/"]
 
@@ -57,7 +56,7 @@ class GoConfig(LangConfig):
                 DetectorPhase("Structural analysis", phase_structural),
                 make_tool_phase(
                     "golangci-lint",
-                    "golangci-lint run --out-format=json",
+                    "golangci-lint run --output.json.path stdout --output.text.path '' --show-stats=false",
                     "golangci",
                     "golangci_lint",
                     tier=2,

--- a/desloppify/languages/go/tests/test_init.py
+++ b/desloppify/languages/go/tests/test_init.py
@@ -5,9 +5,15 @@ Go plugin originally contributed by tinker495 (PR #128).
 
 from __future__ import annotations
 
-from desloppify.engine.policy.zones import FileZoneMap, Zone
 from desloppify.engine.hook_registry import get_lang_hook
+from desloppify.engine.policy.zones import FileZoneMap, Zone
 from desloppify.languages import get_lang
+from desloppify.languages._framework.generic_parts import tool_factories
+
+
+class _ToolPhaseRuntime:
+    detector_coverage = {}
+    coverage_warnings = []
 
 
 def test_config_name():
@@ -37,6 +43,23 @@ def test_has_core_phases():
     assert "Security" in labels
     assert "golangci-lint" in labels
     assert "go vet" in labels
+
+
+def test_golangci_lint_phase_uses_v2_json_output_flags(tmp_path, monkeypatch):
+    cfg = get_lang("go")
+    phase = next(p for p in cfg.phases if p.label == "golangci-lint")
+    captured = {}
+
+    def fake_run_tool_result(cmd, run_path, parser):
+        captured["cmd"] = cmd
+        return tool_factories.ToolRunResult(status="empty", entries=[], meta={})
+
+    monkeypatch.setattr(tool_factories, "run_tool_result", fake_run_tool_result)
+
+    phase.run(tmp_path, _ToolPhaseRuntime())
+
+    assert "--out-format=json" not in captured["cmd"]
+    assert "--output.json.path stdout" in captured["cmd"]
 
 
 def test_integration_depth_full():


### PR DESCRIPTION
## Summary

- update the Go plugin golangci-lint command to use golangci-lint v2 JSON output flags
- keep text/stats output disabled so the existing JSON parser receives clean JSON only
- add a focused regression test for the registered Go golangci-lint phase command

## Verification

- `.venv/bin/python -m pytest -q desloppify/languages/go/tests/test_init.py -k golangci` failed before the fix with `--out-format=json` still present
- `.venv/bin/python -m pytest -q desloppify/languages/go/tests`
- `.venv/bin/python -m pytest -q desloppify/tests/lang/common/test_generic_plugin.py`
- `.venv/bin/python -m ruff check desloppify/languages/go/__init__.py desloppify/languages/go/tests/test_init.py`
- `.venv/bin/desloppify scan --path <temporary-go-module> --no-badge` with local golangci-lint v2.9.0
