### PR TITLE
fix: support golangci-lint v2 JSON output

### DIFF
--- a/desloppify/languages/go/__init__.py
+++ b/desloppify/languages/go/__init__.py
@@ -19,6 +19,7 @@ from desloppify.languages._framework.registry.registration import register_full_
 from desloppify.languages._framework.registry.state import register_lang_hooks
 from desloppify.languages._framework.treesitter.phases import all_treesitter_phases
 from desloppify.languages.go import test_coverage as go_test_coverage_hooks
+from desloppify.languages.go._zones import GO_ZONE_RULES
 from desloppify.languages.go.commands import get_detect_commands
 from desloppify.languages.go.detectors.deps import build_dep_graph as build_go_dep_graph
 from desloppify.languages.go.extractors import (
@@ -37,9 +38,8 @@ from desloppify.languages.go.review import (
     module_patterns,
 )
 
-from desloppify.languages.go._zones import GO_ZONE_RULES
-
 GO_ENTRY_PATTERNS = ["/main.go", "/cmd/"]
+
 
 class GoConfig(LangConfig):
     """Go language configuration."""
@@ -57,14 +57,12 @@ class GoConfig(LangConfig):
                 DetectorPhase("Structural analysis", phase_structural),
                 make_tool_phase(
                     "golangci-lint",
-                    "golangci-lint run --out-format=json",
+                    "golangci-lint run --output.json.path stdout --show-stats=false",
                     "golangci",
                     "golangci_lint",
                     tier=2,
                 ),
-                make_tool_phase(
-                    "go vet", "go vet ./...", "gnu", "vet_error", tier=3
-                ),
+                make_tool_phase("go vet", "go vet ./...", "gnu", "vet_error", tier=3),
                 *all_treesitter_phases("go"),
                 detector_phase_signature(),
                 detector_phase_test_coverage(),
@@ -107,6 +105,7 @@ def register() -> None:
 def register_hooks() -> None:
     """Register Go hook modules without language-config bootstrap."""
     register_lang_hooks("go", test_coverage=go_test_coverage_hooks)
+
 
 Config = GoConfig
 

--- a/desloppify/languages/go/tests/test_init.py
+++ b/desloppify/languages/go/tests/test_init.py
@@ -5,9 +5,13 @@ Go plugin originally contributed by tinker495 (PR #128).
 
 from __future__ import annotations
 
-from desloppify.engine.policy.zones import FileZoneMap, Zone
+from pathlib import Path
+
 from desloppify.engine.hook_registry import get_lang_hook
+from desloppify.engine.policy.zones import FileZoneMap, Zone
 from desloppify.languages import get_lang
+from desloppify.languages._framework.generic_parts import tool_factories
+from desloppify.languages._framework.generic_parts.tool_runner import ToolRunResult
 
 
 def test_config_name():
@@ -37,6 +41,25 @@ def test_has_core_phases():
     assert "Security" in labels
     assert "golangci-lint" in labels
     assert "go vet" in labels
+
+
+def test_golangci_lint_uses_v2_json_output(monkeypatch, tmp_path: Path):
+    captured = {}
+
+    def fake_run_tool_result(cmd, path, parser):
+        captured["cmd"] = cmd
+        return ToolRunResult(entries=[], status="empty")
+
+    monkeypatch.setattr(tool_factories, "run_tool_result", fake_run_tool_result)
+    phase = next(
+        phase for phase in get_lang("go").phases if phase.label == "golangci-lint"
+    )
+
+    phase.run(tmp_path, object())
+
+    assert captured["cmd"] == (
+        "golangci-lint run --output.json.path stdout --show-stats=false"
+    )
 
 
 def test_integration_depth_full():


### PR DESCRIPTION
## Problem

The Go scanner still invokes `golangci-lint run --out-format=json`. golangci-lint v2 removed that flag, so every Go scan reports `golangci_lint tooling unavailable (parser_error)` and silently loses linter coverage.

## Fix

Use the v2 `--output.json.path stdout` flag and disable stats so the existing JSON parser receives only the structured report. Add a focused regression test that executes the configured Go phase and verifies the exact command.

## Validation

- Focused Go plugin suite: 12 passed
- Ruff check and format: passed
- Patched scanner against dsx-mcp test backend: completed without reduced golangci coverage
- Core suite: 5,649 passed and 153 skipped. Five pre-existing failures remain in Bash unused-import and review prompt tests, outside these files.