### PR TITLE
fix: align staged triage prompt contract

### DIFF
--- a/desloppify/app/commands/plan/triage/runner/stage_prompts.py
+++ b/desloppify/app/commands/plan/triage/runner/stage_prompts.py
@@ -97,7 +97,13 @@ def _issue_context_for_stage(
 ) -> str:
     """Return the amount of issue context appropriate for a stage."""
     if stage in {"observe", "reflect"}:
-        parts = ["## Issue Data\n\n" + build_triage_prompt(triage_input)]
+        parts = [
+            "## Issue Data\n\n"
+            + build_triage_prompt(
+                triage_input,
+                include_auto_cluster_decision_guidance=False,
+            )
+        ]
         if stage == "reflect":
             issue_tokens = _required_issue_tokens(triage_input)
             parts.append(

--- a/desloppify/engine/_plan/triage/prompt.py
+++ b/desloppify/engine/_plan/triage/prompt.py
@@ -457,6 +457,8 @@ def _append_mechanical_backlog_section(
     parts: list[str],
     objective_backlog_issues: dict[str, dict],
     auto_clusters: dict[str, dict],
+    *,
+    include_auto_cluster_decision_guidance: bool = True,
 ) -> None:
     if not objective_backlog_issues:
         return
@@ -494,18 +496,19 @@ def _append_mechanical_backlog_section(
         "These are detector-created findings grouped by rule type. Each auto-cluster "
         "is a first-class triage candidate — decide its fate just like review issues."
     )
-    parts.append(
-        "You MUST make an explicit decision for each auto-cluster listed below. "
-        "Include every auto-cluster in your `auto_cluster_decisions` output with one of: "
-        "promote (add to active queue with a priority position), "
-        "skip (with a specific reason — e.g. 'mostly false positives per sampling'), "
-        "defer (keep in backlog — revisit after higher-impact work is done), or "
-        "break_up (split into smaller sub-clusters with a reason).\n\n"
-        "IMPORTANT: Prioritize code quality fixes (dead code, naming, smells, duplication, "
-        "structural issues) BEFORE test coverage. Writing tests for sloppy code locks in the "
-        "slop. Clean up the code first, then add tests to protect the clean version. "
-        "Defer test_coverage clusters unless code quality dimensions are already above 80%."
-    )
+    if include_auto_cluster_decision_guidance:
+        parts.append(
+            "You MUST make an explicit decision for each auto-cluster listed below. "
+            "Include every auto-cluster in your `auto_cluster_decisions` output with one of: "
+            "promote (add to active queue with a priority position), "
+            "skip (with a specific reason — e.g. 'mostly false positives per sampling'), "
+            "defer (keep in backlog — revisit after higher-impact work is done), or "
+            "break_up (split into smaller sub-clusters with a reason).\n\n"
+            "IMPORTANT: Prioritize code quality fixes (dead code, naming, smells, duplication, "
+            "structural issues) BEFORE test coverage. Writing tests for sloppy code locks in the "
+            "slop. Clean up the code first, then add tests to protect the clean version. "
+            "Defer test_coverage clusters unless code quality dimensions are already above 80%."
+        )
 
     rendered_clusters: list[tuple[str, dict, int]] = []
     for name, cluster in auto_clusters.items():
@@ -521,11 +524,18 @@ def _append_mechanical_backlog_section(
         rendered_clusters.append((name, cluster, member_count))
 
     if rendered_clusters:
-        parts.append("### Auto-clusters (decision required for each)")
-        parts.append(
-            "Each cluster below includes a statistical summary with severity breakdown "
-            "and sample issues. Decide for each: promote, skip (with reason), or break_up."
-        )
+        if include_auto_cluster_decision_guidance:
+            parts.append("### Auto-clusters (decision required for each)")
+            parts.append(
+                "Each cluster below includes a statistical summary with severity breakdown "
+                "and sample issues. Decide for each: promote, skip (with reason), or break_up."
+            )
+        else:
+            parts.append("### Auto-clusters")
+            parts.append(
+                "Each cluster below includes a statistical summary with severity breakdown "
+                "and sample issues."
+            )
         rendered_clusters.sort(key=lambda item: (-item[2], item[0]))
         visible_clusters = rendered_clusters[:15]
         for name, cluster, member_count in visible_clusters:
@@ -656,7 +666,11 @@ def _append_previously_dismissed_section(parts: list[str], dismissed_ids: list[s
     parts.append("")
 
 
-def build_triage_prompt(si: TriageInput) -> str:
+def build_triage_prompt(
+    si: TriageInput,
+    *,
+    include_auto_cluster_decision_guidance: bool = True,
+) -> str:
     """Build the user-facing prompt content with all issue data."""
     parts: list[str] = []
     _append_existing_clusters_section(parts, si.existing_clusters)
@@ -680,6 +694,7 @@ def build_triage_prompt(si: TriageInput) -> str:
         parts,
         si.objective_backlog_issues,
         si.auto_clusters,
+        include_auto_cluster_decision_guidance=include_auto_cluster_decision_guidance,
     )
     _append_previously_dismissed_section(parts, si.previously_dismissed)
     return "\n".join(parts)

--- a/desloppify/tests/commands/plan/test_reflect_disposition_ledger.py
+++ b/desloppify/tests/commands/plan/test_reflect_disposition_ledger.py
@@ -9,6 +9,10 @@ from desloppify.app.commands.plan.triage.validation.core import (
 from desloppify.app.commands.plan.triage.validation.organize_policy import (
     validate_organize_against_reflect_ledger,
 )
+from desloppify.app.commands.plan.triage.validation.reflect_accounting import (
+    parse_backlog_decisions,
+    validate_backlog_decisions,
+)
 
 # ---------------------------------------------------------------------------
 # parse_reflect_dispositions
@@ -166,6 +170,25 @@ class TestParseReflectDispositions:
         }
         result = parse_reflect_dispositions(report, valid_ids)
         assert result == []
+
+
+def test_backlog_decisions_reject_legacy_defer_and_break_up_actions() -> None:
+    report = (
+        "## Backlog Decisions\n"
+        '- auto/unused-imports -> defer "revisit later"\n'
+        '- auto/dead-code -> break_up "split by package"\n'
+    )
+
+    assert parse_backlog_decisions(report) == []
+
+    valid, messages = validate_backlog_decisions(
+        report=report,
+        auto_cluster_names=["auto/unused-imports", "auto/dead-code"],
+    )
+
+    assert valid is False
+    assert "auto/unused-imports" in messages[0]
+    assert "auto/dead-code" in messages[0]
 
 
 # ---------------------------------------------------------------------------

--- a/desloppify/tests/commands/plan/test_triage_runner.py
+++ b/desloppify/tests/commands/plan/test_triage_runner.py
@@ -22,7 +22,11 @@ from desloppify.app.commands.plan.triage.runner.stage_validation import (
 from desloppify.engine._plan.triage.prompt import TriageInput
 
 
-def _make_triage_input(n_issues: int = 5) -> TriageInput:
+def _make_triage_input(
+    n_issues: int = 5,
+    *,
+    with_auto_cluster: bool = False,
+) -> TriageInput:
     """Create a minimal TriageInput for testing."""
     issues = {}
     for i in range(n_issues):
@@ -34,9 +38,28 @@ def _make_triage_input(n_issues: int = 5) -> TriageInput:
             "summary": f"Issue {i} summary",
             "detail": {"dimension": f"dim_{i % 3}", "suggestion": "Fix it"},
         }
+    objective_backlog_issues = {}
+    auto_clusters = {}
+    if with_auto_cluster:
+        objective_backlog_issues = {
+            "unused::src/legacy.py::dead": {
+                "detector": "unused",
+                "summary": "Unused legacy export",
+                "file": "src/legacy.py",
+                "confidence": "high",
+            }
+        }
+        auto_clusters = {
+            "auto/unused-imports": {
+                "auto": True,
+                "issue_ids": ["unused::src/legacy.py::dead"],
+                "description": "Remove the unused legacy export",
+            }
+        }
     return TriageInput(
         review_issues=issues,
-        objective_backlog_issues={},
+        objective_backlog_issues=objective_backlog_issues,
+        auto_clusters=auto_clusters,
         existing_clusters={},
         dimension_scores={"dim_0": {"score": 70, "strict": 65, "failing": 2}},
         new_since_last=set(),
@@ -69,6 +92,28 @@ def test_build_reflect_prompt_includes_prior(tmp_path: Path) -> None:
     assert "## Coverage Ledger Template" in prompt
     assert "-> TODO" in prompt
     assert "exactly once" in prompt
+
+
+def test_staged_prompts_omit_legacy_auto_cluster_decision_contract(tmp_path: Path) -> None:
+    si = _make_triage_input(with_auto_cluster=True)
+
+    observe_prompt = build_stage_prompt("observe", si, {}, repo_root=tmp_path)
+    reflect_prompt = build_stage_prompt(
+        "reflect",
+        si,
+        {"observe": "My observation report about themes and root causes."},
+        repo_root=tmp_path,
+    )
+
+    for prompt in (observe_prompt, reflect_prompt):
+        assert "## Auto-cluster candidates (1 items: 1 in 1 auto-clusters, 0 unclustered)" in prompt
+        assert "### Auto-clusters" in prompt
+        assert "- auto/unused-imports (1 items)" in prompt
+        assert "`auto_cluster_decisions`" not in prompt
+        assert "defer (keep in backlog" not in prompt
+        assert "### Auto-clusters (decision required for each)" not in prompt
+
+    assert "supersede" in reflect_prompt
 
 
 def test_build_stage_prompt_places_prior_reports_before_issue_data(tmp_path: Path) -> None:

--- a/desloppify/tests/plan/test_epic_triage_prompt_direct.py
+++ b/desloppify/tests/plan/test_epic_triage_prompt_direct.py
@@ -136,8 +136,56 @@ def test_build_triage_prompt_includes_mechanical_backlog_context() -> None:
 
     assert "## Auto-cluster candidates (2 items: 1 in 1 auto-clusters, 1 unclustered)" in prompt
     assert "### Auto-clusters (decision required for each)" in prompt
+    assert "`auto_cluster_decisions`" in prompt
     assert "- auto/unused-imports (1 items) [autofix: desloppify autofix import-cleanup --dry-run]" in prompt
     assert "Remove 1 unused import issue" in prompt
     assert "### Unclustered items (1 items — needs human judgment or isolated findings)" in prompt
     assert "- [medium] test_coverage::src/b.py::miss — Missing behavioral coverage" in prompt
     assert "Inspect a cluster: `desloppify plan cluster show auto/<name>`" in prompt
+
+
+def test_build_triage_prompt_can_omit_legacy_auto_cluster_decision_guidance() -> None:
+    open_id, open_issue = _issue(
+        "review::open::1111aaaa",
+        summary="Open API drift",
+        dimension="api_surface_coherence",
+    )
+    triage_input = TriageInput(
+        review_issues={open_id: open_issue},
+        objective_backlog_issues={
+            "unused::src/a.py::dead": {
+                "detector": "unused",
+                "summary": "Unused export",
+                "file": "src/a.py",
+                "confidence": "high",
+            },
+        },
+        auto_clusters={
+            "auto/unused-imports": {
+                "auto": True,
+                "issue_ids": ["unused::src/a.py::dead"],
+                "description": "Remove 1 unused import issue",
+            }
+        },
+        existing_clusters={},
+        dimension_scores={},
+        new_since_last=set(),
+        resolved_since_last=set(),
+        previously_dismissed=[],
+        triage_version=1,
+        resolved_issues={},
+        completed_clusters=[],
+    )
+
+    prompt = build_triage_prompt(
+        triage_input,
+        include_auto_cluster_decision_guidance=False,
+    )
+
+    assert "## Auto-cluster candidates (1 items: 1 in 1 auto-clusters, 0 unclustered)" in prompt
+    assert "### Auto-clusters" in prompt
+    assert "### Auto-clusters (decision required for each)" not in prompt
+    assert "- auto/unused-imports (1 items)" in prompt
+    assert "`auto_cluster_decisions`" not in prompt
+    assert "defer (keep in backlog" not in prompt
+    assert "break_up (split into smaller sub-clusters" not in prompt


### PR DESCRIPTION
## Problem

Staged observe and reflect prompts embed generic whole-plan auto-cluster guidance that advertises `defer` and `break_up`. The staged reflect validator accepts only `promote`, `skip`, and `supersede`, so valid-looking runner output can fail the accounting gate.

## Fix

Keep the generic triage prompt contract unchanged by default, while allowing staged prompt builders to omit the incompatible legacy auto-cluster decision guidance. Staged prompts retain the auto-cluster summary and use their own `promote`/`skip`/`supersede` contract.

## Validation

- `python3 -m pytest -q desloppify/tests/plan/test_epic_triage_prompt_direct.py desloppify/tests/commands/plan/test_triage_runner.py desloppify/tests/commands/plan/test_reflect_disposition_ledger.py` (82 passed)
- `python3 -m ruff check desloppify/tests/commands/plan/test_reflect_disposition_ledger.py desloppify/tests/plan/test_epic_triage_prompt_direct.py`
- `python3 -m compileall -q desloppify/engine/_plan/triage/prompt.py desloppify/app/commands/plan/triage/runner/stage_prompts.py`