### PR TITLE
fix: allow targeted review batch imports

### DIFF
--- a/desloppify/app/commands/review/batch/execution_results.py
+++ b/desloppify/app/commands/review/batch/execution_results.py
@@ -223,9 +223,15 @@ def enforce_import_coverage(
     scan_path: str,
     colorize_fn,
 ) -> None:
-    """Apply trusted import coverage gate after merge output is written."""
+    """Apply trusted import coverage gate to the requested review dimensions."""
+    requested_dimensions = set(packet_dimensions)
+    missing_requested_dimensions = [
+        dimension
+        for dimension in missing_after_import
+        if dimension in requested_dimensions
+    ]
     enforce_trusted_import_coverage_gate(
-        missing_dims=missing_after_import,
+        missing_dims=missing_requested_dimensions,
         selected_dims=packet_dimensions,
         allow_partial=allow_partial,
         scan_path=scan_path,

--- a/desloppify/tests/commands/review/test_review_batch_execution_helpers_direct.py
+++ b/desloppify/tests/commands/review/test_review_batch_execution_helpers_direct.py
@@ -228,6 +228,29 @@ def test_merge_and_finalize_helpers(tmp_path: Path, monkeypatch) -> None:
     assert any("run-finished" in line for line in logs)
 
 
+def test_enforce_import_coverage_allows_unrelated_dimension_gaps() -> None:
+    """A targeted review need only assess the dimensions it requested."""
+    results_mod.enforce_import_coverage(
+        missing_after_import=["naming_quality", "type_safety"],
+        packet_dimensions=["mid_level_elegance"],
+        allow_partial=False,
+        scan_path=".",
+        colorize_fn=lambda text, _tone=None: text,
+    )
+
+
+def test_enforce_import_coverage_blocks_missing_requested_dimension() -> None:
+    """A full packet still cannot import when one of its dimensions is absent."""
+    with pytest.raises(CommandError, match="incomplete selected-dimension coverage"):
+        results_mod.enforce_import_coverage(
+            missing_after_import=["type_safety"],
+            packet_dimensions=["mid_level_elegance", "type_safety"],
+            allow_partial=False,
+            scan_path=".",
+            colorize_fn=lambda text, _tone=None: text,
+        )
+
+
 def test_import_and_finalize_raises_when_followup_scan_fails(tmp_path: Path) -> None:
     merged_path = tmp_path / "merged.json"
     merged_path.write_text("{}")


### PR DESCRIPTION
## Problem

A review run intentionally limited with --dimensions completed its batches and merged valid results, but import failed because the trusted-import coverage gate treated every globally unassessed dimension as missing. This made targeted review batches require --allow-partial even when every requested dimension was present.

## Fix

Apply the coverage gate only to dimensions in the immutable review packet. The regression tests prove unrelated global gaps are allowed while a missing requested dimension still fails.

## Verification

PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="/tmp/desloppify-review-subset-fix" python3 -m pytest -q -p no:cacheprovider desloppify/tests/commands/review/test_review_batch_execution_helpers_direct.py