### PR TITLE
fix: parse multiline TypeScript function bodies

### DIFF
--- a/desloppify/languages/typescript/detectors/smells/detector_core.py
+++ b/desloppify/languages/typescript/detectors/smells/detector_core.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import re
 
+from desloppify.languages.typescript.syntax.scanner import scan_code
+
 from .helpers import (
     _code_text,
+    _find_block_end,
     _strip_ts_comments,
-    _track_brace_body,
 )
 
 _MONSTER_FUNCTION_LOC = 150
@@ -96,6 +98,24 @@ def _find_function_start(line: str, next_lines: list[str]) -> str | None:
     return None
 
 
+def _previous_code_char(content: str, pos: int) -> str:
+    cursor = pos - 1
+    while cursor >= 0:
+        if not content[cursor].isspace():
+            return content[cursor]
+        cursor -= 1
+    return ""
+
+
+def _next_code_char(content: str, pos: int) -> str:
+    cursor = pos + 1
+    while cursor < len(content):
+        if not content[cursor].isspace():
+            return content[cursor]
+        cursor += 1
+    return ""
+
+
 def _find_opening_brace_line(lines: list[str], start: int, *, window: int = 5) -> int | None:
     for idx in range(start, min(start + window, len(lines))):
         if "{" in lines[idx]:
@@ -103,22 +123,51 @@ def _find_opening_brace_line(lines: list[str], start: int, *, window: int = 5) -
     return None
 
 
+def _find_function_body_brace(content: str) -> int | None:
+    """Find the function body ``{``, ignoring braces in params/defaults/types."""
+    paren_depth = 0
+    saw_signature_close = False
+    for index, ch, in_string in scan_code(content):
+        if in_string:
+            continue
+        if ch == "(":
+            paren_depth += 1
+            continue
+        if ch == ")":
+            paren_depth = max(0, paren_depth - 1)
+            if paren_depth == 0:
+                saw_signature_close = True
+            continue
+        if ch != "{" or paren_depth != 0 or not saw_signature_close:
+            continue
+        # ``function f(): { value: string } {`` has a return-type literal
+        # before the real body. Keep scanning until the body brace.
+        if _previous_code_char(content, index) == ":":
+            continue
+        # ``function f(): Promise<{ value: string }> {`` nests a type literal
+        # inside the return type. Its closing brace is followed by type syntax,
+        # not by the next top-level declaration/expression.
+        end = _find_block_end(content, index)
+        if end is None:
+            continue
+        if _next_code_char(content, end) in {"{", ">", "|", "&", ","}:
+            continue
+        return index
+    return None
+
+
 def _extract_function_body(
     lines: list[str], start_line: int, *, max_scan: int = 2000,
 ) -> str | None:
     """Extract the inner body text of a function starting at start_line."""
-    brace_line = _find_opening_brace_line(lines, start_line, window=5)
-    if brace_line is None:
+    content = "\n".join(lines[start_line : min(start_line + max_scan, len(lines))])
+    body_start = _find_function_body_brace(content)
+    if body_start is None:
         return None
-    end_line = _track_brace_body(lines, brace_line, max_scan=max_scan)
-    if end_line is None:
+    body_end = _find_block_end(content, body_start, max_scan=max_scan)
+    if body_end is None or body_start >= body_end:
         return None
-    body_text = "\n".join(lines[brace_line : end_line + 1])
-    first_brace = body_text.find("{")
-    last_brace = body_text.rfind("}")
-    if first_brace == -1 or last_brace == -1 or first_brace >= last_brace:
-        return None
-    return body_text[first_brace + 1 : last_brace]
+    return content[body_start + 1 : body_end]
 
 
 def _count_pattern_in_body(body: str, pattern: re.Pattern[str]) -> int:

--- a/desloppify/languages/typescript/tests/smells/test_ts_smell_helpers.py
+++ b/desloppify/languages/typescript/tests/smells/test_ts_smell_helpers.py
@@ -1,5 +1,6 @@
 """Tests for desloppify.languages.typescript.detectors.smells.helpers."""
 
+from desloppify.languages.typescript.detectors.smells import TS_SMELL_CHECKS
 from desloppify.languages.typescript.detectors.smells.detector_core import (
     _find_function_start,
 )
@@ -25,7 +26,6 @@ from desloppify.languages.typescript.detectors.smells.helpers import (
     _track_brace_body,
     _ts_match_is_in_string,
 )
-from desloppify.languages.typescript.detectors.smells import TS_SMELL_CHECKS
 
 
 def _ctx(content: str, filepath: str = "test.ts") -> _FileContext:
@@ -325,6 +325,38 @@ class TestDetectAsyncNoAwait:
 
     def test_skips_async_with_await(self):
         content = "async function fetchData() {\n  const d = await fetch('/');\n  return d;\n}\n"
+        counts = _make_counts()
+        _detect_async_no_await(_ctx(content), counts)
+        assert len(counts["async_no_await"]) == 0
+
+    def test_skips_multiline_async_with_default_object_and_await(self):
+        content = (
+            "export async function runOperation(\n"
+            "  operationId: string,\n"
+            "  input: Record<string, unknown>,\n"
+            "  opts: RunOpts = {},\n"
+            "): Promise<Envelope> {\n"
+            "  const registry = await loadRegistry();\n"
+            "  return registry.get(operationId);\n"
+            "}\n"
+        )
+        counts = _make_counts()
+        _detect_async_no_await(_ctx(content), counts)
+        assert len(counts["async_no_await"]) == 0
+
+    def test_skips_multiline_async_destructured_param_with_await(self):
+        content = (
+            "async function runSinglePage(\n"
+            "  {\n"
+            "    cmd,\n"
+            "    warnings = [],\n"
+            "  }: ExecutableOperationRun,\n"
+            "  makeRequest: RequestFactory,\n"
+            "): Promise<{ env: Envelope }> {\n"
+            "  const req = await makeRequest(cmd);\n"
+            "  return { env: req };\n"
+            "}\n"
+        )
         counts = _make_counts()
         _detect_async_no_await(_ctx(content), counts)
         assert len(counts["async_no_await"]) == 0


### PR DESCRIPTION
## Problem
The TypeScript `async_no_await` smell detector can report false positives for multiline async functions whose signatures contain braces before the function body, such as:

- default object parameters (`opts = {}`)
- destructured parameters
- return type object literals inside generics (`Promise<{ ... }>`)

The previous body extractor picked the first `{` within the signature window, so it inspected an empty/default/destructuring/type block instead of the real function body and missed real `await` expressions.

## Fix
- Find the actual function body brace while ignoring braces inside parameter lists and return-type syntax.
- Reuse the existing block-end scanner once the body brace is found.
- Add regressions for multiline exported async signatures and destructured parameters with `Promise<{ ... }>` return types.

## Verification
- `uvx pytest desloppify/languages/typescript/tests/smells/test_ts_smell_helpers.py::TestDetectAsyncNoAwait desloppify/languages/typescript/tests/test_ts_smells.py::test_detect_async_no_await desloppify/languages/typescript/tests/test_ts_smells.py::test_async_with_await_not_flagged -q` — passed
- `uvx pytest desloppify/languages/typescript/tests -q` — passed, 428 tests
- `uvx ruff check desloppify/languages/typescript/detectors/smells/detector_core.py desloppify/languages/typescript/tests/smells/test_ts_smell_helpers.py` — passed
- Verified against `/Users/treygoff/Code/elevenlabs-cli` with `PYTHONPATH=/tmp/desloppify-fix ... python -m desloppify scan --path .`; false async/no-await findings dropped and objective score improved.

Note: `uvx pytest desloppify/tests/ -q` currently has 3 unrelated failures in `desloppify/tests/lang/common/test_bash_unused_imports.py` (bash source/dot-source unused import expectations returned no findings). These are unrelated to this TypeScript detector change.