### PR TITLE
fix: use utf-8 encoding for typescript fixers on Windows

### DIFF
--- a/desloppify/languages/typescript/fixers/fixer_io.py
+++ b/desloppify/languages/typescript/fixers/fixer_io.py
@@ -65,7 +65,7 @@ def _process_fixer_file(
     dry_run: bool,
 ) -> dict[str, object] | None:
     path = Path(filepath) if Path(filepath).is_absolute() else get_project_root() / filepath
-    original = path.read_text()
+    original = path.read_text(encoding="utf-8")
     lines = original.splitlines(keepends=True)
 
     new_lines, removed_names = transform_fn(lines, file_entries)


### PR DESCRIPTION
On Windows, sys.getdefaultencoding() defaults to cp1252, causing character map decode errors when reading files that contain Unicode/emoji characters (such as FaceCameraScreen.tsx). This change explicitly specifies utf-8 encoding when reading the TypeScript files in the fixer pipeline.