### PR TITLE
fix: propagate explicit state through automated triage

### DIFF
--- a/desloppify/app/commands/plan/triage/runner/orchestrator_codex_pipeline.py
+++ b/desloppify/app/commands/plan/triage/runner/orchestrator_codex_pipeline.py
@@ -105,15 +105,25 @@ def _read_stage_output(output_file: Path) -> str:
 
 
 
-def _write_desloppify_cli_helper(run_dir: Path) -> Path:
+def _write_desloppify_cli_helper(run_dir: Path, state_path: Path | None = None) -> Path:
     """Create an exact CLI wrapper so codex subagents use this checkout + interpreter."""
     package_root = Path(desloppify.__file__).resolve().parent.parent
     script_path = run_dir / "run_desloppify.sh"
+    python_command = f"{shlex.quote(sys.executable)} -m desloppify.cli"
     script = (
         "#!/bin/sh\n"
         f"export PYTHONPATH={shlex.quote(str(package_root))}${{PYTHONPATH:+:$PYTHONPATH}}\n"
-        f"exec {shlex.quote(sys.executable)} -m desloppify.cli \"$@\"\n"
     )
+    if state_path is None:
+        script += f'exec {python_command} "$@"\n'
+    else:
+        script += (
+            f'[ "$#" -gt 0 ] || exec {python_command} "$@"\n'
+            'command_name=$1\n'
+            'shift\n'
+            f'exec {python_command} "$command_name" --state '
+            f'{shlex.quote(str(state_path))} "$@"\n'
+        )
     safe_write_text(script_path, script)
     os.chmod(script_path, 0o700)
     return script_path
@@ -383,7 +393,10 @@ def run_codex_pipeline(
 
     run_log_path = run_dir / "run.log"
     append_run_log = make_run_log_writer(run_log_path)
-    cli_helper = _write_desloppify_cli_helper(run_dir)
+    cli_helper = _write_desloppify_cli_helper(
+        run_dir,
+        getattr(runtime, "state_path", None),
+    )
     runner_label = active_runner_name()
     append_run_log(
         f"run-start runner={runner_label} stages={','.join(stages_to_run)} "

--- a/desloppify/tests/commands/plan/test_triage_split_modules_direct.py
+++ b/desloppify/tests/commands/plan/test_triage_split_modules_direct.py
@@ -1319,6 +1319,33 @@ def test_orchestrator_pipeline_writes_exact_cli_helper(tmp_path: Path) -> None:
     assert "-m desloppify.cli" in text
 
 
+def test_orchestrator_pipeline_cli_helper_propagates_state(monkeypatch, tmp_path: Path) -> None:
+    import subprocess
+
+    recorded_args = tmp_path / "recorded-args.txt"
+    python = tmp_path / "record-python"
+    python.write_text(
+        f'#!/bin/sh\nprintf "%s\\n" "$@" > {recorded_args}\n',
+        encoding="utf-8",
+    )
+    python.chmod(0o700)
+    monkeypatch.setattr(orchestrator_pipeline_mod.sys, "executable", str(python))
+
+    state_path = tmp_path / "named state" / "state.json"
+    helper = orchestrator_pipeline_mod._write_desloppify_cli_helper(tmp_path, state_path)
+    subprocess.run([str(helper), "plan", "cluster", "list"], check=True)
+
+    assert recorded_args.read_text(encoding="utf-8").splitlines() == [
+        "-m",
+        "desloppify.cli",
+        "plan",
+        "--state",
+        str(state_path),
+        "cluster",
+        "list",
+    ]
+
+
 def test_load_prior_reports_from_plan_uses_existing_stage_reports() -> None:
     plan = {
         "epic_triage_meta": {
@@ -1856,7 +1883,7 @@ def test_run_codex_pipeline_raises_on_stage_failure(monkeypatch, tmp_path: Path)
     monkeypatch.setattr(
         orchestrator_pipeline_mod,
         "_write_desloppify_cli_helper",
-        lambda run_dir: run_dir / "run_desloppify.sh",
+        lambda run_dir, _state_path: run_dir / "run_desloppify.sh",
     )
     monkeypatch.setattr(
         orchestrator_pipeline_mod,


### PR DESCRIPTION
## Problem

Automated Codex/Rovo triage creates `run_desloppify.sh` for stage subprocesses, but the wrapper previously preserved only the checkout/interpreter. When the parent invocation used an explicit state file, for example:

```sh
desloppify plan --state .desloppify/parent/state.json triage --run-stages --runner codex
```

the generated prompt commands silently fell back to the default/root state. Self-recording stages such as organize then could not match issue IDs from the selected state.

## Fix

Pass the active `CommandRuntime.state_path` into the generated helper. The wrapper inserts `--state <path>` immediately after every top-level command, so all stage prompt commands (`plan`, `show`, `next`, and `backlog`) use the same state as the parent triage run. Default-state runs keep the existing wrapper behavior.

Added an executable regression test that records the helper's argv, including a state path containing a space.

## Verification

- `python3 -m pytest desloppify/tests/commands/plan/test_triage_split_modules_direct.py -q` — 44 passed
- `ruff check . --select E9,F63,F7,F82` — passed
- Full `desloppify/tests/` run: 5661 passed, 152 skipped, with 3 pre-existing Bash unused-source failures reproduced unchanged on pristine `main`
- Replayed the Santoro multi-state repro in a disposable clone: the generated helper included `.desloppify/parent/state.json`, listed 20 parent review issues, and successfully added the previously unmatched issue pattern to a test cluster
