### PR TITLE
fix: preserve triage scope across sense reloads

### DIFF
--- a/desloppify/app/commands/plan/triage/runner/orchestrator_codex_sense.py
+++ b/desloppify/app/commands/plan/triage/runner/orchestrator_codex_sense.py
@@ -358,7 +358,7 @@ def run_sense_check(
         reloaded_plan = _reload_structure_plan(reload_plan=reload_plan, log=_log)
         if reloaded_plan is None:
             return TriageStageRunResult(exit_code=1, reason="plan_reload_failed")
-        structure_plan = reloaded_plan
+        structure_plan = triage_scoped_plan(reloaded_plan, state)
         structure_config = _structure_batch_config(
             plan=structure_plan,
             repo_root=repo_root,
@@ -391,11 +391,11 @@ def run_sense_check(
         return _parallel_failure_result(structure_failures, log=_log)
 
     # Value batch — runs after structure (needs corrected plan state)
-    value_plan = dict(plan)
+    value_plan = dict(scoped_plan)
     if apply_updates and reload_plan is not None:
         reloaded = _reload_structure_plan(reload_plan=reload_plan, log=_log)
         if reloaded is not None:
-            value_plan = reloaded
+            value_plan = triage_scoped_plan(reloaded, state)
             _log("sense-check-plan-reloaded phase=value")
 
     value_mode = "self_record" if apply_updates else "output_only"

--- a/desloppify/tests/commands/plan/test_triage_split_modules_direct.py
+++ b/desloppify/tests/commands/plan/test_triage_split_modules_direct.py
@@ -1207,6 +1207,93 @@ def test_orchestrator_sense_scopes_content_batches_to_active_triage(monkeypatch,
     assert len(structure_versions) == 1
 
 
+def test_orchestrator_sense_scopes_reloaded_structure_and_value_plans(monkeypatch, tmp_path) -> None:
+    structure_clusters: list[set[str]] = []
+    value_clusters: list[set[str]] = []
+
+    monkeypatch.setattr(
+        orchestrator_sense_mod,
+        "scoped_manual_clusters_with_issues",
+        lambda _plan, _state=None: ["current"],
+    )
+    monkeypatch.setattr(
+        orchestrator_sense_mod,
+        "triage_scoped_plan",
+        lambda plan, _state=None: {
+            **plan,
+            "clusters": {"current": plan["clusters"]["current"]},
+        },
+    )
+    monkeypatch.setattr(
+        orchestrator_sense_mod,
+        "build_sense_check_content_prompt",
+        lambda **_kwargs: "content prompt",
+    )
+
+    def fake_structure_prompt(*, plan, **_kwargs):
+        structure_clusters.append(set(plan["clusters"]))
+        return "structure prompt"
+
+    def fake_value_prompt(*, plan, **_kwargs):
+        value_clusters.append(set(plan["clusters"]))
+        return "value prompt"
+
+    monkeypatch.setattr(orchestrator_sense_mod, "build_sense_check_structure_prompt", fake_structure_prompt)
+    monkeypatch.setattr(orchestrator_sense_mod, "build_sense_check_value_prompt", fake_value_prompt)
+
+    def fake_run_triage_stage(
+        *,
+        prompt,
+        repo_root,
+        output_file,
+        log_file,
+        timeout_seconds,
+        validate_output_fn,
+    ):
+        del prompt, repo_root, log_file, timeout_seconds
+        output_file.write_text("ok", encoding="utf-8")
+        assert validate_output_fn(output_file)
+        return codex_runner_mod.TriageStageRunResult(exit_code=0)
+
+    import desloppify.app.commands.plan.triage.runner.stage_runner_override as override_mod
+
+    monkeypatch.setattr(override_mod, "_STAGE_RUNNER_OVERRIDE", fake_run_triage_stage)
+    monkeypatch.setattr(
+        orchestrator_sense_mod,
+        "run_parallel_batches",
+        lambda **kwargs: [task() for task in kwargs["tasks"].values()] and [],
+    )
+
+    prompts_dir = tmp_path / "prompts"
+    output_dir = tmp_path / "out"
+    logs_dir = tmp_path / "logs"
+    prompts_dir.mkdir()
+    output_dir.mkdir()
+    logs_dir.mkdir()
+
+    reloaded_plan = {
+        "clusters": {
+            "current": {"issue_ids": ["review::current::issue"], "action_steps": []},
+            "legacy": {"issue_ids": ["review::legacy::issue"], "action_steps": []},
+        }
+    }
+    result = orchestrator_sense_mod.run_sense_check(
+        plan={"clusters": {"current": reloaded_plan["clusters"]["current"]}},
+        state={"issues": {"review::current::issue": {"status": "open", "detector": "review"}}},
+        repo_root=tmp_path,
+        prompts_dir=prompts_dir,
+        output_dir=output_dir,
+        logs_dir=logs_dir,
+        timeout_seconds=60,
+        apply_updates=True,
+        reload_plan=lambda: reloaded_plan,
+    )
+
+    assert result.ok
+    assert structure_clusters == [{"current"}, {"current"}]
+    assert value_clusters == [{"current"}]
+
+
 def test_default_sense_handler_enables_apply_update_mode(monkeypatch, tmp_path: Path) -> None:
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Problem

Sense-check content batches correctly use the active triage scope, but post-update plan reloads gave the structure and value batches the full historical plan. On a large tracker this sends an oversized prompt to Codex and aborts the stage before its global checks run.

## Fix

Reapply `triage_scoped_plan` after each reload and seed the value batch from the already scoped plan. A regression covers a reload that includes a legacy cluster and verifies that the rebuilt structure and value prompts retain only the active cluster.

## Validation

- `python3 -m pytest -q desloppify/tests/commands/plan/test_triage_split_modules_direct.py` (44 passed)
- Ruff and compile checks for the changed test file
