### PR TITLE
fix(triage): preserve explicit state in Codex helper

### DIFF
--- a/desloppify/app/commands/plan/triage/runner/orchestrator_codex_pipeline.py
+++ b/desloppify/app/commands/plan/triage/runner/orchestrator_codex_pipeline.py
@@ -105,15 +105,30 @@ def _read_stage_output(output_file: Path) -> str:
 
 
 
-def _write_desloppify_cli_helper(run_dir: Path) -> Path:
+def _write_desloppify_cli_helper(
+    run_dir: Path,
+    *,
+    state_path: Path | None = None,
+) -> Path:
     """Create an exact CLI wrapper so codex subagents use this checkout + interpreter."""
     package_root = Path(desloppify.__file__).resolve().parent.parent
     script_path = run_dir / "run_desloppify.sh"
+    command = f"{shlex.quote(sys.executable)} -m desloppify.cli"
     script = (
         "#!/bin/sh\n"
         f"export PYTHONPATH={shlex.quote(str(package_root))}${{PYTHONPATH:+:$PYTHONPATH}}\n"
-        f"exec {shlex.quote(sys.executable)} -m desloppify.cli \"$@\"\n"
     )
+    if state_path is not None:
+        script += f"state_path={shlex.quote(str(state_path.resolve()))}\n"
+        script += (
+            'if [ "$1" = "plan" ]; then\n'
+            "  shift\n"
+            f'  exec {command} plan --state "$state_path" "$@"\n'
+            "fi\n"
+            f'exec {command} "$@" --state "$state_path"\n'
+        )
+    else:
+        script += f'exec {command} "$@"\n'
     safe_write_text(script_path, script)
     os.chmod(script_path, 0o700)
     return script_path
@@ -383,7 +398,10 @@ def run_codex_pipeline(
 
     run_log_path = run_dir / "run.log"
     append_run_log = make_run_log_writer(run_log_path)
-    cli_helper = _write_desloppify_cli_helper(run_dir)
+    cli_helper = _write_desloppify_cli_helper(
+        run_dir,
+        state_path=getattr(runtime, "state_path", None),
+    )
     runner_label = active_runner_name()
     append_run_log(
         f"run-start runner={runner_label} stages={','.join(stages_to_run)} "

--- a/desloppify/tests/commands/plan/test_triage_split_modules_direct.py
+++ b/desloppify/tests/commands/plan/test_triage_split_modules_direct.py
@@ -1311,12 +1311,19 @@ def test_orchestrator_pipeline_entrypoint_is_exposed() -> None:
 
 
 def test_orchestrator_pipeline_writes_exact_cli_helper(tmp_path: Path) -> None:
-    helper = orchestrator_pipeline_mod._write_desloppify_cli_helper(tmp_path)
+    state_path = tmp_path / "states" / "api.json"
+    helper = orchestrator_pipeline_mod._write_desloppify_cli_helper(
+        tmp_path,
+        state_path=state_path,
+    )
     text = helper.read_text(encoding="utf-8")
     assert helper.exists()
     assert helper.stat().st_mode & 0o111
     assert "PYTHONPATH=" in text
     assert "-m desloppify.cli" in text
+    assert f"state_path={state_path.resolve()}" in text
+    assert 'plan --state "$state_path" "$@"' in text
+    assert '"$@" --state "$state_path"' in text
 
 
 def test_load_prior_reports_from_plan_uses_existing_stage_reports() -> None:
@@ -1856,7 +1863,7 @@ def test_run_codex_pipeline_raises_on_stage_failure(monkeypatch, tmp_path: Path)
     monkeypatch.setattr(
         orchestrator_pipeline_mod,
         "_write_desloppify_cli_helper",
-        lambda run_dir: run_dir / "run_desloppify.sh",
+        lambda run_dir, **_kwargs: run_dir / "run_desloppify.sh",
     )
     monkeypatch.setattr(
         orchestrator_pipeline_mod,


### PR DESCRIPTION
## Summary
- pass the active explicit state path into the generated Codex triage helper
- inject `--state` in the correct position for `plan` and non-`plan` commands
- cover both command shapes with focused tests

## Validation
- 43 focused triage tests passed
- `ruff check --select E9,F63,F7,F82` passed