### PR TITLE
chore(ci): unblock CI by gating bash tests on tree-sitter; sort review prompt glob

### DIFF
--- a/desloppify/tests/lang/common/test_bash_unused_imports.py
+++ b/desloppify/tests/lang/common/test_bash_unused_imports.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 import textwrap
 
+import pytest
+
+from desloppify.languages._framework.treesitter import is_available
+
+pytestmark = pytest.mark.skipif(
+    not is_available(), reason="tree-sitter-language-pack not installed"
+)
+
 
 def _detect(tmp_path, contents: str):
     from desloppify.languages._framework.treesitter.analysis.unused_imports import (

--- a/desloppify/tests/review/review_commands_cases.py
+++ b/desloppify/tests/review/review_commands_cases.py
@@ -873,7 +873,10 @@ class TestCmdReviewPrepare:
         assert len(packet_files) == 1
         blind_packet = tmp_path / ".desloppify" / "review_packet_blind.json"
         assert blind_packet.exists()
-        prompt_files = list(runs_dir.glob("*/prompts/batch-*.md"))
+        # Sort: prompt files are named batch-1.md, batch-2.md; glob order is
+        # filesystem-dependent (differs Linux vs macOS) and the assertions
+        # below assume batch-1 (high_level_elegance, with historical_focus) first.
+        prompt_files = sorted(runs_dir.glob("*/prompts/batch-*.md"))
         assert len(prompt_files) == 2
         prompt_text = prompt_files[0].read_text()
         assert "Blind packet:" in prompt_text


### PR DESCRIPTION
## Summary

CI has been red on `main` since **2026-04-06**, and on every PR opened since, because of **5 pre-existing test failures unrelated to any feature work**. Because they live on `main`, every PR inherits them and can't go green without bundling a workaround (see #614, #616). This standalone, test-only PR fixes the root cause so `main` gets a green baseline.

Two distinct root causes:

### 1. Bash tests assume tree-sitter is installed
`desloppify/tests/lang/common/test_bash_unused_imports.py` calls `detect_unused_imports`, which parses via tree-sitter. tree-sitter is an **optional** dependency (`[project.optional-dependencies]`), so the **`tests-core`** job (no extras) doesn't have it — there `detect_unused_imports` returns `[]` and the tests, asserting specific findings, fail. In **`tests-full`** (`pip install -e ".[full]"`) tree-sitter is present and the tests pass.

**Fix:** gate the file with the *exact* `skipif` pattern its sibling tree-sitter tests already use (`test_treesitter.py`, `test_treesitter_complexity_and_integration.py`):

```python
pytestmark = pytest.mark.skipif(
    not is_available(), reason="tree-sitter-language-pack not installed"
)
```

This is a **consistency fix** — the bash file was the only tree-sitter-dependent test file missing the guard. **Coverage is preserved**: with tree-sitter (`tests-full`) the tests run and assert real findings; without it (`tests-core`) they skip cleanly, because the feature genuinely cannot run there.

### 2. Review tests rely on filesystem-dependent glob order
`test_review_commands.py` (and its integration counterpart) use `list(runs_dir.glob("*/prompts/batch-*.md"))` **unsorted**. macOS happens to return `batch-1.md` first; Linux returns `batch-2.md` first. The assertion `"Previously flagged issues" in prompt_text` only holds for `batch-1.md`, so it fails on Linux.

**Fix:** `sorted(...)` the glob. Deterministic across OSes, removes a latent flake that only passed on macOS by luck, and the assertion still verifies exactly what it intends (batch-1's content).

## Why this is safe
- **Test-only.** No product/runtime behaviour changes.
- **No tests made meaningless.** Fix 1 preserves full bash coverage in `tests-full` and only skips where the optional feature is absent; the graceful-degradation path is itself covered by `test_treesitter.py::test_is_available_false_when_uninstalled`. Fix 2 strengthens (de-flakes) its test.

## Verification
Reproduced both CI environments locally:
- **tree-sitter present** (mirrors `tests-full`): the 3 bash tests **run and pass**, both review tests **pass**.
- **tree-sitter absent** (mirrors `tests-core`): the bash tests **skip** with reason `tree-sitter-language-pack not installed`; review fix is OS-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
