### PR TITLE
fix: map Python alias coverage to canonical modules

### DIFF
--- a/desloppify/engine/detectors/coverage/mapping_imports.py
+++ b/desloppify/engine/detectors/coverage/mapping_imports.py
@@ -8,7 +8,6 @@ from desloppify.engine.detectors.test_coverage.io import read_coverage_file
 from desloppify.engine.hook_registry import get_lang_hook
 
 
-
 def _load_lang_test_coverage_module(lang_name: str | None):
     """Load language-specific test coverage helpers from ``lang/<name>/test_coverage.py``."""
     return get_lang_hook(lang_name, "test_coverage") or object()
@@ -129,6 +128,7 @@ def _parse_test_imports(
         resolved = _resolve_import(spec, test_path, production_files, lang_name)
         if resolved:
             tested.add(resolved)
+            tested |= _resolve_barrel_reexports(resolved, production_files, lang_name)
             continue
 
         # Fallback: module-name lookup with progressively shorter prefixes.
@@ -137,7 +137,13 @@ def _parse_test_imports(
         for i in range(len(parts), 0, -1):
             candidate = ".".join(parts[:i])
             if candidate in prod_by_module:
-                tested.add(prod_by_module[candidate])
+                resolved = prod_by_module[candidate]
+                tested.add(resolved)
+                tested |= _resolve_barrel_reexports(
+                    resolved,
+                    production_files,
+                    lang_name,
+                )
                 break
 
     return tested

--- a/desloppify/languages/python/test_coverage.py
+++ b/desloppify/languages/python/test_coverage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+from pathlib import Path
 
 # Python: does the file contain any function definition?
 _PY_DEF_RE = re.compile(r"^\s*(?:async\s+)?def\s+", re.MULTILINE)
@@ -41,11 +42,56 @@ MOCK_PATTERNS = [
 SNAPSHOT_PATTERNS: list[re.Pattern[str]] = []
 TEST_FUNCTION_RE = re.compile(r"^\s*(?:async\s+)?def\s+(test_\w+)\s*\(", re.MULTILINE)
 
-# Python has no barrel-file expansion in coverage mapping.
-BARREL_BASENAMES: set[str] = set()
+# Python package __init__ files can explicitly re-export concrete submodules.
+BARREL_BASENAMES: set[str] = {"__init__.py"}
+
+PY_IMPORT_MODULE_RE = re.compile(
+    r"(?P<name>\w+)\s*=\s*import_module\(\s*['\"](?P<spec>[\w.]+)['\"]\s*\)"
+)
+PY_SYS_MODULES_ALIAS_RE = re.compile(
+    r"sys\.modules\[\s*__name__\s*\]\s*=\s*"
+    r"(?:import_module\(\s*['\"](?P<spec>[\w.]+)['\"]\s*\)|(?P<name>\w+))"
+)
+PY_LOCAL_IMPORT_RE = re.compile(
+    r"^\s*from\s+\.\s+import\s+(?P<names>[\w \t,]+)|"
+    r"^\s*from\s+\.(?P<module>[\w.]+)\s+import\s+(?:\*|\(?\s*[\w \t,]+)",
+    re.MULTILINE,
+)
 
 # Common source layout prefixes for src-layout projects (PEP 621).
 _SRC_PREFIXES = ("src/",)
+
+
+def _normalized_path(path: str) -> str:
+    return path.replace("\\", "/")
+
+
+def _match_production_candidate(candidate: str, production_files: set[str]) -> str | None:
+    normalized_candidate = _normalized_path(candidate).lstrip("/")
+    exact_matches = [
+        prod
+        for prod in production_files
+        if _normalized_path(prod).lstrip("/") == normalized_candidate
+    ]
+    if len(exact_matches) == 1:
+        return exact_matches[0]
+
+    suffix = f"/{normalized_candidate}"
+    suffix_matches = [
+        prod
+        for prod in production_files
+        if _normalized_path(prod).endswith(suffix)
+    ]
+    if len(suffix_matches) == 1:
+        return suffix_matches[0]
+    return None
+
+
+def _module_path_candidates(module_path: str) -> tuple[str, str]:
+    return (
+        f"{module_path}.py",
+        f"{module_path}/__init__.py",
+    )
 
 
 def has_testable_logic(filepath: str, content: str) -> bool:
@@ -62,28 +108,105 @@ def resolve_import_spec(
     if not module_path or module_path.startswith("/"):
         return None
 
-    candidates = (
-        f"{module_path}.py",
-        f"{module_path}/__init__.py",
-    )
+    candidates = _module_path_candidates(module_path)
     for candidate in candidates:
-        if candidate in production_files:
-            return candidate
+        matched = _match_production_candidate(candidate, production_files)
+        if matched:
+            return matched
         # Try src/-prefixed variants for src-layout projects
         for prefix in _SRC_PREFIXES:
             prefixed = f"{prefix}{candidate}"
-            if prefixed in production_files:
-                return prefixed
+            matched = _match_production_candidate(prefixed, production_files)
+            if matched:
+                return matched
         if test_path:
             sibling = os.path.join(os.path.dirname(test_path), candidate)
-            if sibling in production_files:
-                return sibling
+            matched = _match_production_candidate(sibling, production_files)
+            if matched:
+                return matched
     return None
 
 
-def resolve_barrel_reexports(_filepath: str, _production_files: set[str]) -> set[str]:
-    """Python has no barrel-file re-export expansion for coverage mapping."""
-    return set()
+def _identity_alias_targets(content: str) -> list[str]:
+    import_module_aliases = {
+        match.group("name"): match.group("spec")
+        for match in PY_IMPORT_MODULE_RE.finditer(content)
+    }
+
+    targets: list[str] = []
+    for match in PY_SYS_MODULES_ALIAS_RE.finditer(content):
+        spec = match.group("spec")
+        if spec:
+            targets.append(spec)
+            continue
+        alias_name = match.group("name")
+        if alias_name and alias_name in import_module_aliases:
+            targets.append(import_module_aliases[alias_name])
+    return targets
+
+
+def _local_module_path(filepath: str, imported_module: str) -> str:
+    base = Path(filepath).parent
+    for part in imported_module.split("."):
+        base /= part
+    return _normalized_path(str(base))
+
+
+def _local_import_targets(content: str, filepath: str) -> list[str]:
+    targets: list[str] = []
+    for match in PY_LOCAL_IMPORT_RE.finditer(content):
+        module_name = match.group("module")
+        if module_name:
+            targets.append(_local_module_path(filepath, module_name))
+            continue
+
+        raw_names = match.group("names") or ""
+        for raw_name in raw_names.split(","):
+            name = raw_name.strip()
+            if not name or not _looks_reexported(content, name):
+                continue
+            targets.append(_local_module_path(filepath, name))
+    return targets
+
+
+def _looks_reexported(content: str, name: str) -> bool:
+    return any(
+        pattern in content
+        for pattern in (
+            f"{name}.__dict__",
+            f"getattr({name},",
+            f"dir({name})",
+            f"{name}.__all__",
+        )
+    )
+
+
+def _resolve_local_target(target: str, production_files: set[str]) -> str | None:
+    for candidate in _module_path_candidates(target):
+        matched = _match_production_candidate(candidate, production_files)
+        if matched:
+            return matched
+    return None
+
+
+def resolve_barrel_reexports(filepath: str, production_files: set[str]) -> set[str]:
+    """Resolve explicit Python identity aliases and package re-export modules."""
+    try:
+        content = Path(filepath).read_text()
+    except (OSError, UnicodeDecodeError):
+        return set()
+
+    results: set[str] = set()
+    for spec in _identity_alias_targets(content):
+        resolved = resolve_import_spec(spec, filepath, production_files)
+        if resolved:
+            results.add(resolved)
+
+    for target in _local_import_targets(content, filepath):
+        resolved = _resolve_local_target(target, production_files)
+        if resolved:
+            results.add(resolved)
+    return results
 
 
 def parse_test_import_specs(content: str) -> list[str]:

--- a/desloppify/tests/detectors/coverage/test_test_coverage.py
+++ b/desloppify/tests/detectors/coverage/test_test_coverage.py
@@ -6,10 +6,12 @@ import math
 
 import pytest
 
+from desloppify.base.runtime_state import RuntimeContext, runtime_scope
 from desloppify.engine.detectors.coverage.mapping import (
     _map_test_to_source,
     _strip_test_markers,
     analyze_test_quality,
+    build_test_import_index,
     get_test_files_for_prod,
     import_based_mapping,
     transitive_coverage,
@@ -253,6 +255,106 @@ class TestImportBasedMapping:
         }
         result = import_based_mapping(graph, {test_file}, {prod_file}, "typescript")
         assert prod_file in result
+
+    def test_python_package_reexport_import_marks_canonical_module_directly_tested(
+        self,
+        tmp_path,
+    ):
+        package_init = _write_file(tmp_path, "pkg/geometry/__init__.py", (
+            "from __future__ import annotations\n"
+            "from . import geojson\n"
+            "for _name, _value in geojson.__dict__.items():\n"
+            "    if not _name.startswith('__'):\n"
+            "        globals()[_name] = _value\n"
+            "__all__ = ['geojson', 'point_in_geojson']\n"
+            "def __getattr__(name):\n"
+            "    return getattr(geojson, name)\n"
+        ))
+        canonical = _write_file(
+            tmp_path,
+            "pkg/geometry/geojson.py",
+            "def point_in_geojson(payload):\n    return bool(payload)\n",
+        )
+        test_file = _write_file(tmp_path, "tests/test_point_in_geojson.py", (
+            "from pkg import geometry\n\n"
+            "def test_point_in_geojson():\n"
+            "    assert geometry.point_in_geojson({'type': 'Point'}) is True\n"
+        ))
+        graph = {test_file: {"imports": set()}}
+        production_files = {package_init, canonical}
+
+        with runtime_scope(RuntimeContext(project_root=tmp_path)):
+            directly_tested = import_based_mapping(
+                graph,
+                {test_file},
+                production_files,
+                "python",
+            )
+            parsed_imports = build_test_import_index(
+                {test_file},
+                production_files,
+                "python",
+            )
+            related = get_test_files_for_prod(
+                canonical,
+                {test_file},
+                graph,
+                "python",
+                parsed_imports_by_test=parsed_imports,
+            )
+
+        assert package_init in directly_tested
+        assert canonical in directly_tested
+        assert test_file in related
+
+    def test_python_identity_alias_import_marks_canonical_module_directly_tested(
+        self,
+        tmp_path,
+    ):
+        alias_file = _write_file(tmp_path, "vendor_core/app/tasks/intermod_result_mapping.py", (
+            "from __future__ import annotations\n"
+            "import sys\n"
+            "from importlib import import_module\n"
+            "sys.modules[__name__] = import_module(\n"
+            "    'vendor_core.app.tasks.intermod.result_mapping'\n"
+            ")\n"
+        ))
+        canonical = _write_file(
+            tmp_path,
+            "vendor_core/app/tasks/intermod/result_mapping.py",
+            "def normalize(payload):\n    return dict(payload)\n",
+        )
+        test_file = _write_file(tmp_path, "vendor_core/tests/tasks/test_intermod_result_mapping_direct.py", (
+            "from vendor_core.app.tasks import intermod_result_mapping\n\n"
+            "def test_normalize():\n"
+            "    assert intermod_result_mapping.normalize({'ok': True}) == {'ok': True}\n"
+        ))
+        graph = {test_file: {"imports": set()}}
+        production_files = {alias_file, canonical}
+
+        with runtime_scope(RuntimeContext(project_root=tmp_path)):
+            directly_tested = import_based_mapping(
+                graph,
+                {test_file},
+                production_files,
+                "python",
+            )
+            parsed_imports = build_test_import_index(
+                {test_file},
+                production_files,
+                "python",
+            )
+            related = get_test_files_for_prod(
+                canonical,
+                {test_file},
+                graph,
+                "python",
+                parsed_imports_by_test=parsed_imports,
+            )
+
+        assert alias_file in directly_tested
+        assert canonical in directly_tested
+        assert test_file in related
 
 
 class TestInlineRustCoverage:
@@ -971,4 +1073,3 @@ class TestDetectTestCoverage:
             if e["detail"]["kind"] in ("untested_module", "untested_critical")
         ]
         assert untested == []
-


### PR DESCRIPTION
## Problem
Python test coverage mapping currently credits tests that import explicit alias/re-export modules to the alias file or package __init__ only. In the Frequency Coordination MonoRepo this misclassifies directly tested canonical modules such as shared_services.common.geometry.geojson and vendor_core.app.tasks.intermod.* as untested or transitive-only when tests exercise them through documented alias surfaces.

## Fix
- Expand resolved Python test imports through strict alias/re-export detection.
- Support sys.modules[__name__] = import_module(...) identity aliases.
- Support package __init__.py modules that explicitly re-export local submodules.
- Apply the expansion both during direct import mapping and parsed import indexing used for related-test lookup.

## Verification
- python3 -m py_compile desloppify/languages/python/test_coverage.py desloppify/engine/detectors/coverage/mapping_imports.py desloppify/tests/detectors/coverage/test_test_coverage.py
- ruff check desloppify/languages/python/test_coverage.py desloppify/engine/detectors/coverage/mapping_imports.py desloppify/tests/detectors/coverage/test_test_coverage.py
- python3 -m pytest desloppify/tests/detectors/coverage -q (195 passed)
- python3 -m pytest desloppify/languages/python/tests -q (280 passed)
- Frequency Coordination focused app tests: .pytest-env/bin/python -m pytest shared_services/tests/common/test_point_in_geojson.py vendor_core/tests/tasks/test_intermod_result_mapping_direct.py vendor_core/tests/tasks/test_intermod_tasks_direct.py -q (18 passed)
- Patched mapper direct check against the MonoRepo marked geojson.py, intermod/result_mapping.py, and intermod/tasks.py as DIRECT with their expected tests.

Note: a full patched 
Desloppify Scan (python)

  Plan: 20 subjective dimension(s) queued for review.
  Scan complete
  ──────────────────────────────────────────────────
  +677 new
  Scores: overall 24.6/100 (+24.6)  objective 98.3/100 (+98.3)  strict 24.6/100 (+24.6)  verified 98.3/100 (+98.3)
  ⚠ 20 subjective dimensions are unassessed (scored as 0). The strict score currently reflects only mechanical detectors (25% of score weight). Run `desloppify review --prepare` to assess.
  Score guide:
    overall  = 25% mechanical + 75% subjective (lenient — ignores wontfix)
    objective = mechanical detectors only (no subjective review)
    strict   = like overall, but wontfix counts against you  <-- your north star
    verified = strict, but only credits scan-verified fixes
  Strict 24.6 (target: 85.0)
  * 511 issues hidden (showing 10/detector). Use `desloppify show <detector>` to see all.
  Scorecard dimensions (matches scorecard.png):
  File health        ███████████████  98.4%  (strict  98.4%)
  Code quality       ██████████████░  96.5%  (strict  96.5%)
  Duplication        ███████████████  98.6%  (strict  98.6%)
  Security           ███████████████  99.8%  (strict  99.8%)
  Test health        ███████████████  98.2%  (strict  98.2%)

  Score recipe:
    overall = 25% mechanical + 75% subjective
    Pool averages: mechanical 98.3% · subjective 0.0%
    Biggest weighted drags:
      - High elegance: -13.41 pts (score 0.0%, 17.9% of subjective pool)
      - Mid elegance: -13.41 pts (score 0.0%, 17.9% of subjective pool)
      - Contracts: -7.32 pts (score 0.0%, 9.8% of subjective pool)
      - Low elegance: -7.32 pts (score 0.0%, 9.8% of subjective pool)
      - Type safety: -7.32 pts (score 0.0%, 9.8% of subjective pool)

  677 new issues with few resolutions — likely cascading.

  → ⚠ 12 security issues — review before other cleanup. First scan complete. 677 open issues across 3 dimensions.
  Run `desloppify next` for the highest-priority item.
  Run `desloppify plan` to see the updated living plan.
  Run `desloppify status` for the full dashboard.

  Scorecard → scorecard.png  (disable: --no-badge | move: --badge-path <path>) against the MonoRepo was intentionally not forced because the tool correctly refused mid-cycle with 30 queue items remaining.