### PR TITLE
fix: keep language detection within scan boundaries

### DIFF
--- a/desloppify/app/commands/helpers/lang.py
+++ b/desloppify/app/commands/helpers/lang.py
@@ -92,9 +92,9 @@ def resolve_detection_root(
     """Best root to auto-detect language from."""
     marker_provider = marker_provider or _lang_config_markers
     markers = marker_provider()
-    project_root_path = (
+    project_root_path = Path(
         project_root if project_root is not None else get_project_root()
-    )
+    ).resolve()
 
     raw_path = getattr(args, "path", None)
     if not raw_path:
@@ -109,6 +109,8 @@ def resolve_detection_root(
     for probe_root in (candidate_root, *candidate_root.parents):
         if any((probe_root / marker).exists() for marker in markers):
             return probe_root
+        if probe_root == project_root_path or (probe_root / ".git").exists():
+            break
     return candidate_root
 
 

--- a/desloppify/tests/commands/test_cli.py
+++ b/desloppify/tests/commands/test_cli.py
@@ -938,6 +938,34 @@ class TestResolveLang:
         resolved = lang_helpers_mod.resolve_detection_root(args)
         assert resolved == target_root
 
+    @pytest.mark.parametrize("external", [False, True], ids=["project", "worktree"])
+    def test_resolve_detection_root_does_not_cross_boundaries(
+        self, tmp_path, monkeypatch, external
+    ):
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "package.json").write_text("{}\n")
+
+        worktree = home / "worktree"
+        worktree.mkdir()
+        (worktree / ".git").write_text("gitdir: /repo/.git/worktrees/worktree\n")
+
+        project_root = worktree
+        path = "."
+        if external:
+            project_root = tmp_path / "current_project"
+            project_root.mkdir()
+            path = str(worktree)
+
+        monkeypatch.setattr(lang_helpers_mod, "get_project_root", lambda: project_root)
+        monkeypatch.setattr(
+            lang_helpers_mod, "_lang_config_markers", lambda: ("package.json",)
+        )
+
+        args = SimpleNamespace(path=path)
+        resolved = lang_helpers_mod.resolve_detection_root(args)
+        assert resolved == worktree
+
 
 # ===========================================================================
 # _project_root_from_state_path


### PR DESCRIPTION
## Problem

When an explicit scan path has no language marker, `resolve_detection_root` walks every parent until it finds one. A marker-less Git worktree under a home directory containing `package.json` therefore selects the home directory as its detection root.

In the reported repository, `desloppify scan --path .` resolved the detection root to `/home/roku`. JavaScript and TypeScript then both matched the ancestor `package.json`, so dominant-language detection recursively walked the entire home directory. The process read more than 20 GB before being interrupted, while the intended repository contained only 157 files (28 MiB).

## Fix

Stop upward marker discovery at either the active project root or a Git boundary. If no marker exists within that boundary, retain the original explicit scan path for marker-less source-count detection. This preserves subdirectory scans while preventing unrelated ancestor markers from widening scope.

Regression coverage includes both the current project boundary and an explicitly scanned external Git worktree whose parent contains `package.json`.

## Verification

- `TestResolveLang`: 11 passed
- Full `desloppify/tests/`: 5660 passed, 151 skipped; five unrelated baseline failures reproduced unchanged on `origin/main` (three Bash tree-sitter import cases and the same review prompt case collected twice)
- Before: detection root `/home/roku`
- After: detection root `/home/roku/src/Rokurolize/scp-tag-translation-worktrees/main-integration`, language `python`
- Patched automatic `scan --path .` against a clean clone of the affected repository: exit 0 in 7.78 seconds