### PR TITLE
fix: respect triage plan queue order

### DIFF
--- a/desloppify/app/commands/plan/triage/validation/enrich_quality.py
+++ b/desloppify/app/commands/plan/triage/validation/enrich_quality.py
@@ -77,8 +77,7 @@ def _active_cluster_names(plan: dict, triage_issue_ids: set[str]) -> set[str]:
     return {
         name
         for name, cluster in plan.get("clusters", {}).items()
-        if not cluster_issue_ids(cluster)
-        or set(cluster_issue_ids(cluster)) & triage_issue_ids
+        if set(cluster_issue_ids(cluster)) & triage_issue_ids
     }
 
 

--- a/desloppify/engine/_work_queue/plan_order.py
+++ b/desloppify/engine/_work_queue/plan_order.py
@@ -231,11 +231,29 @@ def collapse_clusters(items: list[WorkQueueItem], plan: dict) -> list[WorkQueueI
             cname, members, clusters.get(cname, {})
         )
 
-    # Collect manual cluster names in plan order (for front-insertion)
+    # Collect manual cluster names in explicit queue order (for front-insertion).
+    # Cluster mapping insertion order is incidental: ``plan cluster reorder``
+    # moves member IDs in ``queue_order`` and expects collapsed manual clusters
+    # to follow that same order.
+    queue_order = plan.get("queue_order", [])
+    queue_positions: dict[str, int] = {}
+    for position, issue_id in enumerate(queue_order):
+        queue_positions.setdefault(issue_id, position)
     manual_names = [
-        name for name in clusters
+        name
+        for name in clusters
         if not clusters[name].get("auto") and name in meta_items
     ]
+    manual_names.sort(
+        key=lambda name: min(
+            (
+                queue_positions[member["id"]]
+                for member in cluster_members[name]
+                if member["id"] in queue_positions
+            ),
+            default=len(queue_order),
+        )
+    )
 
     # Walk in order: replace first auto-cluster member with meta-item,
     # skip subsequent members.  Manual cluster members are always skipped

--- a/desloppify/tests/commands/plan/test_triage_split_modules_direct.py
+++ b/desloppify/tests/commands/plan/test_triage_split_modules_direct.py
@@ -468,6 +468,30 @@ def test_confirmation_pipeline_threads_triage_issue_scope(monkeypatch) -> None:
     assert captured["triage_issue_ids"] == {"review::current::issue"}
 
 
+def test_enrich_quality_scope_excludes_empty_and_historical_clusters() -> None:
+    """Current-cycle enrich checks must not inspect historical empty packets."""
+    from desloppify.app.commands.plan.triage.validation import (
+        enrich_quality as enrich_quality_mod,
+    )
+
+    plan = {
+        "clusters": {
+            "current": {"issue_ids": ["review::current::issue"]},
+            "historical": {"issue_ids": ["review::historical::issue"]},
+            "completed-empty": {"issue_ids": [], "action_steps": [{"detail": "stale"}]},
+        },
+    }
+
+    active = enrich_quality_mod._active_cluster_names(
+        plan,
+        {"review::current::issue"},
+    )
+    scoped = enrich_quality_mod._scoped_plan(plan, {"review::current::issue"})
+
+    assert active == {"current"}
+    assert set(scoped["clusters"]) == {"current"}
+
+
 def test_validate_attestation_rules() -> None:
     assert confirmations_basic_mod.validate_attestation("mentions naming", "observe", dimensions=["Naming"]) is None
     err = confirmations_basic_mod.validate_attestation(

--- a/desloppify/tests/review/test_work_queue_plan_order_and_triage.py
+++ b/desloppify/tests/review/test_work_queue_plan_order_and_triage.py
@@ -87,6 +87,40 @@ def test_collapse_clusters_preserves_order():
     assert len(result) == 2  # other + cluster
 
 
+def test_collapse_manual_clusters_respects_explicit_queue_order():
+    """Manual cluster display follows member order, not cluster-map insertion order."""
+    from desloppify.engine._work_queue.plan_order import collapse_clusters
+
+    plan = {
+        "queue_order": ["first-1", "first-2", "later-1", "later-2"],
+        "clusters": {
+            # Deliberately inserted first even though it was reordered behind
+            # ``first`` in the execution queue.
+            "later": {
+                "auto": False,
+                "issue_ids": ["later-1", "later-2"],
+                "description": "The later manual packet",
+            },
+            "first": {
+                "auto": False,
+                "issue_ids": ["first-1", "first-2"],
+                "description": "The first manual packet",
+            },
+        },
+    }
+    items = [
+        {"id": "later-1", "kind": "issue", "detector": "review", "detail": {}},
+        {"id": "first-1", "kind": "issue", "detector": "review", "detail": {}},
+        {"id": "later-2", "kind": "issue", "detector": "review", "detail": {}},
+        {"id": "first-2", "kind": "issue", "detector": "review", "detail": {}},
+        {"id": "other", "kind": "issue", "detector": "smells", "detail": {}},
+    ]
+
+    result = collapse_clusters(items, plan)
+
+    assert [item["id"] for item in result] == ["first", "later", "other"]
+
+
 # -- Plan-ordered subjective items surface despite objective backlog --------
 
 


### PR DESCRIPTION
## Problem

Manual multi-item triage clusters were rendered ahead of the execution queue based on cluster-map insertion order. This made `plan cluster reorder` ineffective for collapsed packets. Enrich-quality scoping also admitted empty historical clusters despite being documented as current-cycle scoped.

## Fix

- Order collapsed manual clusters by their first live member in `plan["queue_order"]`, with a stable fallback for unqueued packets.
- Scope enrich/sense-check quality checks only to clusters overlapping the active triage issue IDs.
- Add direct regressions for both behaviors.

## Validation

- `python3 -m pytest -q desloppify/tests/review/test_work_queue_plan_order_and_triage.py desloppify/tests/plan/test_auto_cluster.py desloppify/tests/commands/plan/test_triage_split_modules_direct.py` — 118 passed
- `python3 -m ruff check --select F ...`
- `python3 -m py_compile ...`
- `git diff --check`
