### PR TITLE
fix: preserve jscpd reports above project threshold

### DIFF
--- a/desloppify/engine/detectors/jscpd_adapter.py
+++ b/desloppify/engine/detectors/jscpd_adapter.py
@@ -248,6 +248,9 @@ def detect_with_jscpd(path: Path) -> list[dict] | None:
                     "4",
                     "--min-tokens",
                     "50",
+                    # The report is the result; project thresholds must not hide it.
+                    "--threshold",
+                    "100",
                     "--ignore",
                     _jscpd_ignore_arg(path),
                     "--silent",

--- a/desloppify/tests/detectors/test_external_adapters.py
+++ b/desloppify/tests/detectors/test_external_adapters.py
@@ -767,6 +767,27 @@ class TestJscpdAdapter:
             result = detect_with_jscpd(tmp_path)
         assert result == []
 
+    def test_detect_command_disables_jscpd_threshold_failure(self, tmp_path):
+        report_file = tmp_path / "jscpd-report.json"
+        report_file.write_text(json.dumps({"duplicates": []}))
+
+        def _fake_run(cmd, **kwargs):
+            assert cmd[cmd.index("--threshold") + 1] == "100"
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch(
+            "desloppify.engine.detectors.jscpd_adapter._resolve_jscpd_command",
+            return_value=["/usr/bin/npx", "--yes", "jscpd"],
+        ), patch(
+            "desloppify.engine.detectors.jscpd_adapter._run_jscpd_command",
+            side_effect=_fake_run,
+        ), patch("tempfile.TemporaryDirectory") as mock_td:
+            mock_td.return_value.__enter__.return_value = str(tmp_path)
+            mock_td.return_value.__exit__.return_value = None
+            result = detect_with_jscpd(tmp_path)
+
+        assert result == []
+
 
 # ── Extended ruff smells adapter ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

The jscpd adapter inherits a repository's `.jscpd.json` threshold. When
duplication exceeds that threshold, jscpd writes a valid JSON report and exits
1. Desloppify currently treats that as an execution failure and discards the
report, so scans warn that duplication detection was skipped.

Minimal reproduction:

1. Configure jscpd with `"threshold": 0`.
2. Scan a project containing a duplicate block.
3. Observe that jscpd writes `jscpd-report.json` but desloppify reports
   `jscpd exited with errors` and imports no clusters.

## Fix

Run jscpd with `--threshold 100`. Desloppify consumes the report itself, so a
project-level CI threshold must not prevent the adapter from reading valid
results.

## Verification

- Added a regression test that failed before the threshold override.
- `14 passed` for the jscpd adapter tests.
- `6823 passed, 17 skipped` for the full test suite with full extras installed.
- Verified against a real TypeScript monorepo: the warning disappeared and
  duplication clusters were imported.
