### PR TITLE
fix: label test coverage scoring denominator accurately

### DIFF
--- a/desloppify/languages/_framework/base/shared_phases_review.py
+++ b/desloppify/languages/_framework/base/shared_phases_review.py
@@ -597,7 +597,10 @@ def phase_test_coverage(
     entries = filter_entries(zone_map, entries, "test_coverage")
 
     results = _entries_to_issues("test_coverage", entries, default_name="")
-    _log_phase_summary("test coverage", results, potential, "production files")
+    # ``potential`` is the LOC-weighted scoring denominator, not a file count.
+    # Label it accordingly so large projects do not appear to contain thousands
+    # more production files than discovery actually found.
+    _log_phase_summary("test coverage", results, potential, "weighted checks")
 
     return results, {"test_coverage": potential}
 

--- a/desloppify/tests/snapshots/cli_smoke/scan.txt
+++ b/desloppify/tests/snapshots/cli_smoke/scan.txt
@@ -8,7 +8,7 @@
          single-use: 0 found, 0 suppressed (50-200 LOC)
          -> 0 coupling/structural findings total
   [5/14] Test coverage...
-         test coverage: clean (0 production files)
+         test coverage: clean (0 weighted checks)
   [6/14] Code smells...
          -> 0 smell findings
   [7/14] Mutable state...
@@ -81,4 +81,3 @@ Desloppify Scan (python)
     - subjective_review: 1 open — `desloppify review --prepare`
 
   → First scan complete. 1 open findings across 3 dimensions.
-


### PR DESCRIPTION
## Problem

Python scans report the LOC-weighted test-coverage denominator as a count of production files. In Wayfinder, the scan said `5567 production files` while zone classification showed 778 first-party production/script files. The number is `total_potential`, whose detector formula weights uncovered source lines.

## Fix

Rename the progress label to `weighted checks`, add an explanatory comment, and update the CLI smoke snapshot.

## Verification

- `uv run --with pytest python -m pytest desloppify/tests/test_cli_smoke.py -q`: 66 passed
- Full suite: 5649 passed, 153 skipped, 5 unrelated pre-existing failures
- Patched scanner against Wayfinder now reports `489 issues (5567 weighted checks)` while zones report 776 production + 2 script files.