### PR TITLE
fix: resolve nested scan files for codebase metrics

### DIFF
--- a/desloppify/app/commands/scan/helpers.py
+++ b/desloppify/app/commands/scan/helpers.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from desloppify.languages import framework as lang_api
 from desloppify import state as state_mod
+from desloppify.base.discovery.file_paths import count_lines, resolve_scan_file
 from desloppify.base.discovery.source import (
     DEFAULT_EXCLUSIONS,
     read_file_text,
 )
-from desloppify.base.discovery.file_paths import count_lines
 from desloppify.base.output.terminal import colorize
+from desloppify.languages import framework as lang_api
 
 logger = logging.getLogger(__name__)
 
@@ -94,12 +94,12 @@ def collect_codebase_metrics(
     dirs = set()
     for filepath in files:
         try:
-            abs_path = _resolve_scan_file_path(filepath, project_root=scan_root)
-            content = read_file_text(abs_path)
+            abs_path = resolve_scan_file(filepath, scan_root=scan_root)
+            content = read_file_text(str(abs_path))
             if content is not None:
                 total_loc += len(content.splitlines())
             else:
-                total_loc += count_lines(Path(abs_path))
+                total_loc += count_lines(abs_path)
             dirs.add(str(Path(filepath).parent))
         except (OSError, UnicodeDecodeError) as exc:
             logger.debug(
@@ -119,14 +119,6 @@ def _resolve_scan_files(lang, path: Path, *, files: list[str] | None = None) -> 
     if files is not None:
         return files
     return lang.file_finder(path)
-
-
-def _resolve_scan_file_path(filepath: str, *, project_root: Path) -> str:
-    """Resolve relative scan filepaths against the active scan path."""
-    file_path = Path(filepath)
-    if file_path.is_absolute():
-        return str(file_path)
-    return str((project_root / file_path).resolve())
 
 
 def resolve_scan_profile(profile: str | None, lang) -> str:

--- a/desloppify/tests/commands/scan/test_cmd_scan.py
+++ b/desloppify/tests/commands/scan/test_cmd_scan.py
@@ -8,21 +8,21 @@ import desloppify.app.commands.scan.artifacts as scan_artifacts_mod
 import desloppify.app.commands.scan.cmd as scan_cmd_mod
 import desloppify.app.commands.scan.preflight as scan_preflight_mod
 import desloppify.languages as lang_mod
-from desloppify.app.commands.scan.helpers import (
-    audit_excluded_dirs,
-    collect_codebase_metrics,
-    effective_include_slow,
-    resolve_scan_profile,
-    warn_explicit_lang_with_no_files,
-    format_delta,
-)
-from desloppify.app.commands.scan.reporting.summary import (
-    show_strict_target_progress,
-)
 from desloppify.app.commands.scan.cmd import (
     cmd_scan,
     show_diff_summary,
     show_score_delta,
+)
+from desloppify.app.commands.scan.helpers import (
+    audit_excluded_dirs,
+    collect_codebase_metrics,
+    effective_include_slow,
+    format_delta,
+    resolve_scan_profile,
+    warn_explicit_lang_with_no_files,
+)
+from desloppify.app.commands.scan.reporting.summary import (
+    show_strict_target_progress,
 )
 from desloppify.base.exception_sets import CommandError
 
@@ -557,6 +557,23 @@ class TestCollectCodebaseMetrics:
             tmp_path,
             files=[str(file_path)],
         )
+        assert result is not None
+        assert result["total_files"] == 1
+        assert result["total_loc"] == 2
+
+    def test_counts_project_relative_files_for_nested_scan_path(
+        self, set_project_root
+    ):
+        scan_root = set_project_root / "remote-agent-platform"
+        scan_root.mkdir()
+        (scan_root / "a.py").write_text("line1\nline2\n")
+
+        class FakeLang:
+            def file_finder(self, _path):
+                return ["remote-agent-platform/a.py"]
+
+        result = collect_codebase_metrics(FakeLang(), scan_root)
+
         assert result is not None
         assert result["total_files"] == 1
         assert result["total_loc"] == 2


### PR DESCRIPTION
## Summary

- Fix codebase metrics for nested scan paths when language discovery returns project-root-relative file names.
- Reuse `resolve_scan_file` so paths are resolved against the scan root when present and fall back to the project root, instead of unconditionally prefixing the nested scan root and duplicating path segments.
- Add regression coverage for a nested scan whose file finder returns `remote-agent-platform/a.py`.

## Validation

- Targeted `TestCollectCodebaseMetrics`: 5 passed.
- Ruff: passed.
- Full suite baseline: 6685 passed, 152 skipped, with 3 pre-existing Bash failures identical on the parent commit.
- Disposable nested scan: 313 files, 183,949 LOC, 14 dirs.
- Diff check: `uv.lock` is not changed.