### PR TITLE
fix: allow jscpd timeout override

### DIFF
--- a/desloppify/engine/detectors/jscpd_adapter.py
+++ b/desloppify/engine/detectors/jscpd_adapter.py
@@ -42,6 +42,24 @@ _BASE_IGNORES = (
 
 _ARTIFACT_PREFIXES = ("build/", "dist/", ".desloppify/", ".claude/")
 _BUILD_MIRROR_PREFIX = "build/lib/"
+_DEFAULT_JSCPD_TIMEOUT_SECONDS = 120
+
+
+def _jscpd_timeout_seconds(default: int = _DEFAULT_JSCPD_TIMEOUT_SECONDS) -> int:
+    """Return the jscpd timeout, allowing local long-scan overrides."""
+
+    raw_timeout = os.environ.get("DESLOPPIFY_JSCPD_TIMEOUT_SECONDS")
+    if raw_timeout is None:
+        return default
+    try:
+        timeout = int(raw_timeout)
+    except ValueError:
+        warn_best_effort(
+            "Ignoring invalid DESLOPPIFY_JSCPD_TIMEOUT_SECONDS value; "
+            f"expected integer seconds, got {raw_timeout!r}."
+        )
+        return default
+    return max(1, timeout)
 
 
 def _to_scan_relative(path_resolved: Path, name: str) -> str | None:
@@ -234,6 +252,7 @@ def detect_with_jscpd(path: Path) -> list[dict] | None:
         logger.debug("jscpd: neither jscpd nor npx found — skipping")
         return None
 
+    timeout_seconds = _jscpd_timeout_seconds()
     with tempfile.TemporaryDirectory() as tmpdir:
         try:
             _run_jscpd_command(
@@ -252,7 +271,7 @@ def detect_with_jscpd(path: Path) -> list[dict] | None:
                     _jscpd_ignore_arg(path),
                     "--silent",
                 ],
-                timeout=120,
+                timeout=timeout_seconds,
             )
         except FileNotFoundError:
             warn_best_effort(
@@ -279,7 +298,8 @@ def detect_with_jscpd(path: Path) -> list[dict] | None:
             return None
         except subprocess.TimeoutExpired:
             warn_best_effort(
-                "Boilerplate duplication detection skipped: jscpd timed out after 120s."
+                "Boilerplate duplication detection skipped: "
+                f"jscpd timed out after {timeout_seconds}s."
             )
             logger.debug("jscpd: timed out")
             return None

--- a/desloppify/tests/detectors/test_external_adapters.py
+++ b/desloppify/tests/detectors/test_external_adapters.py
@@ -531,11 +531,27 @@ class TestBanditExcludeIntegration:
 from desloppify.engine.detectors.jscpd_adapter import (  # noqa: E402
     _parse_jscpd_report,
     _run_jscpd_command,
+    _jscpd_timeout_seconds,
     detect_with_jscpd,
 )
 
 
 class TestJscpdAdapter:
+    def test_jscpd_timeout_defaults_to_120_seconds(self, monkeypatch):
+        monkeypatch.delenv("DESLOPPIFY_JSCPD_TIMEOUT_SECONDS", raising=False)
+
+        assert _jscpd_timeout_seconds() == 120
+
+    def test_jscpd_timeout_reads_environment_override(self, monkeypatch):
+        monkeypatch.setenv("DESLOPPIFY_JSCPD_TIMEOUT_SECONDS", "1800")
+
+        assert _jscpd_timeout_seconds() == 1800
+
+    def test_jscpd_timeout_ignores_invalid_environment_override(self, monkeypatch):
+        monkeypatch.setenv("DESLOPPIFY_JSCPD_TIMEOUT_SECONDS", "forever")
+
+        assert _jscpd_timeout_seconds() == 120
+
     def test_returns_none_when_jscpd_not_installed(self, tmp_path):
         with patch(
             "desloppify.engine.detectors.jscpd_adapter._resolve_jscpd_command",
@@ -552,6 +568,28 @@ class TestJscpdAdapter:
             side_effect=subprocess.TimeoutExpired("npx", 120),
         ):
             assert detect_with_jscpd(tmp_path) is None
+
+    def test_detect_uses_environment_timeout_override(self, tmp_path, monkeypatch):
+        report_file = tmp_path / "jscpd-report.json"
+        report_file.write_text(json.dumps({"duplicates": []}))
+        monkeypatch.setenv("DESLOPPIFY_JSCPD_TIMEOUT_SECONDS", "1800")
+
+        def _fake_run(_cmd, **kwargs):
+            assert kwargs["timeout"] == 1800
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch(
+            "desloppify.engine.detectors.jscpd_adapter._resolve_jscpd_command",
+            return_value=["/usr/bin/npx", "--yes", "jscpd"],
+        ), patch(
+            "desloppify.engine.detectors.jscpd_adapter._run_jscpd_command",
+            side_effect=_fake_run,
+        ), patch(
+            "tempfile.TemporaryDirectory"
+        ) as mock_td:
+            mock_td.return_value.__enter__.return_value = str(tmp_path)
+            mock_td.return_value.__exit__.return_value = None
+            assert detect_with_jscpd(tmp_path) == []
 
     def test_timeout_kills_jscpd_process_group(self):
         class FakeProc:


### PR DESCRIPTION
## Problem
Large repos can exceed the hardcoded 120-second timeout in the jscpd duplication adapter, causing boilerplate duplication detection to be skipped even when the detector is still actively making progress. In the Frequency Coordination monorepo, `desloppify scan --path .` repeatedly reported `jscpd timed out after 120s`; a local run with `DESLOPPIFY_JSCPD_TIMEOUT_SECONDS=1800` allowed the detector to continue beyond the old cap.

## Fix
Add `DESLOPPIFY_JSCPD_TIMEOUT_SECONDS` as an optional integer-second override while preserving the 120-second default. Invalid values fall back to the default with a best-effort warning, and timeout messages now include the effective timeout.

## Verification
- `python3 -m pytest desloppify/tests/detectors/test_external_adapters.py::TestJscpdAdapter -q`
- `python3 -m py_compile desloppify/engine/detectors/jscpd_adapter.py`