### PR TITLE
fix: honor configured queue target

### DIFF
--- a/desloppify/app/commands/plan/triage/confirmations/enrich.py
+++ b/desloppify/app/commands/plan/triage/confirmations/enrich.py
@@ -7,19 +7,25 @@ import argparse
 from desloppify.base.output.terminal import colorize
 from desloppify.base.output.user_message import print_user_message
 
+from ..services import TriageServices, default_triage_services
+from ..stages.helpers import (
+    active_triage_issue_scope,
+    scoped_manual_clusters_with_issues,
+)
+from ..validation.enrich_quality import (
+    EnrichQualityIssue as _ConfirmationCheckIssue,
+)
+from ..validation.enrich_quality import (
+    EnrichQualityReport as _ConfirmationCheckReport,
+)
+from ..validation.enrich_quality import (
+    evaluate_enrich_quality,
+)
 from .basic import MIN_ATTESTATION_LEN, validate_attestation
 from .shared import (
     StageConfirmationRequest,
     ensure_stage_is_confirmable,
     finalize_stage_confirmation,
-)
-from ..services import TriageServices, default_triage_services
-from ..stages.helpers import scoped_manual_clusters_with_issues
-from ..review_coverage import active_triage_issue_ids
-from ..validation.enrich_quality import (
-    EnrichQualityIssue as _ConfirmationCheckIssue,
-    EnrichQualityReport as _ConfirmationCheckReport,
-    evaluate_enrich_quality,
 )
 
 
@@ -179,7 +185,7 @@ def confirm_enrich(
     checks = _collect_enrich_level_confirmation_checks(
         plan,
         include_stale_issue_ref_warning=True,
-        triage_issue_ids=active_triage_issue_ids(plan, state) or None,
+        triage_issue_ids=active_triage_issue_scope(plan, state),
     )
 
     print(colorize("  Stage: ENRICH — Make steps executor-ready (detail, refs)", "bold"))
@@ -232,7 +238,7 @@ def confirm_sense_check(
     checks = _collect_enrich_level_confirmation_checks(
         plan,
         include_stale_issue_ref_warning=False,
-        triage_issue_ids=active_triage_issue_ids(plan, state) or None,
+        triage_issue_ids=active_triage_issue_scope(plan, state),
     )
 
     print(colorize("  Stage: SENSE-CHECK — Verify accuracy & cross-cluster deps", "bold"))

--- a/desloppify/app/commands/plan/triage/runner/stage_validation.py
+++ b/desloppify/app/commands/plan/triage/runner/stage_validation.py
@@ -7,26 +7,16 @@ from pathlib import Path
 
 from desloppify.engine.plan_triage import TriageInput
 
+from ..completion_flow import count_log_activity_since
+from ..observe_batches import observe_dimension_breakdown
+from ..review_coverage import cluster_issue_ids, open_review_ids_from_state
 from ..stages.evidence_parsing import (
     parse_observe_evidence,
+    parse_value_check_decision_ledger,
     validate_observe_evidence,
     validate_reflect_skip_evidence,
     validate_report_has_file_paths,
     validate_report_references_clusters,
-)
-from ..validation.enrich_quality import evaluate_enrich_quality
-from ..validation.completion_policy import evaluate_completion_readiness
-from ..validation.enrich_checks import (
-    _cluster_file_overlaps,
-    _clusters_with_directory_scatter,
-    _clusters_with_high_step_ratio,
-)
-from ..completion_flow import count_log_activity_since
-from ..observe_batches import observe_dimension_breakdown
-from ..review_coverage import (
-    active_triage_issue_ids,
-    cluster_issue_ids,
-    open_review_ids_from_state,
 )
 from ..stages.helpers import (
     active_triage_issue_scope,
@@ -35,7 +25,13 @@ from ..stages.helpers import (
     unenriched_clusters,
     value_check_targets,
 )
-from ..stages.evidence_parsing import parse_value_check_decision_ledger
+from ..validation.completion_policy import evaluate_completion_readiness
+from ..validation.enrich_checks import (
+    _cluster_file_overlaps,
+    _clusters_with_directory_scatter,
+    _clusters_with_high_step_ratio,
+)
+from ..validation.enrich_quality import evaluate_enrich_quality
 
 
 @dataclass(frozen=True)
@@ -238,7 +234,7 @@ def _validate_enrich_stage(
         plan,
         repo_root,
         phase_label="enrich",
-        triage_issue_ids=active_triage_issue_ids(plan, state) or None,
+        triage_issue_ids=active_triage_issue_scope(plan, state),
     )
     if failures:
         return False, failures[0].message
@@ -260,7 +256,7 @@ def _validate_sense_check_stage(
     if len(report) < 100:
         return False, f"Sense-check report too short ({len(report)} chars, need 100+)."
     manual_clusters = scoped_manual_clusters_with_issues(plan, state)
-    triage_issue_ids = active_triage_issue_ids(plan, state) or None
+    triage_issue_ids = active_triage_issue_scope(plan, state)
     triage_scope = active_triage_issue_scope(plan, state)
     open_review_ids = open_review_ids_from_state(state) if triage_scope is None else triage_scope
     if not open_review_ids and not manual_clusters:

--- a/desloppify/app/commands/plan/triage/stages/enrich.py
+++ b/desloppify/app/commands/plan/triage/stages/enrich.py
@@ -11,8 +11,12 @@ from desloppify.base.output.terminal import colorize
 from desloppify.base.output.user_message import print_user_message
 from desloppify.engine.plan_triage import compute_triage_progress
 
-from .records import record_enrich_stage, resolve_reusable_report
-from ..validation.enrich_quality import evaluate_enrich_quality
+from ..completion_flow import count_log_activity_since
+from ..review_coverage import (
+    open_review_ids_from_state,
+)
+from ..services import TriageServices, default_triage_services
+from ..stage_queue import has_triage_in_queue, print_cascade_clear_feedback
 from ..validation.enrich_checks import (
     _enrich_report_or_error,
     _require_organize_stage_for_enrich,
@@ -20,13 +24,9 @@ from ..validation.enrich_checks import (
     _steps_without_effort,
     _underspecified_steps,
 )
-from ..completion_flow import count_log_activity_since
-from ..review_coverage import (
-    active_triage_issue_ids,
-    open_review_ids_from_state,
-)
-from ..stage_queue import has_triage_in_queue, print_cascade_clear_feedback
-from ..services import TriageServices, default_triage_services
+from ..validation.enrich_quality import evaluate_enrich_quality
+from .helpers import active_triage_issue_scope
+from .records import record_enrich_stage, resolve_reusable_report
 
 ColorizeFn = Callable[[str, str], str]
 
@@ -120,7 +120,11 @@ def _require_cluster_update_activity(
         return True
     activity = deps.count_log_activity_since(plan, organize_ts)
     update_ops = activity.get("cluster_update", 0)
-    if update_ops != 0 or not open_review_ids_from_state(state):
+    triage_scope = active_triage_issue_scope(plan, state)
+    open_review_ids = (
+        open_review_ids_from_state(state) if triage_scope is None else triage_scope
+    )
+    if update_ops != 0 or not open_review_ids:
         return True
     if attestation and len(attestation.strip()) >= 40:
         print(
@@ -268,7 +272,7 @@ def run_stage_enrich(
     if get_project_root is None:
         from desloppify.base.discovery.paths import get_project_root
 
-    triage_ids = active_triage_issue_ids(plan, state) or None
+    triage_ids = active_triage_issue_scope(plan, state)
     quality_report = evaluate_enrich_quality(
         plan,
         get_project_root(),

--- a/desloppify/app/commands/plan/triage/stages/organize.py
+++ b/desloppify/app/commands/plan/triage/stages/organize.py
@@ -6,15 +6,11 @@ import argparse
 
 from desloppify.base.output.terminal import colorize
 
-from ..display.dashboard import print_organize_result
 from ..completion_flow import count_log_activity_since
+from ..display.dashboard import print_organize_result
 from ..review_coverage import open_review_ids_from_state
-from ..stage_queue import has_triage_in_queue
 from ..services import TriageServices, default_triage_services
-from ..validation.stage_policy import (
-    ReflectAutoConfirmDeps,
-    auto_confirm_reflect_for_organize,
-)
+from ..stage_queue import has_triage_in_queue
 from ..validation.organize_policy import (
     _clusters_enriched_or_error,
     _manual_clusters_or_error,
@@ -23,7 +19,12 @@ from ..validation.organize_policy import (
     _validate_organize_against_ledger_or_error,
     validate_backlog_promotions_executed,
 )
-from ..validation.stage_policy import require_prerequisite
+from ..validation.stage_policy import (
+    ReflectAutoConfirmDeps,
+    auto_confirm_reflect_for_organize,
+    require_prerequisite,
+)
+from .helpers import active_triage_issue_scope, triage_scoped_plan
 from .records import record_organize_stage
 
 
@@ -110,7 +111,10 @@ def _validate_organize_submission(
     is_reuse: bool,
     services: TriageServices,
 ) -> tuple[list[str], str] | None:
-    open_review_ids = open_review_ids_from_state(state)
+    triage_scope = active_triage_issue_scope(plan, state)
+    open_review_ids = (
+        open_review_ids_from_state(state) if triage_scope is None else triage_scope
+    )
     triage_input = services.collect_triage_input(plan, state)
     if not auto_confirm_reflect_for_organize(
         args=args,
@@ -125,7 +129,10 @@ def _validate_organize_submission(
     ):
         return None
 
-    manual_clusters = _manual_clusters_or_error(plan, open_review_ids=open_review_ids)
+    manual_clusters = _manual_clusters_or_error(
+        triage_scoped_plan(plan, state),
+        open_review_ids=open_review_ids,
+    )
     if manual_clusters is None:
         return None
     if not _clusters_enriched_or_error(plan, state):
@@ -233,7 +240,10 @@ def _cmd_stage_organize(
 
     runtime = resolved_services.command_runtime(args)
     state = runtime.state
-    open_review_ids = open_review_ids_from_state(state)
+    triage_scope = active_triage_issue_scope(plan, state)
+    open_review_ids = (
+        open_review_ids_from_state(state) if triage_scope is None else triage_scope
+    )
 
     validated = _validate_organize_submission(
         args=args,

--- a/desloppify/app/commands/plan/triage/stages/sense_check.py
+++ b/desloppify/app/commands/plan/triage/stages/sense_check.py
@@ -9,9 +9,9 @@ from pathlib import Path
 
 from desloppify.base.output.terminal import colorize
 
-from .records import record_sense_check_stage, resolve_reusable_report
-from .helpers import value_check_targets
-from ..validation.enrich_quality import evaluate_enrich_quality
+from ..review_coverage import open_review_ids_from_state
+from ..services import TriageServices, default_triage_services
+from ..stage_queue import has_triage_in_queue, print_cascade_clear_feedback
 from ..validation.enrich_checks import (
     _steps_missing_issue_refs,
     _steps_with_bad_paths,
@@ -19,10 +19,14 @@ from ..validation.enrich_checks import (
     _steps_without_effort,
     _underspecified_steps,
 )
-from ..review_coverage import active_triage_issue_ids, open_review_ids_from_state
-from ..stage_queue import has_triage_in_queue, print_cascade_clear_feedback
-from ..services import TriageServices, default_triage_services
+from ..validation.enrich_quality import evaluate_enrich_quality
 from .enrich import ColorizeFn
+from .helpers import (
+    active_triage_issue_scope,
+    scoped_manual_clusters_with_issues,
+    value_check_targets,
+)
+from .records import record_sense_check_stage, resolve_reusable_report
 
 
 @dataclass(frozen=True)
@@ -66,7 +70,7 @@ def _sense_check_quality_problems(
         from desloppify.base.discovery.paths import get_project_root
 
     repo_root = get_project_root()
-    triage_ids = active_triage_issue_ids(plan, state) or None
+    triage_ids = active_triage_issue_scope(plan, state)
     quality_report = evaluate_enrich_quality(
         plan,
         repo_root,
@@ -118,13 +122,15 @@ def _sense_check_evidence_failures(
         validate_report_has_file_paths,
         validate_report_references_clusters,
     )
-    from ..review_coverage import manual_clusters_with_issues
-
     failures: list[object] = []
-    if open_review_ids_from_state(state):
+    triage_scope = active_triage_issue_scope(plan, state)
+    open_review_ids = (
+        open_review_ids_from_state(state) if triage_scope is None else triage_scope
+    )
+    if open_review_ids:
         failures.extend(validate_report_has_file_paths(report) or [])
 
-    cluster_names = manual_clusters_with_issues(plan)
+    cluster_names = scoped_manual_clusters_with_issues(plan, state)
     if cluster_names:
         failures.extend(validate_report_references_clusters(report, cluster_names) or [])
 

--- a/desloppify/app/commands/plan/triage/stages/strategize.py
+++ b/desloppify/app/commands/plan/triage/stages/strategize.py
@@ -140,7 +140,14 @@ def _create_strategic_work_items(
     plan: dict,
     strategic_issues: list[dict],
 ) -> None:
-    """Create work items in state and insert IDs at front of queue_order."""
+    """Create work items in state and insert IDs at front of queue_order.
+
+    A strategist can reuse an identifier from an older cycle.  Existing skips,
+    especially protected false-positive and permanent skips, are deliberate
+    plan intent and must not be silently revived by a generated report.  The
+    new assessment remains available in the strategist briefing, while the
+    skipped ID stays out of the execution queue.
+    """
     work_items = state.setdefault("work_items", {})
     if not work_items:
         issues = state.get("issues")
@@ -150,10 +157,13 @@ def _create_strategic_work_items(
             state["work_items"] = work_items
 
     queue_order = plan.setdefault("queue_order", [])
+    skipped = plan.setdefault("skipped", {})
     new_ids: list[str] = []
 
     for entry in strategic_issues:
         issue_id = f"strategy::{entry['identifier']}"
+        if issue_id in skipped:
+            continue
         work_items[issue_id] = {
             "status": "open",
             "detector": "strategy",

--- a/desloppify/app/commands/plan/triage/validation/enrich_quality.py
+++ b/desloppify/app/commands/plan/triage/validation/enrich_quality.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+from ..review_coverage import cluster_issue_ids
 from .enrich_checks import (
     _steps_missing_issue_refs,
     _steps_referencing_skipped_issues,
@@ -14,7 +15,6 @@ from .enrich_checks import (
     _steps_without_effort,
     _underspecified_steps,
 )
-from ..review_coverage import cluster_issue_ids
 
 Severity = Literal["failure", "warning"]
 
@@ -77,17 +77,18 @@ def _active_cluster_names(plan: dict, triage_issue_ids: set[str]) -> set[str]:
     return {
         name
         for name, cluster in plan.get("clusters", {}).items()
-        if not cluster_issue_ids(cluster)
-        or set(cluster_issue_ids(cluster)) & triage_issue_ids
+        if set(cluster_issue_ids(cluster)) & triage_issue_ids
     }
 
 
 def _scoped_plan(plan: dict, triage_issue_ids: set[str] | None) -> dict:
     """Narrow plan to only clusters relevant to the current triage cycle.
 
-    Returns the original plan unchanged when no triage scoping is needed.
+    ``None`` means no triage scoping is needed.  An empty set means a frozen
+    triage cycle has no remaining live issues, so no historical clusters may
+    leak back into validation.
     """
-    if not triage_issue_ids:
+    if triage_issue_ids is None:
         return plan
     active = _active_cluster_names(plan, triage_issue_ids)
     return {

--- a/desloppify/engine/planning/queue_policy.py
+++ b/desloppify/engine/planning/queue_policy.py
@@ -67,7 +67,11 @@ def build_execution_queue(
     )
     return _build_work_queue_with_visibility(
         state,
-        options=replace(options, context=ctx),
+        options=replace(
+            options,
+            context=ctx,
+            subjective_threshold=ctx.target_strict,
+        ),
         visibility=QueueVisibility.EXECUTION,
     )
 
@@ -86,7 +90,11 @@ def build_backlog_queue(
     )
     return _build_work_queue_with_visibility(
         state,
-        options=replace(options, context=ctx),
+        options=replace(
+            options,
+            context=ctx,
+            subjective_threshold=ctx.target_strict,
+        ),
         visibility=QueueVisibility.BACKLOG,
     )
 

--- a/desloppify/languages/python/detectors/dict_keys/visitor.py
+++ b/desloppify/languages/python/detectors/dict_keys/visitor.py
@@ -113,7 +113,7 @@ class DictKeyVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def _check_dict_creation(self, name: str, value: ast.expr, line: int):
-        """Detect d = {}, d = dict(), d = {"k": v, ...}."""
+        """Detect local dict literals, dict(), and dict(key=value) constructors."""
         initial_keys: list[str] = []
         is_creation = False
 
@@ -144,11 +144,12 @@ class DictKeyVisitor(ast.NodeVisitor):
             isinstance(value, ast.Call)
             and isinstance(value.func, ast.Name)
             and value.func.id == "dict"
+            and not value.args
+            and all(keyword.arg is not None for keyword in value.keywords)
         ):
             is_creation = True
             for kw in value.keywords:
-                if kw.arg:
-                    initial_keys.append(kw.arg)
+                initial_keys.append(kw.arg)
 
         if is_creation:
             td = self._track(

--- a/desloppify/languages/python/detectors/dict_keys/visitor.py
+++ b/desloppify/languages/python/detectors/dict_keys/visitor.py
@@ -9,6 +9,7 @@ from desloppify.languages.python.detectors.dict_keys import (
     _get_name,
     _get_str_key,
 )
+
 from .visitor_helpers import (
     analyze_scope_issues,
     mark_assignment_escape,
@@ -90,7 +91,9 @@ class DictKeyVisitor(ast.NodeVisitor):
             target = node.targets[0]
             name = _get_name(target)
             if name:
-                self._check_dict_creation(name, node.value, node.lineno)
+                tracked = self._check_dict_creation(name, node.value, node.lineno)
+                if tracked is not None and isinstance(target, ast.Attribute):
+                    tracked.returned_or_passed = True
         # Also check for subscript writes: d["key"] = val
         for target in node.targets:
             self._check_subscript_write(target, node.lineno)
@@ -112,7 +115,12 @@ class DictKeyVisitor(ast.NodeVisitor):
         self._check_subscript_write(node.target, node.lineno)
         self.generic_visit(node)
 
-    def _check_dict_creation(self, name: str, value: ast.expr, line: int):
+    def _check_dict_creation(
+        self,
+        name: str,
+        value: ast.expr,
+        line: int,
+    ) -> TrackedDict | None:
         """Detect local dict literals, dict(), and dict(key=value) constructors."""
         initial_keys: list[str] = []
         is_creation = False
@@ -158,6 +166,8 @@ class DictKeyVisitor(ast.NodeVisitor):
             # Store as class dict if it's self.x
             if name.startswith("self.") and self._in_init_or_setup:
                 self._class_dicts[name] = td
+            return td
+        return None
 
     def _check_subscript_write(self, target: ast.expr, line: int):
         """Handle d["key"] = val or d["key"] += val."""

--- a/desloppify/languages/python/tests/test_py_dict_keys.py
+++ b/desloppify/languages/python/tests/test_py_dict_keys.py
@@ -3,6 +3,8 @@
 import textwrap
 from pathlib import Path
 
+import pytest
+
 from desloppify.languages.python.detectors import dict_keys as dict_keys_mod
 from desloppify.languages.python.detectors.dict_keys import (
     detect_dict_key_flow,
@@ -93,6 +95,43 @@ class TestPhantomRead:
         )
         entries, _ = detect_dict_key_flow(path)
         assert "phantom_read" not in _kinds(entries)
+
+    @pytest.mark.parametrize("constructor", ("dict(source)", "dict(**source)"))
+    def test_copy_constructor_does_not_assume_an_empty_local_dict(
+        self, tmp_path, constructor
+    ):
+        path = _write_py(
+            tmp_path,
+            f"""\
+            def build(source):
+                copied = {constructor}
+                value = copied["expected"]
+                return value
+        """,
+        )
+
+        entries, _ = detect_dict_key_flow(path)
+
+        assert "phantom_read" not in _kinds(entries)
+
+    @pytest.mark.parametrize("constructor", ("dict()", "dict(expected=1)"))
+    def test_empty_and_keyword_dict_constructors_still_track_reads(
+        self, tmp_path, constructor
+    ):
+        path = _write_py(
+            tmp_path,
+            f"""\
+            def build():
+                created = {constructor}
+                value = created["missing"]
+                return value
+        """,
+        )
+
+        entries, _ = detect_dict_key_flow(path)
+
+        phantom = _find_kind(entries, "phantom_read")
+        assert any(entry["key"] == "missing" for entry in phantom)
 
 
 # ── Dead writes (written key never read) ──────────────────

--- a/desloppify/languages/python/tests/test_py_dict_keys.py
+++ b/desloppify/languages/python/tests/test_py_dict_keys.py
@@ -209,6 +209,23 @@ class TestDeadWrite:
         entries, _ = detect_dict_key_flow(path)
         assert "dead_write" not in _kinds(entries)
 
+    def test_no_dead_write_when_dict_literal_assigned_to_attribute(self, tmp_path):
+        """A durable attribute assignment is an escape boundary, not local dead code."""
+        path = _write_py(
+            tmp_path,
+            """\
+            def record(receipt):
+                receipt.result_payload = {
+                    "data": 1,
+                    "error_code": None,
+                    "user_message": None,
+                    "extra": None,
+                }
+        """,
+        )
+        entries, _ = detect_dict_key_flow(path)
+        assert "dead_write" not in _kinds(entries)
+
     def test_no_dead_write_when_nested_in_list_return(self, tmp_path):
         """Dict returned inside nested list/tuple structures should be escaped."""
         path = _write_py(

--- a/desloppify/tests/commands/plan/test_strategist.py
+++ b/desloppify/tests/commands/plan/test_strategist.py
@@ -5,21 +5,20 @@ from __future__ import annotations
 import argparse
 from types import SimpleNamespace
 
-import pytest
-
 import desloppify.app.commands.plan.triage.stages.strategize as strategize_mod
-from desloppify.app.commands.plan.triage.workflow import run_triage_workflow
 from desloppify.app.cli_support.parser_groups_plan_impl_sections_triage_commit_scan import (
     _add_triage_subparser,
 )
+from desloppify.app.commands.plan.triage.stages.observe import cmd_stage_observe
+from desloppify.app.commands.plan.triage.workflow import run_triage_workflow
 from desloppify.engine._plan.constants import (
     TRIAGE_STAGE_IDS,
     confirmed_triage_stage_names,
     recorded_unconfirmed_triage_stage_names,
 )
+from desloppify.engine._plan.schema import empty_plan, validate_plan
 from desloppify.engine._plan.sync.triage import _inject_pending_triage_stages
 from desloppify.engine.plan_triage import compute_triage_progress
-from desloppify.app.commands.plan.triage.stages.observe import cmd_stage_observe
 
 
 def _services(plan: dict, state: dict):
@@ -76,6 +75,62 @@ def test_cmd_stage_strategize_persists_briefing_and_auto_confirms(monkeypatch, c
     assert record["confirmed_text"] == "auto-confirmed"
     assert events and events[0]["event_type"] == "strategist_complete"
     assert "auto-confirmed" in capsys.readouterr().out
+
+
+def test_create_strategic_work_items_preserves_matching_skipped_strategy_id() -> None:
+    """Generated reports must not silently revive an explicitly skipped ID."""
+    plan = empty_plan()
+    plan["skipped"] = {
+        "strategy::repeat": {
+            "issue_id": "strategy::repeat",
+            "kind": "false_positive",
+        }
+    }
+    state = {"work_items": {}}
+    strategic_issues = [
+        {
+            "identifier": "repeat",
+            "summary": "Fresh strategic concern",
+            "priority": "high",
+            "recommendation": "Work the newly observed concern as a bounded packet.",
+            "dimensions_affected": ["naming"],
+        }
+    ]
+
+    strategize_mod._create_strategic_work_items(
+        state,
+        plan,
+        strategic_issues,
+    )
+
+    validate_plan(plan)
+    assert "strategy::repeat" not in plan["queue_order"]
+    assert "strategy::repeat" in plan["skipped"]
+    assert "strategy::repeat" not in state["work_items"]
+
+
+def test_create_strategic_work_items_queues_new_strategy_id() -> None:
+    plan = empty_plan()
+    state = {"work_items": {}}
+    strategic_issues = [
+        {
+            "identifier": "fresh",
+            "summary": "Fresh strategic concern",
+            "priority": "high",
+            "recommendation": "Work the newly observed concern as a bounded packet.",
+            "dimensions_affected": ["naming"],
+        }
+    ]
+
+    strategize_mod._create_strategic_work_items(
+        state,
+        plan,
+        strategic_issues,
+    )
+
+    validate_plan(plan)
+    assert plan["queue_order"] == ["strategy::fresh"]
+    assert state["work_items"]["strategy::fresh"]["status"] == "open"
 
 
 def test_observe_is_blocked_until_strategize_is_recorded(capsys) -> None:

--- a/desloppify/tests/commands/plan/test_triage_runner.py
+++ b/desloppify/tests/commands/plan/test_triage_runner.py
@@ -6,9 +6,6 @@ from pathlib import Path
 
 import pytest
 
-from desloppify.app.commands.plan.triage.validation.core import (
-    _validate_reflect_issue_accounting,
-)
 from desloppify.app.commands.plan.triage.runner import codex_runner
 from desloppify.app.commands.plan.triage.runner.orchestrator_codex_pipeline_execution import (
     build_reflect_repair_prompt,
@@ -18,6 +15,9 @@ from desloppify.app.commands.plan.triage.runner.stage_validation import (
     build_auto_attestation,
     validate_completion,
     validate_stage,
+)
+from desloppify.app.commands.plan.triage.validation.core import (
+    _validate_reflect_issue_accounting,
 )
 from desloppify.engine._plan.triage.prompt import TriageInput
 
@@ -535,6 +535,45 @@ def test_validate_enrich_ignores_out_of_scope_clusters_for_frozen_triage(tmp_pat
             "review::legacy::issue": {"status": "open", "detector": "review"},
         }
     }
+    ok, msg = validate_stage("enrich", plan, state, tmp_path)
+    assert ok, msg
+
+
+def test_validate_enrich_ignores_closed_member_of_frozen_triage(tmp_path: Path) -> None:
+    """A closed frozen finding must not revive its old cluster for validation."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "current.ts").write_text("export {}")
+    plan = _plan_with_stages(enrich={"report": "x" * 150})
+    plan["epic_triage_meta"]["active_triage_issue_ids"] = [
+        "review::current::issue",
+        "review::closed::issue",
+    ]
+    plan["clusters"] = {
+        "current": {
+            "issue_ids": ["review::current::issue"],
+            "description": "current batch",
+            "action_steps": [
+                {
+                    "title": "fix current",
+                    "detail": "Update src/current.ts to simplify the active path and remove duplication. " + "x" * 30,
+                    "effort": "small",
+                    "issue_refs": ["review::current::issue"],
+                }
+            ],
+        },
+        "closed-legacy": {
+            "issue_ids": ["review::closed::issue"],
+            "description": "old batch",
+            "action_steps": [{"title": "stale empty step"}],
+        },
+    }
+    state = {
+        "issues": {
+            "review::current::issue": {"status": "open", "detector": "review"},
+            "review::closed::issue": {"status": "closed", "detector": "review"},
+        }
+    }
+
     ok, msg = validate_stage("enrich", plan, state, tmp_path)
     assert ok, msg
 

--- a/desloppify/tests/commands/plan/test_triage_split_modules_direct.py
+++ b/desloppify/tests/commands/plan/test_triage_split_modules_direct.py
@@ -329,6 +329,107 @@ def test_validate_organize_submission_passes_state_to_enrichment_gate(monkeypatc
     assert captured["state"] is state
 
 
+def test_validate_organize_submission_scopes_cluster_activity_to_live_triage(monkeypatch) -> None:
+    """Historical clusters must not inflate the current triage operation floor."""
+    captured: dict[str, object] = {}
+    plan = {
+        "epic_triage_meta": {"active_triage_issue_ids": ["review::current"]},
+        "clusters": {
+            "current": {
+                "issue_ids": ["review::current"],
+                "description": "current work",
+                "action_steps": [{"title": "current step"}],
+            },
+            "legacy": {
+                "issue_ids": ["review::legacy"],
+                "description": "historical work",
+                "action_steps": [{"title": "legacy step"}],
+            },
+        },
+    }
+    state = {
+        "issues": {
+            "review::current": {"status": "open", "detector": "review"},
+            "review::legacy": {"status": "open", "detector": "review"},
+        }
+    }
+
+    monkeypatch.setattr(
+        organize_stage_mod, "auto_confirm_reflect_for_organize", lambda **_kwargs: True
+    )
+    monkeypatch.setattr(organize_stage_mod, "_clusters_enriched_or_error", lambda *_args: True)
+    monkeypatch.setattr(
+        organize_stage_mod, "_unclustered_review_issues_or_error", lambda *_args: True
+    )
+    monkeypatch.setattr(
+        organize_stage_mod, "_validate_organize_against_ledger_or_error", lambda **_kwargs: True
+    )
+    monkeypatch.setattr(
+        organize_stage_mod, "validate_backlog_promotions_executed", lambda **_kwargs: []
+    )
+
+    def _capture_activity(**kwargs) -> bool:
+        captured["manual_clusters"] = kwargs["manual_clusters"]
+        captured["open_review_ids"] = kwargs["open_review_ids"]
+        return True
+
+    monkeypatch.setattr(organize_stage_mod, "_enforce_cluster_activity_for_organize", _capture_activity)
+
+    services = SimpleNamespace(
+        collect_triage_input=lambda _plan, _state: {},
+        detect_recurring_patterns=lambda *_args, **_kwargs: [],
+        save_plan=lambda _plan: None,
+    )
+    report = "current cluster is the live review packet and is ready for execution. " + "x" * 70
+
+    result = organize_stage_mod._validate_organize_submission(
+        args=argparse.Namespace(),
+        plan=plan,
+        state=state,
+        stages={"observe": {}, "reflect": {}},
+        report=report,
+        attestation=None,
+        is_reuse=False,
+        services=services,
+    )
+
+    assert result == (["current"], report)
+    assert captured == {
+        "manual_clusters": ["current"],
+        "open_review_ids": {"review::current"},
+    }
+
+
+def test_enrich_quality_does_not_reopen_historical_clusters_for_empty_live_scope(tmp_path) -> None:
+    """An empty frozen scope is distinct from legacy no-scope validation."""
+    from desloppify.app.commands.plan.triage.validation.enrich_quality import (
+        evaluate_enrich_quality,
+    )
+
+    plan = {
+        "clusters": {
+            "legacy": {
+                "issue_ids": ["review::legacy"],
+                "action_steps": [{"title": "underspecified legacy step"}],
+            }
+        }
+    }
+
+    report = evaluate_enrich_quality(
+        plan,
+        tmp_path,
+        phase_label="enrich",
+        bad_paths_severity="warning",
+        missing_effort_severity="warning",
+        include_missing_issue_refs=False,
+        include_vague_detail=False,
+        stale_issue_refs_severity=None,
+        triage_issue_ids=set(),
+    )
+
+    assert report.failures == []
+
+
 def test_confirm_organize_passes_state_to_enrichment_gate(monkeypatch) -> None:
     captured: dict[str, object] = {}
     state = {"issues": {"review::closed-only": {"status": "closed", "detector": "review"}}}

--- a/desloppify/tests/commands/plan/test_triage_stage_prompts_flow_direct.py
+++ b/desloppify/tests/commands/plan/test_triage_stage_prompts_flow_direct.py
@@ -191,6 +191,56 @@ def test_run_stage_enrich_handles_no_queue_and_records_stage(tmp_path, capsys) -
     assert services.save_calls >= 2
 
 
+def test_enrich_activity_gate_ignores_out_of_scope_open_reviews() -> None:
+    """Only live findings from the frozen triage cycle require a post-organize update."""
+    plan = {"epic_triage_meta": {"active_triage_issue_ids": ["review::current"]}}
+    state = {
+        "issues": {
+            "review::current": {"status": "closed", "detector": "review"},
+            "review::legacy": {"status": "open", "detector": "review"},
+        }
+    }
+    stages = {"organize": {"timestamp": "2026-03-09T00:00:00+00:00"}}
+    deps = stage_flow_enrich_mod.EnrichStageDeps(
+        count_log_activity_since=lambda _plan, _timestamp: {},
+    )
+
+    assert stage_flow_enrich_mod._require_cluster_update_activity(
+        plan=plan,
+        state=state,
+        stages=stages,
+        attestation=None,
+        deps=deps,
+    )
+
+
+def test_sense_check_evidence_rejects_legacy_only_cluster_mentions() -> None:
+    """A sense-check report must mention a cluster from the current frozen cycle."""
+    plan = {
+        "epic_triage_meta": {"active_triage_issue_ids": ["review::current"]},
+        "clusters": {
+            "current-packet": {"issue_ids": ["review::current"]},
+            "legacy-packet": {"issue_ids": ["review::legacy"]},
+        },
+    }
+    state = {
+        "issues": {
+            "review::current": {"status": "open", "detector": "review"},
+            "review::legacy": {"status": "open", "detector": "review"},
+        }
+    }
+    report = "Verified src/review_source.py lines 1-20 while reviewing legacy-packet behavior."
+
+    blocking, advisory = stage_flow_sense_mod._sense_check_evidence_failures(
+        report,
+        plan=plan,
+        state=state,
+    )
+
+    assert [failure.code for failure in blocking] == ["no_cluster_mention"]
+    assert advisory == []
+
+
 def test_record_sense_stage_and_run_stage_sense_check(tmp_path, capsys, monkeypatch) -> None:
     stages: dict = {}
     monkeypatch.setattr(

--- a/desloppify/tests/commands/test_queue_progress.py
+++ b/desloppify/tests/commands/test_queue_progress.py
@@ -458,6 +458,63 @@ def test_plan_aware_queue_breakdown_counts_execution_items_as_live():
     assert breakdown.stale_plan_ordered == 0
 
 
+def test_plan_aware_breakdown_honors_configured_subjective_target():
+    """Scan preflight sees no work when all subjective scores clear the target."""
+    from desloppify.engine._plan.schema import empty_plan
+
+    state = {
+        "config": {"target_strict_score": 85},
+        "issues": {},
+        "dimension_scores": {
+            "Init coupling": {
+                "score": 91.0,
+                "strict": 91.0,
+                "failing": 0,
+                "tier": 4,
+                "detectors": {
+                    "subjective_assessment": {
+                        "dimension_key": "initialization_coupling",
+                        "placeholder": False,
+                    },
+                },
+            },
+            "Dep health": {
+                "score": 94.0,
+                "strict": 94.0,
+                "failing": 0,
+                "tier": 4,
+                "detectors": {
+                    "subjective_assessment": {
+                        "dimension_key": "dependency_health",
+                        "placeholder": False,
+                    },
+                },
+            },
+        },
+        "subjective_assessments": {
+            "initialization_coupling": {
+                "score": 91.0,
+                "needs_review_refresh": True,
+            },
+            "dependency_health": {
+                "score": 94.0,
+                "needs_review_refresh": True,
+            },
+        },
+    }
+    plan = empty_plan()
+    plan["plan_start_scores"] = {"strict": 81.2}
+    plan["refresh_state"] = {
+        "lifecycle_phase": "plan",
+        "postflight_scan_completed_at_scan_count": 1,
+        "subjective_review_completed_at_scan_count": 1,
+    }
+
+    breakdown = plan_aware_queue_breakdown(state, plan=plan)
+
+    assert breakdown.queue_total == 0
+
+
 # ── print_frozen_score_with_queue_context ────────────────────
 
 

--- a/desloppify/tests/review/test_work_queue_plan_order_and_triage.py
+++ b/desloppify/tests/review/test_work_queue_plan_order_and_triage.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from desloppify.engine._plan.refresh_lifecycle import carry_forward_subjective_review
+from desloppify.engine._work_queue.core import QueueBuildOptions
+from desloppify.engine._work_queue.core import build_work_queue as _build_work_queue
 from desloppify.engine.planning.queue_policy import (
     build_backlog_queue,
     build_execution_queue,
 )
-from desloppify.engine._work_queue.core import QueueBuildOptions
-from desloppify.engine._work_queue.core import build_work_queue as _build_work_queue
 
 
 def build_work_queue(state, **kwargs):
@@ -528,6 +528,60 @@ def test_backlog_queue_excludes_execution_objective_items():
     assert "smells::src/a.py::planned" not in ids
     assert "smells::src/b.py::unplanned" in ids
     assert "workflow::run-scan" not in ids
+
+
+def test_policy_queues_honor_configured_subjective_threshold():
+    """All plan queue views use the configured strict target, not 100.0."""
+    from desloppify.engine._plan.schema import empty_plan
+
+    state = _state(
+        [],
+        dimension_scores={
+            "Init coupling": {
+                "score": 91.0,
+                "strict": 91.0,
+                "failing": 0,
+                "tier": 4,
+                "detectors": {
+                    "subjective_assessment": {
+                        "dimension_key": "initialization_coupling",
+                        "placeholder": False,
+                    },
+                },
+            },
+            "Dep health": {
+                "score": 94.0,
+                "strict": 94.0,
+                "failing": 0,
+                "tier": 4,
+                "detectors": {
+                    "subjective_assessment": {
+                        "dimension_key": "dependency_health",
+                        "placeholder": False,
+                    },
+                },
+            },
+        },
+    )
+    state["config"] = {"target_strict_score": 85}
+    state["subjective_assessments"] = {
+        "initialization_coupling": {"score": 91.0, "needs_review_refresh": True},
+        "dependency_health": {"score": 94.0, "needs_review_refresh": True},
+    }
+    plan = empty_plan()
+    plan["plan_start_scores"] = {"strict": 81.2}
+    plan["refresh_state"] = {
+        "lifecycle_phase": "plan",
+        "postflight_scan_completed_at_scan_count": 1,
+        "subjective_review_completed_at_scan_count": 1,
+    }
+    options = QueueBuildOptions(count=None, include_subjective=True, plan=plan)
+
+    execution = build_execution_queue(state, options=options)
+    backlog = build_backlog_queue(state, options=options)
+
+    assert execution["items"] == []
+    assert backlog["items"] == []
 
 
 def test_unplanned_objective_items_dont_block_postflight():


### PR DESCRIPTION
## Problem
Plan queue rendering and scan preflight constructed a queue context with the configured strict target, but retained QueueBuildOptions.subjective_threshold at its default of 100. This surfaced stale 91/94 subjective scores as false work for a configured target of 85, while next used the configured target.

## Fix
Normalize execution and backlog queue options to the context target before queue construction. Added regression coverage for both policy queues and plan-aware preflight breakdowns.

## Verification
- python3 -m pytest -q desloppify/tests/review/test_work_queue_plan_order_and_triage.py desloppify/tests/commands/test_queue_progress.py desloppify/tests/commands/scan/test_scan_preflight.py
- python3 -m ruff check desloppify/engine/planning/queue_policy.py desloppify/tests/review/test_work_queue_plan_order_and_triage.py desloppify/tests/commands/test_queue_progress.py