### PR TITLE
fix: scope reloaded sense-check prompts

### DIFF
--- a/desloppify/app/commands/plan/triage/runner/orchestrator_codex_sense.py
+++ b/desloppify/app/commands/plan/triage/runner/orchestrator_codex_sense.py
@@ -358,7 +358,10 @@ def run_sense_check(
         reloaded_plan = _reload_structure_plan(reload_plan=reload_plan, log=_log)
         if reloaded_plan is None:
             return TriageStageRunResult(exit_code=1, reason="plan_reload_failed")
-        structure_plan = reloaded_plan
+        # Content self-recording reloads the full persisted plan. Keep the
+        # structure pass confined to this triage run rather than serializing
+        # every historical manual cluster into its global dependency prompt.
+        structure_plan = triage_scoped_plan(reloaded_plan, state)
         structure_config = _structure_batch_config(
             plan=structure_plan,
             repo_root=repo_root,
@@ -395,7 +398,7 @@ def run_sense_check(
     if apply_updates and reload_plan is not None:
         reloaded = _reload_structure_plan(reload_plan=reload_plan, log=_log)
         if reloaded is not None:
-            value_plan = reloaded
+            value_plan = triage_scoped_plan(reloaded, state)
             _log("sense-check-plan-reloaded phase=value")
 
     value_mode = "self_record" if apply_updates else "output_only"

--- a/desloppify/tests/commands/plan/test_triage_split_modules_direct.py
+++ b/desloppify/tests/commands/plan/test_triage_split_modules_direct.py
@@ -1207,6 +1207,93 @@ def test_orchestrator_sense_scopes_content_batches_to_active_triage(monkeypatch,
     assert len(structure_versions) == 1
 
 
+def test_orchestrator_sense_rescopes_reloaded_prompts_to_active_triage(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Post-content prompts must not revive historical clusters."""
+    active_issue = "review::current::issue"
+    current_cluster = {
+        "issue_ids": [active_issue],
+        "action_steps": [{"title": "Keep current scope", "detail": "Touch src/current.py"}],
+    }
+    reloaded_plan = {
+        "epic_triage_meta": {"active_triage_issue_ids": [active_issue]},
+        "clusters": {
+            "current": current_cluster,
+            **{
+                f"legacy-history-{index}": {
+                    "issue_ids": [f"review::legacy::{index}"],
+                    "action_steps": [
+                        {
+                            "title": "Historical work",
+                            "detail": "Touch src/legacy.py",
+                        }
+                    ],
+                }
+                for index in range(3)
+            },
+        },
+    }
+
+    def fake_run_triage_stage(
+        *,
+        prompt,
+        repo_root,
+        output_file,
+        log_file,
+        timeout_seconds,
+        validate_output_fn,
+    ):
+        del prompt, repo_root, log_file, timeout_seconds
+        output_file.write_text("ok", encoding="utf-8")
+        assert validate_output_fn(output_file)
+        return codex_runner_mod.TriageStageRunResult(exit_code=0)
+
+    import desloppify.app.commands.plan.triage.runner.stage_runner_override as override_mod
+
+    monkeypatch.setattr(override_mod, "_STAGE_RUNNER_OVERRIDE", fake_run_triage_stage)
+    monkeypatch.setattr(
+        orchestrator_sense_mod,
+        "run_parallel_batches",
+        lambda **kwargs: [task() for task in kwargs["tasks"].values()] and [],
+    )
+
+    prompts_dir = tmp_path / "prompts"
+    output_dir = tmp_path / "out"
+    logs_dir = tmp_path / "logs"
+    prompts_dir.mkdir()
+    output_dir.mkdir()
+    logs_dir.mkdir()
+
+    result = orchestrator_sense_mod.run_sense_check(
+        plan={
+            "epic_triage_meta": {"active_triage_issue_ids": [active_issue]},
+            "clusters": {"current": current_cluster},
+        },
+        repo_root=tmp_path,
+        prompts_dir=prompts_dir,
+        output_dir=output_dir,
+        logs_dir=logs_dir,
+        timeout_seconds=60,
+        dry_run=False,
+        apply_updates=True,
+        reload_plan=lambda: reloaded_plan,
+    )
+
+    assert result.ok
+    structure_prompt = (prompts_dir / "sense_check_structure.md").read_text(
+        encoding="utf-8"
+    )
+    assert "### current" in structure_prompt
+    assert "legacy-history-0" not in structure_prompt
+    assert "legacy-history-2" not in structure_prompt
+    value_prompt = (prompts_dir / "sense_check_value.md").read_text(encoding="utf-8")
+    assert "### current" in value_prompt
+    assert "legacy-history-0" not in value_prompt
+    assert "legacy-history-2" not in value_prompt
+
+
 def test_default_sense_handler_enables_apply_update_mode(monkeypatch, tmp_path: Path) -> None:
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Problem

After content self-recording, sense-check reloads the full plan for its structure and value prompts. That revives historical manual clusters outside the active triage session and can exceed the Codex input limit.

## Fix

Reapply the active-triage scoped plan after both post-content reloads. Add a regression that confirms the final structure and value prompts include the active cluster while excluding legacy clusters.

## Validation

- `python3 -m pytest desloppify/tests/commands/plan/test_triage_split_modules_direct.py -q` (44 passed)
- `python3 -m pytest desloppify/tests/commands/plan/test_triage_runner.py -q` (52 passed)
- Full suite stops at a pre-existing unrelated review-prompt assertion after 4,869 passed and 3 skipped.