### PR TITLE
fix: security (bandit) detector ignores config-level excludes

### DIFF
--- a/desloppify/languages/python/_security.py
+++ b/desloppify/languages/python/_security.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import shutil
 
 from desloppify.base.config import load_config
-from desloppify.base.discovery.source import collect_exclude_dirs
+from desloppify.base.discovery.source import collect_exclude_dirs, get_exclusions
 from desloppify.languages._framework.base.types import DetectorCoverageStatus, LangSecurityResult
 from desloppify.languages.python.detectors.bandit_adapter import detect_with_bandit
 from desloppify.languages.python._helpers import scan_root_from_files
@@ -49,7 +49,14 @@ def detect_python_security(files, zone_map) -> LangSecurityResult:
     if scan_root is None:
         return LangSecurityResult(entries=[], files_scanned=0)
 
-    exclude_dirs = collect_exclude_dirs(scan_root)
+    # Config-level excludes (`desloppify exclude <dir>`) are stored in the project
+    # config, not the runtime context that get_exclusions() reads here. Without
+    # loading them explicitly, bandit rescans excluded directories even though every
+    # other detector honours the exclude.
+    config_excludes = tuple(p for p in (load_config().get("exclude") or ()) if isinstance(p, str))
+    exclude_dirs = collect_exclude_dirs(
+        scan_root, extra_exclusions=tuple(get_exclusions()) + config_excludes
+    )
     skip_tests = _load_bandit_skip_tests()
     result = detect_with_bandit(
         scan_root, zone_map, exclude_dirs=exclude_dirs, skip_tests=skip_tests,

--- a/desloppify/tests/detectors/test_external_adapters_exclude_flags.py
+++ b/desloppify/tests/detectors/test_external_adapters_exclude_flags.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+from desloppify.languages.python._security import detect_python_security
 from desloppify.languages.python.detectors.ruff_smells import detect_with_ruff_smells
 from desloppify.languages.python.detectors.unused import detect_unused
 
@@ -104,3 +105,30 @@ class TestRuffUnusedExcludeFlag:
             detect_unused(tmp_path)
 
         assert "--exclude" not in captured_cmd
+
+
+class TestBanditSecurityExcludeFlag:
+    """Regression: config-level excludes (`desloppify exclude <dir>`) must reach
+    bandit's --exclude. Previously only the file-discovery detectors honoured them,
+    so the security detector kept reporting findings from excluded directories."""
+
+    def test_security_passes_config_excludes_to_bandit(self, tmp_path):
+        (tmp_path / "app.py").write_text("x = 1\n")
+        captured_cmd: list[str] = []
+
+        def _capture_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            mock_result = MagicMock()
+            mock_result.stdout = ""
+            mock_result.returncode = 0
+            return mock_result
+
+        with patch("subprocess.run", side_effect=_capture_run), patch(
+            "desloppify.languages.python._security.load_config",
+            return_value={"exclude": ["vendored_lib"]},
+        ):
+            detect_python_security([str(tmp_path / "app.py")], zone_map=None)
+
+        assert "--exclude" in captured_cmd
+        exclude_value = captured_cmd[captured_cmd.index("--exclude") + 1]
+        assert "vendored_lib" in exclude_value


### PR DESCRIPTION
## Problem

`desloppify exclude <dir>` is honoured by the file-discovery detectors (duplication, orphaned, unused, …) but **not by the Python security / bandit detector** — it keeps reporting findings from excluded directories (e.g. a vendored library you don't own).

Minimal repro:

```bash
mkdir -p proj/vendor
printf 'import subprocess\nsubprocess.Popen("x", shell=True)\n' > proj/vendor/bad.py
printf 'x = 1\n' > proj/app.py
cd proj
desloppify exclude vendor
desloppify scan --path .
desloppify show security --status open   # vendor/bad.py is STILL reported
```

## Root cause

`detect_python_security` (`languages/python/_security.py`) builds bandit's `--exclude` list from `collect_exclude_dirs(scan_root)`. That uses `get_exclusions(runtime=None)`, which resolves to a runtime context whose `.exclusions` is empty here — so only the built-in `DEFAULT_EXCLUSIONS` (`.git`, `node_modules`, …) reach bandit. The **persisted config excludes** (`config["exclude"]`, what `desloppify exclude` writes) are never threaded in, so `bandit -r` recursively rescans them.

The bandit adapter already supports `--exclude` correctly — the excludes simply never arrive.

## Fix

Load the config excludes in `detect_python_security` and pass them through `collect_exclude_dirs(extra_exclusions=…)` alongside `get_exclusions()`.

## Tests

There was no bandit exclude-flag test (only ruff ones), which is how this slipped through. Adds `TestBanditSecurityExcludeFlag` to `tests/detectors/test_external_adapters_exclude_flags.py`. Confirmed it **fails without** the fix (the exclude list contains only the defaults) and **passes with** it. Full `languages/python/` + `detectors/security/` suites: **379 passed**.

Environment where observed: Windows, Python 3.13, bandit 1.9.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
