### PR TITLE
fix: preserve skipped strategic work items

### DIFF
--- a/desloppify/app/commands/plan/triage/stages/strategize.py
+++ b/desloppify/app/commands/plan/triage/stages/strategize.py
@@ -150,10 +150,13 @@ def _create_strategic_work_items(
             state["work_items"] = work_items
 
     queue_order = plan.setdefault("queue_order", [])
+    skipped_ids = set(plan.get("skipped", {}))
     new_ids: list[str] = []
 
     for entry in strategic_issues:
         issue_id = f"strategy::{entry['identifier']}"
+        if issue_id in skipped_ids:
+            continue
         work_items[issue_id] = {
             "status": "open",
             "detector": "strategy",

--- a/desloppify/tests/commands/plan/test_strategist.py
+++ b/desloppify/tests/commands/plan/test_strategist.py
@@ -78,6 +78,26 @@ def test_cmd_stage_strategize_persists_briefing_and_auto_confirms(monkeypatch, c
     assert "auto-confirmed" in capsys.readouterr().out
 
 
+def test_strategic_work_item_preserves_existing_skip() -> None:
+    issue = {
+        "identifier": "already-dismissed",
+        "priority": "high",
+        "summary": "A previously dismissed narrative item.",
+        "recommendation": "Do not re-enqueue it.",
+        "dimensions_affected": ["design_coherence"],
+    }
+    state = {"work_items": {}}
+    plan = {
+        "queue_order": ["triage::observe"],
+        "skipped": {"strategy::already-dismissed": {"kind": "permanent"}},
+    }
+
+    strategize_mod._create_strategic_work_items(state, plan, [issue])
+
+    assert plan["queue_order"] == ["triage::observe"]
+    assert "strategy::already-dismissed" not in state["work_items"]
+
+
 def test_observe_is_blocked_until_strategize_is_recorded(capsys) -> None:
     plan = {"queue_order": list(TRIAGE_STAGE_IDS), "epic_triage_meta": {"triage_stages": {}}, "execution_log": [], "commit_log": []}
     state = {"work_items": {}}


### PR DESCRIPTION
## Problem
The strategize stage could recreate a strategy work item already recorded in the plan's skipped map. It then inserted that ID into queue_order, violating the plan invariant that an ID cannot be both queued and skipped.

## Fix
Do not recreate or enqueue strategic entries whose IDs are already skipped. Added a regression test covering the preserved skip.