### PR TITLE
fix: honor nested Python roots and scan exclusions

### DIFF
--- a/desloppify/base/discovery/source.py
+++ b/desloppify/base/discovery/source.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import os
-from contextlib import contextmanager
 from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -139,6 +139,7 @@ def collect_exclude_dirs(
     resolves each against *scan_root*. Filters out glob patterns (``*`` in name)
     since most CLI tools want plain directory paths.
     """
+    scan_root = scan_root.resolve()
     resolved_exclusions = (
         extra_exclusions
         if extra_exclusions is not None

--- a/desloppify/languages/_framework/base/shared_phases_review.py
+++ b/desloppify/languages/_framework/base/shared_phases_review.py
@@ -11,17 +11,15 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger(__name__)
-
 from desloppify.base.discovery.file_paths import rel
 from desloppify.base.output.terminal import log
+from desloppify.engine._state.filtering import make_issue
 from desloppify.engine.detectors.dupes import detect_duplicates
 from desloppify.engine.detectors.jscpd_adapter import detect_with_jscpd
 from desloppify.engine.detectors.security.detector import (
     detect_security_issues as _detect_security_issues_default,
 )
 from desloppify.engine.detectors.test_coverage.detector import detect_test_coverage
-from desloppify.engine._state.filtering import make_issue
 from desloppify.engine.policy.zones import EXCLUDED_ZONES, filter_entries
 from desloppify.languages._framework.base.types import (
     DetectorCoverageStatus,
@@ -41,11 +39,13 @@ from .shared_phases_helpers import (
     _record_detector_coverage,
 )
 
+logger = logging.getLogger(__name__)
+
 # Compatibility export for language phase modules that still import the raw
 # security detector symbol from this module.
 detect_security_issues = _detect_security_issues_default
 
-_DETECTOR_CACHE_VERSION = 1
+_DETECTOR_CACHE_VERSION = 2
 _PREFETCH_ATTR = "_shared_review_prefetch_futures"
 _FUNCTION_CACHE_ATTR = "_shared_review_function_cache"
 _PREFETCH_BOILERPLATE_KEY = "boilerplate"

--- a/desloppify/languages/python/test_coverage.py
+++ b/desloppify/languages/python/test_coverage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import os
 import re
 
@@ -16,6 +17,14 @@ _PY_DEF_RE = re.compile(r"^\s*(?:async\s+)?def\s+", re.MULTILINE)
 PY_IMPORT_RE = re.compile(
     r"^\s*(?:from\s+([\w.]+)\s+import\s+\(?\s*(\w+)|import\s+([\w.]+))",
     re.MULTILINE,
+)
+PY_SCRIPT_LITERAL_RE = re.compile(
+    r"""(?P<quote>["'])(?P<path>[^"' \t\r\n]+\.py)(?P=quote)"""
+)
+PY_DYNAMIC_TEST_LOADERS = (
+    "spec_from_file_location(",
+    "runpy.run_path(",
+    "run_path(",
 )
 
 ASSERT_PATTERNS = [
@@ -58,6 +67,36 @@ def resolve_import_spec(
     spec: str, test_path: str, production_files: set[str]
 ) -> str | None:
     """Best-effort module-spec to source-file resolution for direct imports."""
+    normalized_spec = spec.strip().replace("\\", "/")
+    if normalized_spec.endswith(".py"):
+        relative_spec = normalized_spec.lstrip("./")
+        exact_matches = {
+            source
+            for source in production_files
+            if source.replace("\\", "/") == relative_spec
+        }
+        if len(exact_matches) == 1:
+            return next(iter(exact_matches))
+
+        if "/" in relative_spec:
+            suffix_matches = {
+                source
+                for source in production_files
+                if source.replace("\\", "/").endswith(f"/{relative_spec}")
+            }
+            if len(suffix_matches) == 1:
+                return next(iter(suffix_matches))
+
+        script_name = normalized_spec.rsplit("/", 1)[-1]
+        script_matches = {
+            source
+            for source in production_files
+            if source.replace("\\", "/").rsplit("/", 1)[-1] == script_name
+        }
+        if len(script_matches) == 1:
+            return next(iter(script_matches))
+        return None
+
     module_path = spec.strip().replace(".", "/")
     if not module_path or module_path.startswith("/"):
         return None
@@ -78,6 +117,18 @@ def resolve_import_spec(
             sibling = os.path.join(os.path.dirname(test_path), candidate)
             if sibling in production_files:
                 return sibling
+
+    # Repository layouts often place an import root below an operational
+    # directory, for example backend/app with tests importing app.*. Resolve
+    # that shape only when the suffix identifies one production module.
+    normalized_candidates = tuple(f"/{candidate}" for candidate in candidates)
+    suffix_matches = {
+        source
+        for source in production_files
+        if source.replace("\\", "/").endswith(normalized_candidates)
+    }
+    if len(suffix_matches) == 1:
+        return next(iter(suffix_matches))
     return None
 
 
@@ -105,7 +156,37 @@ def parse_test_import_specs(content: str) -> list[str]:
             specs.append(package)
             if imported_name:
                 specs.append(f"{package}.{imported_name}")
+    if any(loader in content for loader in PY_DYNAMIC_TEST_LOADERS):
+        specs.extend(_parse_dynamic_script_specs(content))
     return specs
+
+
+def _parse_dynamic_script_specs(content: str) -> list[str]:
+    try:
+        tree = ast.parse(content)
+    except SyntaxError:
+        return [
+            match.group("path") for match in PY_SCRIPT_LITERAL_RE.finditer(content)
+        ]
+
+    specs: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if node.value.endswith(".py"):
+                specs.add(node.value)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            parts = _path_literal_parts(node)
+            if parts and parts[-1].endswith(".py"):
+                specs.add("/".join(parts))
+    return sorted(specs)
+
+
+def _path_literal_parts(node: ast.AST) -> list[str]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+        return _path_literal_parts(node.left) + _path_literal_parts(node.right)
+    return []
 
 
 def map_test_to_source(test_path: str, production_set: set[str]) -> str | None:

--- a/desloppify/languages/python/tests/test_py_test_coverage.py
+++ b/desloppify/languages/python/tests/test_py_test_coverage.py
@@ -1,0 +1,131 @@
+"""Tests for Python-specific static test coverage mapping."""
+
+from desloppify.languages.python.test_coverage import (
+    parse_test_import_specs,
+    resolve_import_spec,
+)
+
+
+def test_resolve_import_spec_finds_unique_repository_source_root() -> None:
+    production_files = {
+        "backend/app/routers/alignment.py",
+        "backend/app/services/sync_fix.py",
+    }
+
+    assert (
+        resolve_import_spec(
+            "app.routers.alignment",
+            "backend/tests/test_alignment_router.py",
+            production_files,
+        )
+        == "backend/app/routers/alignment.py"
+    )
+    assert (
+        resolve_import_spec(
+            "app.services.sync_fix",
+            "backend/tests/test_sync_fix_service.py",
+            production_files,
+        )
+        == "backend/app/services/sync_fix.py"
+    )
+
+
+def test_resolve_import_spec_rejects_ambiguous_source_roots() -> None:
+    production_files = {
+        "backend/app/services/sync_fix.py",
+        "legacy/app/services/sync_fix.py",
+    }
+
+    assert (
+        resolve_import_spec(
+            "app.services.sync_fix",
+            "tests/test_sync_fix_service.py",
+            production_files,
+        )
+        is None
+    )
+
+
+def test_parse_test_import_specs_finds_dynamic_python_script_targets() -> None:
+    content = """
+import importlib.util
+import runpy
+from pathlib import Path
+
+WORKER_PATH = Path(__file__).parents[1] / "cli" / "sync_worker.py"
+spec = importlib.util.spec_from_file_location("sync_worker_test", WORKER_PATH)
+runpy.run_path(str(Path(__file__).parents[2] / "launch.py"))
+"""
+
+    specs = parse_test_import_specs(content)
+
+    assert "sync_worker.py" in specs
+    assert "launch.py" in specs
+
+
+def test_parse_test_import_specs_preserves_dynamic_script_path_suffix() -> None:
+    content = """
+import importlib.util
+from pathlib import Path
+
+HELPER_PATH = (
+    Path(__file__).parents[2]
+    / "backend"
+    / "crusoe_runtime"
+    / "crusoe_helper.py"
+)
+spec = importlib.util.spec_from_file_location("helper_test", HELPER_PATH)
+"""
+
+    assert (
+        "backend/crusoe_runtime/crusoe_helper.py"
+        in parse_test_import_specs(content)
+    )
+
+
+def test_resolve_import_spec_finds_unique_dynamic_python_script() -> None:
+    production_files = {
+        "backend/cli/sync_worker.py",
+        "backend/app/services/sync_fix.py",
+    }
+
+    assert (
+        resolve_import_spec(
+            "sync_worker.py",
+            "backend/tests/test_sync_worker.py",
+            production_files,
+        )
+        == "backend/cli/sync_worker.py"
+    )
+
+
+def test_resolve_import_spec_prefers_exact_root_script_path() -> None:
+    production_files = {
+        "qwen.py",
+        "backend/app/services/qwen.py",
+    }
+
+    assert (
+        resolve_import_spec(
+            "qwen.py",
+            "backend/tests/test_qwen_captioner_scripts.py",
+            production_files,
+        )
+        == "qwen.py"
+    )
+
+
+def test_resolve_import_spec_rejects_ambiguous_dynamic_python_script() -> None:
+    production_files = {
+        "backend/cli/sync_worker.py",
+        "legacy/cli/sync_worker.py",
+    }
+
+    assert (
+        resolve_import_spec(
+            "sync_worker.py",
+            "backend/tests/test_sync_worker.py",
+            production_files,
+        )
+        is None
+    )

--- a/desloppify/tests/detectors/test_external_adapters.py
+++ b/desloppify/tests/detectors/test_external_adapters.py
@@ -962,6 +962,19 @@ class TestCollectExcludeDirs:
             result = collect_exclude_dirs(tmp_path)
         assert all(p.startswith(str(tmp_path)) for p in result)
 
+    def test_resolves_relative_scan_root_before_building_paths(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        with patch(
+            "desloppify.base.discovery.source.get_exclusions",
+            return_value=("vendor",),
+        ):
+            result = collect_exclude_dirs(Path("."))
+
+        assert all(Path(path).is_absolute() for path in result)
+        assert str(tmp_path / "vendor") in result
+
     def test_includes_default_non_glob_entries(self, tmp_path):
         with patch(
             "desloppify.base.discovery.source.get_exclusions", return_value=()

--- a/desloppify/tests/lang/common/test_framework_shared_phases_and_structural_split_direct.py
+++ b/desloppify/tests/lang/common/test_framework_shared_phases_and_structural_split_direct.py
@@ -293,6 +293,21 @@ def test_phase_security_reuses_lang_security_cache(monkeypatch, tmp_path) -> Non
     assert second_potentials == {"security": 3}
 
 
+def test_security_cache_rejects_previous_detector_version() -> None:
+    cached = review_mod._load_cached_security_result(
+        {
+            "version": 1,
+            "fingerprint": "same",
+            "entries": [],
+            "files_scanned": 1,
+            "coverage": None,
+        },
+        fingerprint="same",
+    )
+
+    assert cached is None
+
+
 def test_phase_security_uses_prefetched_lang_result(monkeypatch, tmp_path) -> None:
     class _ImmediateExecutor:
         def submit(self, fn, *args, **kwargs):


### PR DESCRIPTION
## Problem

Python coverage correlation assumed imports mapped directly beneath the scan root. Projects with a nested source root such as `backend/app` therefore reported covered modules as untested. Dynamic test loaders using `importlib.util.spec_from_file_location` or `runpy.run_path` were also missed. Separately, external-tool exclusions could remain relative, allowing Bandit to scan excluded vendor/reference trees. Cached detector output then preserved those invalid results.

## Fix

- Resolve dotted Python modules against unique nested source roots, while failing closed when candidates are ambiguous.
- Recognize literal Python scripts loaded through `spec_from_file_location` and `runpy.run_path`, including `Path(...) / ...` chains.
- Prefer an exact root script over a same-named nested module and leave ambiguous basenames unresolved.
- Normalize external-tool exclusion paths to absolute paths.
- Bump the shared detector cache version so stale security results are invalidated.

## Verification

- Focused regression suite: `16 passed`.
- Full suite: `6679 passed, 164 skipped, 5 failed`; the same five failures reproduce on untouched upstream commit `3a7735d5` (three bash source-directive assertions and one review-prompt assertion collected twice).
- Ruff passes on changed surfaces (ignoring only pre-existing `E731` elsewhere in an already-touched test file).
- Verified against WanLoraTools: false test-coverage findings dropped from 11 to 0; Bandit scope dropped from 776 files to the intended 282; excluded reference-tree findings dropped to 0.
