### PR TITLE
fix(dict-keys): ignore mapping-copy phantom reads

### DIFF
--- a/desloppify/languages/python/detectors/dict_keys/visitor.py
+++ b/desloppify/languages/python/detectors/dict_keys/visitor.py
@@ -144,7 +144,11 @@ class DictKeyVisitor(ast.NodeVisitor):
             isinstance(value, ast.Call)
             and isinstance(value.func, ast.Name)
             and value.func.id == "dict"
+            and not value.args
+            and all(kw.arg is not None for kw in value.keywords)
         ):
+            # `dict(mapping)` and `dict(**mapping)` inherit keys the visitor
+            # cannot see, so they are not locally-created literals.
             is_creation = True
             for kw in value.keywords:
                 if kw.arg:

--- a/desloppify/languages/python/tests/test_py_dict_keys.py
+++ b/desloppify/languages/python/tests/test_py_dict_keys.py
@@ -94,6 +94,49 @@ class TestPhantomRead:
         entries, _ = detect_dict_key_flow(path)
         assert "phantom_read" not in _kinds(entries)
 
+    def test_mapping_copies_are_not_tracked_as_empty_literals(self, tmp_path):
+        """Copies retain keys the detector cannot infer from the constructor."""
+        path = _write_py(
+            tmp_path,
+            """\
+            from typing import Mapping, TypedDict
+
+            class Person(TypedDict):
+                name: str
+
+            def copy_typed_dict(person: Person):
+                copied = dict(person)
+                return copied["name"]
+
+            def copy_mapping(person: Mapping[str, str]):
+                copied = dict(**person)
+                return copied["name"]
+        """,
+        )
+        entries, _ = detect_dict_key_flow(path)
+        assert "phantom_read" not in _kinds(entries)
+
+    def test_empty_and_keyword_only_dict_constructors_still_track_keys(self, tmp_path):
+        path = _write_py(
+            tmp_path,
+            """\
+            def read_missing_empty_dict():
+                result = dict()
+                return result["missing"]
+
+            def read_missing_keyword_dict():
+                result = dict(name="Alice")
+                return result["missing"]
+        """,
+        )
+        entries, _ = detect_dict_key_flow(path)
+        phantoms = _find_kind(entries, "phantom_read")
+        assert {entry["key"] for entry in phantoms} == {"missing"}
+        assert {entry["func"] for entry in phantoms} == {
+            "read_missing_empty_dict",
+            "read_missing_keyword_dict",
+        }
+
 
 # ── Dead writes (written key never read) ──────────────────
 


### PR DESCRIPTION
## Problem

The Python dict-key detector treats `dict(mapping)` and `dict(**mapping)` as freshly created empty dictionaries. Reads from those copies are then reported as high-confidence phantom reads even though the copied mapping may already contain the keys.

## Fix

Track only empty and keyword-only `dict(...)` constructors as locally created dictionaries. Mapping-copy constructors are left untracked because their initial keys are not statically knowable.

## Validation

- `python3 -m pytest -q desloppify/languages/python/tests/test_py_dict_keys.py` (28 passed)
- `python3 -m ruff check --select E,F,B,UP --ignore E501 desloppify/languages/python/detectors/dict_keys/visitor.py desloppify/languages/python/tests/test_py_dict_keys.py`
- `git diff --check`

The ignored E501 is an unchanged pre-existing module-docstring line on `origin/main`.
