### PR TITLE
fix: scope Codex enrich prompts to active triage clusters

### DIFF
--- a/desloppify/app/commands/plan/triage/runner/stage_prompts.py
+++ b/desloppify/app/commands/plan/triage/runner/stage_prompts.py
@@ -16,6 +16,10 @@ from desloppify.engine.plan_triage import (
 )
 
 from ..services import TriageServices, default_triage_services
+from ..stages.helpers import (
+    active_triage_issue_scope,
+    scoped_manual_clusters_with_issues,
+)
 from ..validation.reflect_accounting import required_reflect_issue_tokens
 from .stage_prompts_instruction_blocks import _STAGE_INSTRUCTIONS
 from .stage_prompts_instruction_shared import (
@@ -28,12 +32,12 @@ from .stage_prompts_observe import (
     _observe_batch_instructions,
     build_observe_batch_prompt,
 )
-from .stage_prompts_strategist import build_strategist_prompt
 from .stage_prompts_sense import (
     build_sense_check_content_prompt,
     build_sense_check_structure_prompt,
     build_sense_check_value_prompt,
 )
+from .stage_prompts_strategist import build_strategist_prompt
 from .stage_prompts_validation import _validation_requirements
 
 
@@ -86,8 +90,47 @@ To see all open review issues with suggestions:
   desloppify show review --status open --no-budget
 To see a cluster's steps, members, and suggestions:
   desloppify plan cluster show <name>
-To list all clusters:
+To list all clusters (this is global/historical context, not an enrichment mutation scope):
   desloppify plan cluster list --verbose"""
+
+
+def _enrich_active_scope_block(plan: dict | None, state: dict | None) -> str:
+    """Render the frozen triage session's only allowed enrich targets.
+
+    The generic Codex pipeline passes the full plan to every stage prompt.  That
+    plan can contain many historical clusters, while a recovered/current triage
+    session owns only the clusters linked to its frozen review issue IDs.
+    """
+    if not isinstance(plan, dict):
+        return ""
+    meta = plan.get("epic_triage_meta", {})
+    frozen_issue_ids = meta.get("active_triage_issue_ids") if isinstance(meta, dict) else None
+    if not isinstance(frozen_issue_ids, list) or not frozen_issue_ids:
+        return ""
+
+    # ``scoped_manual_clusters_with_issues`` intentionally falls back to all
+    # manual clusters when its live scope is empty. A frozen session whose
+    # issues have all gone stale must instead name no mutation targets.
+    live_scope = active_triage_issue_scope(plan, state)
+    cluster_names = (
+        scoped_manual_clusters_with_issues(plan, state) if live_scope is not None else []
+    )
+    lines = [
+        "## Active Enrich Scope (frozen triage session)",
+        "Mutate ONLY the named active clusters below for this enrich run.",
+    ]
+    if cluster_names:
+        lines.extend(f"- `{name}`" for name in cluster_names)
+    else:
+        lines.append("- No live manual clusters match the frozen triage issues; do not mutate any cluster.")
+    lines.extend(
+        [
+            "",
+            "`desloppify plan cluster list --verbose` is global/historical context. "
+            "Do not use it to discover or mutate additional clusters.",
+        ]
+    )
+    return "\n".join(lines)
 
 
 def _issue_context_for_stage(
@@ -477,6 +520,14 @@ def build_stage_prompt(
 
     # Issue data / summary
     parts.append(_issue_context_for_stage(stage, triage_input, mode))
+
+    # A recovered/current triage session can coexist with many historical
+    # clusters.  Make its frozen ownership explicit before enrich instructions
+    # tell a subprocess to mutate plan state.
+    if stage == "enrich":
+        active_scope = _enrich_active_scope_block(plan, state)
+        if active_scope:
+            parts.append(active_scope)
 
     # Stage-specific instructions
     instruction_fn = _STAGE_INSTRUCTIONS.get(stage)

--- a/desloppify/app/commands/plan/triage/runner/stage_prompts_instruction_blocks.py
+++ b/desloppify/app/commands/plan/triage/runner/stage_prompts_instruction_blocks.py
@@ -325,7 +325,7 @@ Every review issue must end up in a cluster OR be skipped.
 
 def _enrich_instructions(mode: PromptMode = "self_record") -> str:
     subagent_block = """\
-**USE SUBAGENTS — one per cluster.** Each subagent MUST:
+**USE SUBAGENTS — one per in-scope cluster.** Each subagent MUST:
 
 1. Run `desloppify plan cluster show <name>` to get steps, members, and reviewer suggestions
 2. For deeper analysis, run `desloppify show <issue-id> --no-budget` to see full evidence
@@ -343,7 +343,7 @@ desloppify plan triage --stage enrich --report "<enrichment summary>" --attestat
 """
     if mode == "output_only":
         subagent_block = """\
-**USE SUBAGENTS — one per cluster.** Each subagent MUST:
+**USE SUBAGENTS — one per in-scope cluster.** Each subagent MUST:
 
 1. Inspect the cluster definition provided in the prompt context
 2. **Read the actual source file for every step** — not just the issue description.
@@ -359,8 +359,12 @@ effort tags, and issue refs for each cluster. The orchestrator records the stage
     return f"""\
 ## ENRICH Stage Instructions
 
-Your task: make EVERY step executor-ready. The test: could a developer who has never seen
-this codebase read your step detail and make the change without asking a single question?
+Your task: make EVERY step in the current triage clusters executor-ready. When an
+**Active Enrich Scope** block appears above, it is authoritative: mutate ONLY the named
+active clusters. `desloppify plan cluster list --verbose` is global/historical context, not
+an invitation to add historical clusters to this enrich run. The test: could a developer who
+has never seen this codebase read your step detail and make the change without asking a
+single question?
 
 If the answer is "they'd need to figure out which file" or "they'd need to understand the
 context" — your step is not ready. Be specific enough that the work is mechanical.
@@ -369,11 +373,11 @@ strategy from old triage runs unless you find a concrete mismatch you need to ex
 
 ### Requirements (ALL BLOCKING — confirmation will reject if not met)
 
-1. Every step MUST have `--detail` with 80+ chars INCLUDING at least one file path (src/... or supabase/...)
-2. Every step MUST have `--issue-refs` linking it to specific review issue hash(es)
-3. Every step MUST have `--effort` tag (trivial/small/medium/large) — set INDIVIDUALLY, not bulk
+1. Every in-scope step MUST have `--detail` with 80+ chars INCLUDING at least one file path (src/... or supabase/...)
+2. Every in-scope step MUST have `--issue-refs` linking it to specific review issue hash(es)
+3. Every in-scope step MUST have `--effort` tag (trivial/small/medium/large) — set INDIVIDUALLY, not bulk
 4. File paths in detail MUST exist on disk (validator checks this)
-5. No step may reference a skipped/wontfixed issue in its issue_refs
+5. No in-scope step may reference a skipped/wontfixed issue in its issue_refs
 
 ### How to enrich
 

--- a/desloppify/tests/commands/plan/test_triage_runner.py
+++ b/desloppify/tests/commands/plan/test_triage_runner.py
@@ -6,9 +6,6 @@ from pathlib import Path
 
 import pytest
 
-from desloppify.app.commands.plan.triage.validation.core import (
-    _validate_reflect_issue_accounting,
-)
 from desloppify.app.commands.plan.triage.runner import codex_runner
 from desloppify.app.commands.plan.triage.runner.orchestrator_codex_pipeline_execution import (
     build_reflect_repair_prompt,
@@ -18,6 +15,9 @@ from desloppify.app.commands.plan.triage.runner.stage_validation import (
     build_auto_attestation,
     validate_completion,
     validate_stage,
+)
+from desloppify.app.commands.plan.triage.validation.core import (
+    _validate_reflect_issue_accounting,
 )
 from desloppify.engine._plan.triage.prompt import TriageInput
 
@@ -336,6 +336,84 @@ def test_build_enrich_prompt(tmp_path: Path) -> None:
     assert "ENRICH" in prompt
     assert "--issue-refs" in prompt
     assert "exist on disk" in prompt
+
+
+def test_build_enrich_prompt_scopes_frozen_triage_to_current_clusters(tmp_path: Path) -> None:
+    """A generic Codex enrich prompt must not expand into historical clusters."""
+    si = _make_triage_input()
+    prior = {"observe": "obs", "reflect": "ref", "organize": "org"}
+    plan = _plan_with_stages(organize={"report": "organized"})
+    plan["epic_triage_meta"]["active_triage_issue_ids"] = ["review::current::issue"]
+    plan["clusters"] = {
+        "current": {
+            "issue_ids": ["review::current::issue"],
+            "description": "current triage work",
+            "action_steps": [],
+        },
+        "historical": {
+            "issue_ids": ["review::historical::issue"],
+            "description": "finished historical work",
+            "action_steps": [],
+        },
+    }
+    state = {
+        "issues": {
+            "review::current::issue": {"status": "open", "detector": "review"},
+            "review::historical::issue": {"status": "open", "detector": "review"},
+        }
+    }
+
+    prompt = build_stage_prompt(
+        "enrich",
+        si,
+        prior,
+        repo_root=tmp_path,
+        mode="output_only",
+        plan=plan,
+        state=state,
+    )
+
+    assert "## Active Enrich Scope (frozen triage session)" in prompt
+    assert "- `current`" in prompt
+    assert "`historical`" not in prompt
+    assert "Mutate ONLY the named active clusters" in prompt
+    assert "global/historical context" in prompt
+
+
+def test_build_enrich_prompt_does_not_fall_back_to_historical_when_scope_is_stale(
+    tmp_path: Path,
+) -> None:
+    """A frozen but fully stale session must not turn into a global enrich run."""
+    si = _make_triage_input()
+    prior = {"observe": "obs", "reflect": "ref", "organize": "org"}
+    plan = _plan_with_stages(organize={"report": "organized"})
+    plan["epic_triage_meta"]["active_triage_issue_ids"] = ["review::stale::issue"]
+    plan["clusters"] = {
+        "historical": {
+            "issue_ids": ["review::historical::issue"],
+            "description": "still-open historical work",
+            "action_steps": [],
+        }
+    }
+    state = {
+        "issues": {
+            "review::stale::issue": {"status": "closed", "detector": "review"},
+            "review::historical::issue": {"status": "open", "detector": "review"},
+        }
+    }
+
+    prompt = build_stage_prompt(
+        "enrich",
+        si,
+        prior,
+        repo_root=tmp_path,
+        mode="output_only",
+        plan=plan,
+        state=state,
+    )
+
+    assert "No live manual clusters match the frozen triage issues" in prompt
+    assert "- `historical`" not in prompt
 
 
 def test_build_organize_prompt_output_only_omits_mutating_cli_instructions(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

The generic Codex enrich runner received the full plan and its prompt encouraged a global cluster listing. During a frozen/recovered triage session, that could lead the runner to enrich historical clusters unrelated to the active review issues.

## Fix

- Render an explicit Active Enrich Scope from the frozen session using `scoped_manual_clusters_with_issues(plan, state)`.
- Instruct enrich workers to mutate only the named active clusters and treat the global cluster list as historical context.
- Keep a fully stale frozen session from falling back to every manual cluster.

## Validation

- `python3 -m pytest desloppify/tests/commands/plan/test_triage_runner.py -q` (54 passed)
- `ruff check desloppify/app/commands/plan/triage/runner/stage_prompts.py desloppify/app/commands/plan/triage/runner/stage_prompts_instruction_blocks.py desloppify/tests/commands/plan/test_triage_runner.py`