### PR TITLE
fix: preserve triage execution handoff

### DIFF
--- a/desloppify/app/commands/plan/triage/completion_flow.py
+++ b/desloppify/app/commands/plan/triage/completion_flow.py
@@ -8,18 +8,22 @@ from collections import defaultdict
 from typing import Any
 
 from desloppify.base.output.terminal import colorize
-from desloppify.engine._plan.refresh_lifecycle import current_lifecycle_phase
+from desloppify.engine._plan.constants import (
+    WORKFLOW_CREATE_PLAN_ID,
+    WORKFLOW_SCORE_CHECKPOINT_ID,
+    is_synthetic_id,
+)
+from desloppify.engine._plan.policy.stale import review_issue_snapshot_hash
+from desloppify.engine._plan.refresh_lifecycle import (
+    _set_lifecycle_phase,
+    current_lifecycle_phase,
+    mark_postflight_scan_completed,
+)
 from desloppify.engine._state.progression import (
     append_progression_event,
     build_triage_complete_event,
 )
-from desloppify.engine._plan.constants import (
-    WORKFLOW_CREATE_PLAN_ID,
-    WORKFLOW_SCORE_CHECKPOINT_ID,
-)
-from desloppify.engine._plan.policy.stale import review_issue_snapshot_hash
-from desloppify.engine._plan.refresh_lifecycle import mark_postflight_scan_completed
-from desloppify.engine.plan_ops import purge_ids
+from desloppify.engine.plan_ops import purge_ids, remove_queue_entries
 from desloppify.engine.plan_state import Cluster, PlanModel
 from desloppify.engine.plan_triage import TRIAGE_IDS
 from desloppify.state_io import StateModel, utc_now
@@ -225,6 +229,19 @@ def apply_completion(
     _restore_postflight_scan_completion_for_current_scan(
         plan=plan,
         state=state,
+    )
+    # Completing a valid triage board is the handoff from planning to
+    # implementation. Without this persisted transition, queue snapshots
+    # continue exposing postflight/objective backlog instead of the newly
+    # triaged execution work.
+    _set_lifecycle_phase(plan, "execute")
+    remove_queue_entries(
+        plan,
+        [
+            issue_id
+            for issue_id in plan["queue_order"]
+            if isinstance(issue_id, str) and is_synthetic_id(issue_id)
+        ],
     )
     resolved_services.save_plan(plan)
 

--- a/desloppify/engine/_plan/operations/queue.py
+++ b/desloppify/engine/_plan/operations/queue.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from desloppify.engine._plan.promoted_ids import add_promoted_ids
+from desloppify.engine._plan.promoted_ids import add_promoted_ids, prune_promoted_ids
 from desloppify.engine._plan.schema import PlanModel, SkipEntry, ensure_plan_defaults
 
 
@@ -135,4 +135,26 @@ def move_items(
     return len(issue_ids)
 
 
-__all__ = ["move_items", "_remove_id_from_lists"]
+def remove_queue_entries(plan: PlanModel, issue_ids: list[str]) -> list[str]:
+    """Remove queue entries without changing their planning history.
+
+    This is intentionally narrower than :func:`purge_ids`: it removes only
+    queue placement and promotion metadata.  Clusters, overrides, skips,
+    action steps, and state-backed finding history remain intact.
+    """
+    ensure_plan_defaults(plan)
+    removal = set(issue_ids)
+    if not removal:
+        return []
+
+    order: list[str] = plan["queue_order"]
+    removed = [issue_id for issue_id in order if issue_id in removal]
+    if not removed:
+        return []
+
+    order[:] = [issue_id for issue_id in order if issue_id not in removal]
+    prune_promoted_ids(plan, removal)
+    return removed
+
+
+__all__ = ["move_items", "remove_queue_entries", "_remove_id_from_lists"]

--- a/desloppify/engine/_plan/refresh_lifecycle.py
+++ b/desloppify/engine/_plan/refresh_lifecycle.py
@@ -5,7 +5,8 @@ Persisted markers live in ``plan["refresh_state"]`` and have distinct roles:
 ``lifecycle_phase``
     Valid persisted values are only ``"plan"`` and ``"execute"``. The single
     writer is ``_set_lifecycle_phase()``, called from
-    ``engine._plan.sync.pipeline.reconcile_plan()`` after queue reconciliation.
+    ``engine._plan.sync.pipeline.reconcile_plan()`` after queue reconciliation
+    and from triage completion when a validated plan hands off to execution.
     Legacy fine-grained phase names are migrated at load time by
     ``migrate_legacy_phase()`` from ``engine._plan.persistence._load_validated_plan()``.
     The coarse mode transitions from ``plan`` to ``execute`` when planning work

--- a/desloppify/engine/_plan/sync/pipeline.py
+++ b/desloppify/engine/_plan/sync/pipeline.py
@@ -4,36 +4,38 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from desloppify.state_scoring import score_snapshot
 from desloppify.engine._plan.auto_cluster import auto_cluster_issues
 from desloppify.engine._plan.constants import (
     PRE_REVIEW_WORKFLOW_IDS,
     WORKFLOW_COMMUNICATE_SCORE_ID,
     WORKFLOW_CREATE_PLAN_ID,
     WORKFLOW_DEFERRED_DISPOSITION_ID,
-    WORKFLOW_IMPORT_SCORES_ID,
     WORKFLOW_RUN_SCAN_ID,
     WORKFLOW_SCORE_CHECKPOINT_ID,
     QueueSyncResult,
     is_synthetic_id,
 )
 from desloppify.engine._plan.operations.meta import append_log_entry
-from desloppify.engine._plan.policy.subjective import compute_subjective_visibility
+from desloppify.engine._plan.operations.queue import remove_queue_entries
 from desloppify.engine._plan.policy.stale import open_review_ids
+from desloppify.engine._plan.policy.subjective import compute_subjective_visibility
 from desloppify.engine._plan.refresh_lifecycle import (
     _set_lifecycle_phase,
     derive_display_phase,
     user_facing_mode,
 )
+from desloppify.engine._plan.schema import live_planned_queue_ids
 from desloppify.engine._plan.sync.dimensions import sync_subjective_dimensions
 from desloppify.engine._plan.sync.phase_cleanup import prune_synthetic_for_phase
 from desloppify.engine._plan.sync.triage import sync_triage_needed
-from desloppify.engine._plan.triage.snapshot import build_triage_snapshot
 from desloppify.engine._plan.sync.workflow import (
     ScoreSnapshot,
     sync_communicate_score_needed,
     sync_create_plan_needed,
 )
+from desloppify.engine._plan.triage.snapshot import build_triage_snapshot
+from desloppify.engine._state.issue_semantics import is_assessment_request
+from desloppify.state_scoring import score_snapshot
 
 _SCAN_PHASE_WORKFLOW_IDS = {
     WORKFLOW_DEFERRED_DISPOSITION_ID,
@@ -59,6 +61,7 @@ class ReconcileResult:
     triage: QueueSyncResult | None = None
     lifecycle_phase: str = ""
     lifecycle_phase_changed: bool = False
+    queue_entries_pruned: list[str] | None = None
     phase_cleanup_pruned: list[str] | None = None
     # Snapshot of plan_start_scores captured when communicate_score auto-resolves,
     # before post-reconcile clearing can wipe them.
@@ -79,6 +82,7 @@ class ReconcileResult:
                     self.triage.changes or getattr(self.triage, "deferred", False)
                 ),
                 self.lifecycle_phase_changed,
+                bool(self.queue_entries_pruned),
                 bool(self.phase_cleanup_pruned),
             )
         )
@@ -113,6 +117,7 @@ def _resolve_reconcile_display_phase(
     *,
     result: ReconcileResult,
     policy: object | None,
+    force_rescan: bool = False,
 ) -> str:
     """Derive the display phase from queue contents.
 
@@ -149,15 +154,25 @@ def _resolve_reconcile_display_phase(
         and bool(triage_snapshot.live_open_ids)
     )
 
-    # Check for objective work in the queue.
-    has_real_work = any(
-        not item.startswith(("subjective::", "workflow::", "triage::"))
-        for item in order
-        if item not in (plan.get("skipped") or {})
-    )
+    has_real_work = _has_live_execution_work(plan, state)
     has_review_postflight = triage_gated_review or (
         not has_real_work and bool(open_review_ids(state))
     )
+
+    # Match the snapshot's explicit handoff: a persisted execute board with
+    # live state-backed work must not be preempted by stale postflight queue
+    # residue during an ordinary reconcile.  ``force_rescan`` remains the
+    # deliberate escape hatch for starting a new postflight cycle.
+    if _persisted_execute_board_active(
+        plan,
+        state,
+        force_rescan=force_rescan,
+    ):
+        has_postflight_assessment = False
+        prefer_scan = False
+        has_workflow = False
+        has_triage = False
+        has_review_postflight = False
 
     return derive_display_phase(
         has_initial_review=has_initial_review,
@@ -174,7 +189,7 @@ def _resolve_reconcile_display_phase(
 _MIGRATION_PRUNED_KEY = "_subjective_migration_pruned"
 
 
-def _migrate_prune_stale_subjective(plan: dict) -> None:
+def _migrate_prune_stale_subjective(plan: dict) -> list[str]:
     """One-time migration: remove stale subjective:: items from queue_order.
 
     The old system re-injected stale subjective items on every reconcile
@@ -184,20 +199,95 @@ def _migrate_prune_stale_subjective(plan: dict) -> None:
     """
     refresh_state = plan.get("refresh_state")
     if not isinstance(refresh_state, dict):
-        return
+        return []
     if refresh_state.get(_MIGRATION_PRUNED_KEY):
-        return  # Already done
+        return []  # Already done
     queue_order = plan.get("queue_order")
     if not isinstance(queue_order, list):
-        return
-    cleaned = [
+        return []
+    stale_ids = [
         item_id
         for item_id in queue_order
-        if not (isinstance(item_id, str) and item_id.startswith("subjective::"))
+        if isinstance(item_id, str) and item_id.startswith("subjective::")
     ]
-    if len(cleaned) < len(queue_order):
-        plan["queue_order"] = cleaned
+    pruned = remove_queue_entries(plan, stale_ids)
     refresh_state[_MIGRATION_PRUNED_KEY] = True
+    return pruned
+
+
+def _prune_stale_review_queue_entries(plan: dict, state: dict) -> list[str]:
+    """Drop fixed review findings from queue placement without erasing history."""
+    live_review_ids = open_review_ids(state)
+    stale_ids = [
+        issue_id
+        for issue_id in plan.get("queue_order", [])
+        if isinstance(issue_id, str)
+        and issue_id.startswith(("review::", "concerns::"))
+        and issue_id not in live_review_ids
+    ]
+    return remove_queue_entries(plan, stale_ids)
+
+
+def _prune_execute_synthetic_queue_entries(
+    plan: dict,
+    *,
+    force_rescan: bool,
+) -> list[str]:
+    """Clear planning residue from an ordinary persisted execute handoff."""
+    if force_rescan:
+        return []
+    refresh_state = plan.get("refresh_state")
+    if not (
+        isinstance(refresh_state, dict)
+        and refresh_state.get("lifecycle_phase") == "execute"
+    ):
+        return []
+    return remove_queue_entries(
+        plan,
+        [
+            issue_id
+            for issue_id in plan.get("queue_order", [])
+            if isinstance(issue_id, str) and is_synthetic_id(issue_id)
+        ],
+    )
+
+
+def _has_live_execution_work(plan: dict, state: dict) -> bool:
+    """Return whether an explicit queue entry still maps to open work state."""
+    queued_ids = live_planned_queue_ids(plan)
+    if not queued_ids:
+        return False
+
+    work_items = state.get("work_items") or state.get("issues", {})
+    if not isinstance(work_items, dict):
+        return False
+
+    for issue_id in queued_ids:
+        issue = work_items.get(issue_id)
+        if not isinstance(issue, dict):
+            continue
+        if issue.get("suppressed") or issue.get("status", "open") != "open":
+            continue
+        if is_assessment_request(issue):
+            continue
+        return True
+    return False
+
+
+def _persisted_execute_board_active(
+    plan: dict,
+    state: dict,
+    *,
+    force_rescan: bool,
+) -> bool:
+    """Return whether a persisted execution handoff still owns reconciliation."""
+    if force_rescan or not _has_live_execution_work(plan, state):
+        return False
+    refresh_state = plan.get("refresh_state")
+    return (
+        isinstance(refresh_state, dict)
+        and refresh_state.get("lifecycle_phase") == "execute"
+    )
 
 
 def live_planned_queue_empty(plan: dict) -> bool:
@@ -230,7 +320,20 @@ def reconcile_plan(
     # Migration cleanup: prune stale subjective items from queue_order
     # left by the old mid-cycle re-injection bug.  With boundary-only sync
     # they won't be re-added, so they just block phase resolution.
-    _migrate_prune_stale_subjective(plan)
+    result.queue_entries_pruned = [
+        *_migrate_prune_stale_subjective(plan),
+        *_prune_execute_synthetic_queue_entries(
+            plan,
+            force_rescan=force_rescan,
+        ),
+        *_prune_stale_review_queue_entries(plan, state),
+    ]
+    if result.queue_entries_pruned:
+        _log_gate_changes(
+            plan,
+            "prune_stale_queue_entries",
+            {"pruned": list(result.queue_entries_pruned)},
+        )
 
     policy = compute_subjective_visibility(
         state,
@@ -238,16 +341,25 @@ def reconcile_plan(
         plan=plan,
     )
 
-    result.subjective = sync_subjective_dimensions(
+    # A persisted execution board is deliberate work. Re-injecting stale
+    # assessments before it drains replaces that board with generic review
+    # work on the next reconcile cycle.
+    at_queue_boundary = live_planned_queue_empty(plan) or force_rescan
+    if not _persisted_execute_board_active(
         plan,
         state,
-        policy=policy,
-    )
-    if result.subjective.changes:
-        _log_gate_changes(plan, "sync_subjective", {"changes": True})
+        force_rescan=force_rescan,
+    ):
+        result.subjective = sync_subjective_dimensions(
+            plan,
+            state,
+            policy=policy,
+        )
+        if result.subjective.changes:
+            _log_gate_changes(plan, "sync_subjective", {"changes": True})
 
     # Auto-clustering and heavier workflow reconciliation only runs at queue boundaries.
-    if live_planned_queue_empty(plan) or force_rescan:
+    if at_queue_boundary:
         result.auto_cluster_changes = int(
             auto_cluster_issues(
                 plan,
@@ -294,6 +406,7 @@ def reconcile_plan(
         state,
         result=result,
         policy=policy,
+        force_rescan=force_rescan,
     )
     mode = user_facing_mode(result.lifecycle_phase)
     result.lifecycle_phase_changed = _set_lifecycle_phase(plan, mode)

--- a/desloppify/engine/_work_queue/plan_order.py
+++ b/desloppify/engine/_work_queue/plan_order.py
@@ -10,13 +10,14 @@ from desloppify.engine._plan.cluster_semantics import (
     infer_cluster_action_type,
     infer_cluster_execution_policy,
 )
+from desloppify.engine._work_queue.types import WorkQueueItem
 from desloppify.engine.plan_ops import (
     get_issue_description,
     get_issue_note,
     get_issue_override,
 )
-from desloppify.engine._work_queue.types import WorkQueueItem
 from desloppify.state_io import StateModel
+
 
 def new_item_ids(state: StateModel) -> set[str]:
     """Return issue IDs added in the most recent scan."""
@@ -198,7 +199,7 @@ def collapse_clusters(items: list[WorkQueueItem], plan: dict) -> list[WorkQueueI
     """Replace cluster member items with single cluster meta-items.
 
     Both auto-clusters and manual (triage) clusters are collapsed.  Manual
-    clusters are inserted at the front in plan order so triage-prioritised
+    clusters are inserted at the front in explicit priority order so
     work appears before auto-clustered mechanical items.
     """
     clusters = plan.get("clusters", {})
@@ -231,11 +232,37 @@ def collapse_clusters(items: list[WorkQueueItem], plan: dict) -> list[WorkQueueI
             cname, members, clusters.get(cname, {})
         )
 
-    # Collect manual cluster names in plan order (for front-insertion)
-    manual_names = [
-        name for name in clusters
-        if not clusters[name].get("auto") and name in meta_items
-    ]
+    # Preserve every visible manual cluster at the front, whether it has one
+    # member or enough members to collapse into a meta-item. A cluster's
+    # explicit priority is the authoritative execution order; falling back to
+    # its first queue position preserves the old plan-order behavior for
+    # historical clusters that predate priority metadata.
+    cluster_insertion_positions = {
+        name: index for index, name in enumerate(clusters)
+    }
+    cluster_positions = {
+        name: min(
+            (
+                index
+                for index, item in enumerate(items)
+                if fid_to_cluster.get(item.get("id", "")) == name
+            ),
+            default=len(items),
+        )
+        for name, cluster in clusters.items()
+        if not cluster.get("auto") and name in cluster_members
+    }
+
+    def _manual_cluster_sort_key(name: str) -> tuple[int, int, int]:
+        priority = clusters[name].get("priority")
+        normalized_priority = priority if isinstance(priority, int) else 1_000_000
+        return (
+            normalized_priority,
+            cluster_positions[name],
+            cluster_insertion_positions[name],
+        )
+
+    manual_names = sorted(cluster_positions, key=_manual_cluster_sort_key)
 
     # Walk in order: replace first auto-cluster member with meta-item,
     # skip subsequent members.  Manual cluster members are always skipped
@@ -244,6 +271,8 @@ def collapse_clusters(items: list[WorkQueueItem], plan: dict) -> list[WorkQueueI
     rest: list[WorkQueueItem] = []
     for item in items:
         cname = fid_to_cluster.get(item.get("id", ""))
+        if cname and cname in manual_names:
+            continue
         if cname and cname in meta_items:
             if cname not in seen_clusters:
                 seen_clusters.add(cname)
@@ -254,8 +283,15 @@ def collapse_clusters(items: list[WorkQueueItem], plan: dict) -> list[WorkQueueI
         else:
             rest.append(item)
 
-    # Manual clusters at the front in plan order, then everything else
-    manual_result = [meta_items[name] for name in manual_names if name in seen_clusters]
+    # Manual clusters at the front in priority order, then everything else.
+    # Singleton manual clusters stay as their original issue item so callers
+    # still receive the normal per-finding execution detail.
+    manual_result: list[WorkQueueItem] = []
+    for name in manual_names:
+        if name in meta_items:
+            manual_result.append(meta_items[name])
+        else:
+            manual_result.extend(cluster_members[name])
     return manual_result + rest
 
 

--- a/desloppify/engine/plan_ops.py
+++ b/desloppify/engine/plan_ops.py
@@ -27,7 +27,7 @@ from desloppify.engine._plan.operations.meta import (
     append_log_entry,
     describe_issue,
 )
-from desloppify.engine._plan.operations.queue import move_items
+from desloppify.engine._plan.operations.queue import move_items, remove_queue_entries
 from desloppify.engine._plan.operations.skip import (
     backlog_items,
     resurface_stale_skips,
@@ -75,6 +75,7 @@ __all__ = [
     "normalize_step",
     "parse_steps_file",
     "purge_ids",
+    "remove_queue_entries",
     "remove_from_cluster",
     "reset_plan",
     "resurface_stale_skips",

--- a/desloppify/tests/commands/plan/test_triage_completion_cleanup.py
+++ b/desloppify/tests/commands/plan/test_triage_completion_cleanup.py
@@ -16,7 +16,7 @@ from desloppify.engine._plan.constants import (
 )
 from desloppify.engine._plan.policy.stale import is_triage_stale
 from desloppify.engine._plan.refresh_lifecycle import (
-    LIFECYCLE_PHASE_REVIEW_POSTFLIGHT,
+    LIFECYCLE_PHASE_EXECUTE,
 )
 from desloppify.engine._plan.schema import empty_plan
 from desloppify.engine._work_queue.snapshot import build_queue_snapshot
@@ -219,7 +219,7 @@ class TestApplyCompletionClearsTriageState:
         assert "observe" in last["stages"]
 
     def test_completion_restores_postflight_scan_marker_for_current_scan(self):
-        """Completing triage should not bounce the queue back to workflow::run-scan."""
+        """Completing triage starts the validated execution board."""
         state = _state_with_review_issues("r1", "r2")
         plan = _plan_with_triage_and_workflow("r1", "r2")
         services = _make_services(state)
@@ -228,9 +228,24 @@ class TestApplyCompletionClearsTriageState:
         apply_completion(args, plan, "Test strategy", services=services)
 
         assert plan["refresh_state"]["postflight_scan_completed_at_scan_count"] == 5
+        assert plan["refresh_state"]["lifecycle_phase"] == "execute"
         snapshot = build_queue_snapshot(state, plan=plan)
-        assert snapshot.phase == LIFECYCLE_PHASE_REVIEW_POSTFLIGHT
+        assert snapshot.phase == LIFECYCLE_PHASE_EXECUTE
         assert [item["id"] for item in snapshot.execution_items] == ["r1", "r2"]
+
+    def test_completion_removes_stale_synthetic_queue_residue(self):
+        state = _state_with_review_issues("r1")
+        plan = _plan_with_triage_and_workflow("r1")
+        plan["queue_order"] = [
+            "subjective::naming_quality",
+            "strategy::legacy-narrative",
+            *plan["queue_order"],
+        ]
+        services = _make_services(state)
+
+        apply_completion(argparse.Namespace(), plan, "Test strategy", services=services)
+
+        assert plan["queue_order"] == ["r1"]
 
     def test_completion_does_not_forge_scan_marker_without_scan_history(self):
         """Plans loaded without a scan should still require an actual scan."""

--- a/desloppify/tests/plan/test_auto_cluster.py
+++ b/desloppify/tests/plan/test_auto_cluster.py
@@ -357,6 +357,50 @@ def test_collapse_clusters_skips_manual():
     assert all(i["kind"] == "issue" for i in result)
 
 
+def test_collapse_clusters_orders_manual_clusters_by_explicit_priority():
+    """Manual singleton and grouped work respects the declared priority."""
+    plan = empty_plan()
+    plan["clusters"]["late-group"] = {
+        "name": "late-group",
+        "auto": False,
+        "issue_ids": ["g1", "g2"],
+        "description": "late grouped work",
+        "priority": 9,
+    }
+    plan["clusters"]["first-single"] = {
+        "name": "first-single",
+        "auto": False,
+        "issue_ids": ["s1"],
+        "description": "first work",
+        "priority": 1,
+    }
+    plan["clusters"]["second-single"] = {
+        "name": "second-single",
+        "auto": False,
+        "issue_ids": ["s2"],
+        "description": "second work",
+        "priority": 2,
+    }
+
+    items = [
+        {"id": "g1", "kind": "issue", "tier": 1,
+         "detector": "unused", "confidence": "high", "detail": {}},
+        {"id": "g2", "kind": "issue", "tier": 1,
+         "detector": "unused", "confidence": "high", "detail": {}},
+        {"id": "s1", "kind": "issue", "tier": 1,
+         "detector": "unused", "confidence": "high", "detail": {}},
+        {"id": "s2", "kind": "issue", "tier": 1,
+         "detector": "unused", "confidence": "high", "detail": {}},
+        {"id": "other", "kind": "issue", "tier": 2,
+         "detector": "structural", "confidence": "medium", "detail": {}},
+    ]
+
+    result = _collapse_clusters(items, plan)
+    assert [item["id"] for item in result] == [
+        "s1", "s2", "late-group", "other",
+    ]
+
+
 def test_cluster_sort_key_before_issues():
     cluster_item = {
         "kind": "cluster", "action_type": "auto_fix",

--- a/desloppify/tests/plan/test_reconcile_pipeline.py
+++ b/desloppify/tests/plan/test_reconcile_pipeline.py
@@ -179,8 +179,101 @@ def test_phase_resolves_to_assessment_when_stale_injected_mid_cycle() -> None:
     result = reconcile_plan(plan, state, target_strict=95.0)
 
     assert plan["queue_order"] == ["subjective::naming_quality", "unused::a"]
+    assert result.subjective is not None
     assert result.lifecycle_phase == LIFECYCLE_PHASE_ASSESSMENT_POSTFLIGHT
     assert result.lifecycle_phase_changed is True
+
+
+def _persisted_execute_board_with_stale_residue() -> tuple[dict, dict]:
+    state = _stale_subjective_state()
+    state["issues"] = {
+        "review::a": _issue("review::a", detector="review"),
+    }
+
+    plan = empty_plan()
+    plan["queue_order"] = [
+        "subjective::naming_quality",
+        "strategy::legacy-narrative",
+        "review::a",
+        "review::stale",
+    ]
+    plan["promoted_ids"] = ["review::stale"]
+    plan["plan_start_scores"] = {"strict": 80.0}
+    plan["refresh_state"] = {
+        "lifecycle_phase": "execute",
+        "_subjective_migration_pruned": True,
+    }
+    plan["epic_triage_meta"] = {
+        "triaged_ids": ["review::a"],
+        "issue_snapshot_hash": "stable",
+    }
+    plan["clusters"] = {
+        "historic-review": {
+            "name": "historic-review",
+            "issue_ids": [
+                "subjective::naming_quality",
+                "strategy::legacy-narrative",
+                "review::stale",
+            ],
+            "execution_status": "done",
+        }
+    }
+    return plan, state
+
+
+def test_persisted_execute_board_survives_stale_queue_residue() -> None:
+    plan, state = _persisted_execute_board_with_stale_residue()
+
+    result = reconcile_plan(plan, state, target_strict=95.0)
+    snapshot = build_queue_snapshot(state, plan=plan)
+
+    assert result.subjective is None
+    assert result.lifecycle_phase == LIFECYCLE_PHASE_EXECUTE
+    assert result.lifecycle_phase_changed is False
+    assert result.queue_entries_pruned == [
+        "subjective::naming_quality",
+        "strategy::legacy-narrative",
+        "review::stale",
+    ]
+    assert result.phase_cleanup_pruned == []
+    assert plan["queue_order"] == ["review::a"]
+    assert plan["promoted_ids"] == []
+    # Queue cleanup intentionally preserves cluster history.
+    assert plan["clusters"]["historic-review"]["issue_ids"] == [
+        "subjective::naming_quality",
+        "strategy::legacy-narrative",
+        "review::stale",
+    ]
+    assert snapshot.phase == LIFECYCLE_PHASE_EXECUTE
+    assert [item["id"] for item in snapshot.execution_items] == ["review::a"]
+
+
+def test_force_rescan_bypasses_persisted_execute_board() -> None:
+    plan, state = _persisted_execute_board_with_stale_residue()
+
+    result = reconcile_plan(plan, state, target_strict=95.0, force_rescan=True)
+    snapshot = build_queue_snapshot(state, plan=plan)
+
+    assert result.subjective is not None
+    assert result.lifecycle_phase == LIFECYCLE_PHASE_ASSESSMENT_POSTFLIGHT
+    assert plan["refresh_state"]["lifecycle_phase"] == "plan"
+    assert snapshot.phase == LIFECYCLE_PHASE_ASSESSMENT_POSTFLIGHT
+
+
+def test_fixed_review_queue_entry_does_not_hold_execute_mode() -> None:
+    plan = empty_plan()
+    plan["queue_order"] = ["review::fixed"]
+    plan["refresh_state"] = {
+        "lifecycle_phase": "execute",
+        "_subjective_migration_pruned": True,
+    }
+    state = _stale_subjective_state()
+
+    result = reconcile_plan(plan, state, target_strict=95.0)
+
+    assert result.queue_entries_pruned == ["review::fixed"]
+    assert result.lifecycle_phase == LIFECYCLE_PHASE_ASSESSMENT_POSTFLIGHT
+    assert plan["refresh_state"]["lifecycle_phase"] == "plan"
 
 
 def test_reconcile_plan_second_call_is_noop() -> None:

--- a/desloppify/tests/plan/test_skip.py
+++ b/desloppify/tests/plan/test_skip.py
@@ -8,7 +8,7 @@ from desloppify.engine._plan.operations.cluster import (
 )
 from desloppify.engine._plan.operations.lifecycle import purge_ids
 from desloppify.engine._plan.operations.meta import append_log_entry
-from desloppify.engine._plan.operations.queue import move_items
+from desloppify.engine._plan.operations.queue import move_items, remove_queue_entries
 from desloppify.engine._plan.operations.skip import (
     resurface_stale_skips,
     skip_items,
@@ -88,6 +88,23 @@ def test_skip_removes_from_queue_order():
     skip_items(plan, ["b"], kind="temporary")
     assert "b" not in plan["queue_order"]
     assert plan["queue_order"] == ["a", "c"]
+
+
+def test_remove_queue_entries_preserves_planning_history():
+    plan = _plan_with_queue("a", "b", "c")
+    plan["promoted_ids"] = ["a", "b"]
+    plan["skipped"] = {"b": {"issue_id": "b", "kind": "temporary"}}
+    plan["clusters"] = {"historic": {"issue_ids": ["b"]}}
+    plan["overrides"] = {"b": {"issue_id": "b", "cluster": "historic"}}
+
+    removed = remove_queue_entries(plan, ["b", "missing"])
+
+    assert removed == ["b"]
+    assert plan["queue_order"] == ["a", "c"]
+    assert plan["promoted_ids"] == ["a"]
+    assert "b" in plan["skipped"]
+    assert plan["clusters"]["historic"]["issue_ids"] == ["b"]
+    assert plan["overrides"]["b"]["cluster"] == "historic"
 
 
 def test_skip_with_reason():


### PR DESCRIPTION
## Problem

Completing a valid triage board did not persist the execution lifecycle handoff. A later reconcile could inject stale subjective work, let stale queue residue preempt the intended board, and keep a fixed review item from allowing the board to drain. Manual-cluster display ordering also ignored explicit priority.

## Fix

- Persist the triage-to-execution handoff and preserve it during ordinary reconciliation while live planned work remains.
- Remove stale synthetic and fixed-review queue placement without erasing cluster, override, action-step, or state history; keep force-rescan as the explicit postflight escape hatch.
- Honor explicit manual-cluster priority in collapsed queue ordering.

## Impact

Validated triage boards remain executable and queue-driven instead of reverting to generic postflight work. Historical planning evidence is retained when queue residue is cleaned.

## Validation

- `python3 -m pytest -q desloppify/tests/plan/test_reconcile_pipeline.py desloppify/tests/plan/test_phase_cleanup.py desloppify/tests/plan/test_skip.py desloppify/tests/plan/test_auto_cluster.py desloppify/tests/commands/plan/test_triage_completion_cleanup.py desloppify/tests/review/test_work_queue_plan_order_and_triage.py desloppify/tests/engine/test_sync_split_modules_direct.py desloppify/tests/commands/test_queue_order_guard.py desloppify/tests/commands/test_lifecycle_transitions.py`
- `ruff check` on changed implementation and test files
- `git diff --check`
