### PR TITLE
fix(plan): honor promoted work during initial review

### DIFF
--- a/desloppify/engine/_plan/promoted_ids.py
+++ b/desloppify/engine/_plan/promoted_ids.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 
 
@@ -46,8 +47,23 @@ def promoted_insertion_index(order: list[str], plan: dict[str, Any]) -> int:
     return last_idx + 1 if last_idx >= 0 else 0
 
 
+def has_promoted_execution_candidate(
+    plan: dict[str, Any] | None,
+    candidate_ids: Iterable[str],
+) -> bool:
+    """Return whether a live execution candidate was explicitly promoted."""
+    if not isinstance(plan, dict):
+        return False
+    promoted = plan.get("promoted_ids")
+    if not isinstance(promoted, list) or not promoted:
+        return False
+    candidates = set(candidate_ids)
+    return any(issue_id in candidates for issue_id in promoted)
+
+
 __all__ = [
     "add_promoted_ids",
+    "has_promoted_execution_candidate",
     "promoted_insertion_index",
     "prune_promoted_ids",
 ]

--- a/desloppify/engine/_plan/refresh_lifecycle.py
+++ b/desloppify/engine/_plan/refresh_lifecycle.py
@@ -26,14 +26,15 @@ Persisted markers live in ``plan["refresh_state"]`` and have distinct roles:
 
 Display phase is never persisted. ``derive_display_phase()`` computes the
 user-visible phase from boolean signals with this strict priority chain:
-``initial_review > prefer_scan > assessment > workflow > triage >
-review_postflight > execute > scan``. ``user_facing_mode()`` collapses all
+``promoted_execution > initial_review > prefer_scan > assessment > workflow >
+triage > review_postflight > execute > scan``. Explicit promotion is a user
+override of the normal planning gates. ``user_facing_mode()`` collapses all
 non-``execute`` display phases back to the persisted ``"plan"`` mode.
 """
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from desloppify.engine._plan.constants import SYNTHETIC_PREFIXES
 from desloppify.engine._plan.schema import PlanModel, ensure_plan_defaults
@@ -182,8 +183,11 @@ def derive_display_phase(
     has_execution: bool,
     fresh_boundary: bool,
     prefer_scan: bool,
+    has_promoted_execution: bool = False,
 ) -> str:
     """Return the canonical display phase from normalized boolean signals."""
+    if has_execution and has_promoted_execution:
+        return LIFECYCLE_PHASE_EXECUTE
     if fresh_boundary and has_initial_review:
         return LIFECYCLE_PHASE_REVIEW_INITIAL
     if prefer_scan:

--- a/desloppify/engine/_plan/sync/pipeline.py
+++ b/desloppify/engine/_plan/sync/pipeline.py
@@ -4,22 +4,21 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from desloppify.state_scoring import score_snapshot
 from desloppify.engine._plan.auto_cluster import auto_cluster_issues
 from desloppify.engine._plan.constants import (
     PRE_REVIEW_WORKFLOW_IDS,
     WORKFLOW_COMMUNICATE_SCORE_ID,
     WORKFLOW_CREATE_PLAN_ID,
     WORKFLOW_DEFERRED_DISPOSITION_ID,
-    WORKFLOW_IMPORT_SCORES_ID,
     WORKFLOW_RUN_SCAN_ID,
     WORKFLOW_SCORE_CHECKPOINT_ID,
     QueueSyncResult,
     is_synthetic_id,
 )
 from desloppify.engine._plan.operations.meta import append_log_entry
-from desloppify.engine._plan.policy.subjective import compute_subjective_visibility
 from desloppify.engine._plan.policy.stale import open_review_ids
+from desloppify.engine._plan.policy.subjective import compute_subjective_visibility
+from desloppify.engine._plan.promoted_ids import has_promoted_execution_candidate
 from desloppify.engine._plan.refresh_lifecycle import (
     _set_lifecycle_phase,
     derive_display_phase,
@@ -28,12 +27,14 @@ from desloppify.engine._plan.refresh_lifecycle import (
 from desloppify.engine._plan.sync.dimensions import sync_subjective_dimensions
 from desloppify.engine._plan.sync.phase_cleanup import prune_synthetic_for_phase
 from desloppify.engine._plan.sync.triage import sync_triage_needed
-from desloppify.engine._plan.triage.snapshot import build_triage_snapshot
 from desloppify.engine._plan.sync.workflow import (
     ScoreSnapshot,
     sync_communicate_score_needed,
     sync_create_plan_needed,
 )
+from desloppify.engine._plan.triage.snapshot import build_triage_snapshot
+from desloppify.engine._state.issue_semantics import is_assessment_request
+from desloppify.state_scoring import score_snapshot
 
 _SCAN_PHASE_WORKFLOW_IDS = {
     WORKFLOW_DEFERRED_DISPOSITION_ID,
@@ -150,11 +151,23 @@ def _resolve_reconcile_display_phase(
     )
 
     # Check for objective work in the queue.
-    has_real_work = any(
-        not item.startswith(("subjective::", "workflow::", "triage::"))
+    execution_ids = {
+        item
         for item in order
-        if item not in (plan.get("skipped") or {})
-    )
+        if not item.startswith(("subjective::", "workflow::", "triage::"))
+        and item not in (plan.get("skipped") or {})
+    }
+    issues = state.get("work_items") or state.get("issues", {})
+    promoted_execution_ids: set[str] = set()
+    for issue_id in execution_ids:
+        issue = issues.get(issue_id) if isinstance(issues, dict) else None
+        if (
+            isinstance(issue, dict)
+            and issue.get("status") == "open"
+            and not is_assessment_request(issue)
+        ):
+            promoted_execution_ids.add(issue_id)
+    has_real_work = bool(execution_ids)
     has_review_postflight = triage_gated_review or (
         not has_real_work and bool(open_review_ids(state))
     )
@@ -168,6 +181,10 @@ def _resolve_reconcile_display_phase(
         has_execution=has_real_work,
         fresh_boundary=fresh_boundary,
         prefer_scan=prefer_scan,
+        has_promoted_execution=has_promoted_execution_candidate(
+            plan,
+            promoted_execution_ids,
+        ),
     )
 
 

--- a/desloppify/engine/_work_queue/README.md
+++ b/desloppify/engine/_work_queue/README.md
@@ -17,7 +17,9 @@ live item partitions. Legacy fine-grained phase names are migrated once by
 `current_lifecycle_phase()` before snapshot resolution.
 
 1. **LIFECYCLE_PHASE_REVIEW_INITIAL** — fresh boundary, no scores yet. Shows subjective review items.
-   Objective items are NOT visible until initial review completes.
+   Objective items are NOT visible until initial review completes, unless the user explicitly
+   promotes live execution work into the active queue. Explicit promotion overrides the normal
+   planning gates until the promoted work drains.
 
 2. **LIFECYCLE_PHASE_EXECUTE** — the main work phase. Shows objective (mechanical defect) items.
    Only issues in `queue_order` are executable (post-triage). Pre-triage: all objectives visible.

--- a/desloppify/engine/_work_queue/snapshot.py
+++ b/desloppify/engine/_work_queue/snapshot.py
@@ -14,10 +14,7 @@ from desloppify.engine._plan.constants import (
     WORKFLOW_DEFERRED_DISPOSITION_ID,
     WORKFLOW_RUN_SCAN_ID,
 )
-from desloppify.engine._plan.schema import (
-    executable_objective_ids as _executable_objective_ids,
-    live_planned_queue_ids as _live_planned_queue_ids,
-)
+from desloppify.engine._plan.promoted_ids import has_promoted_execution_candidate
 from desloppify.engine._plan.refresh_lifecycle import (
     LIFECYCLE_PHASE_ASSESSMENT_POSTFLIGHT,
     LIFECYCLE_PHASE_EXECUTE,
@@ -29,12 +26,17 @@ from desloppify.engine._plan.refresh_lifecycle import (
     current_lifecycle_phase,
     derive_display_phase,
 )
+from desloppify.engine._plan.schema import (
+    executable_objective_ids as _executable_objective_ids,
+)
+from desloppify.engine._plan.schema import (
+    live_planned_queue_ids as _live_planned_queue_ids,
+)
 from desloppify.engine._plan.triage.snapshot import build_triage_snapshot
 from desloppify.engine._state.filtering import path_scoped_issues
 from desloppify.engine._state.issue_semantics import (
     counts_toward_objective_backlog,
     is_assessment_request,
-    is_review_work_item,
     is_triage_finding,
 )
 from desloppify.engine._state.schema import StateModel
@@ -271,6 +273,11 @@ def _phase_for_snapshot(
     triage_items: list[WorkQueueItem],
 ) -> str:
     has_execution = bool(anchored_execution_items or explicit_queue_items)
+    execution_ids = {
+        str(item.get("id", ""))
+        for item in (*anchored_execution_items, *explicit_queue_items)
+        if item.get("id")
+    }
     raw_phase = current_lifecycle_phase(plan) if isinstance(plan, dict) else None
     persisted_phase = None
     if isinstance(plan, dict) and isinstance(plan.get("refresh_state"), dict):
@@ -301,6 +308,10 @@ def _phase_for_snapshot(
         postflight_review_items=postflight_review_items,
         postflight_workflow_items=postflight_workflow_items,
         triage_items=triage_items,
+        has_promoted_execution=has_promoted_execution_candidate(
+            plan,
+            execution_ids,
+        ),
     )
 
 
@@ -316,6 +327,7 @@ def _derive_display_phase(
     postflight_review_items: list[WorkQueueItem],
     postflight_workflow_items: list[WorkQueueItem],
     triage_items: list[WorkQueueItem],
+    has_promoted_execution: bool,
 ) -> str:
     """Derive the display phase from queue item partitions.
 
@@ -331,6 +343,7 @@ def _derive_display_phase(
         has_execution=bool(anchored_execution_items or explicit_queue_items),
         fresh_boundary=fresh_boundary,
         prefer_scan=prefer_scan and bool(scan_items),
+        has_promoted_execution=has_promoted_execution,
     )
 
 

--- a/desloppify/tests/plan/test_plan_refactor_helpers.py
+++ b/desloppify/tests/plan/test_plan_refactor_helpers.py
@@ -10,6 +10,7 @@ from desloppify.engine._plan.annotations import (
 )
 from desloppify.engine._plan.promoted_ids import (
     add_promoted_ids,
+    has_promoted_execution_candidate,
     promoted_insertion_index,
     prune_promoted_ids,
 )
@@ -71,6 +72,8 @@ def test_promoted_helpers_preserve_order_and_prune():
     add_promoted_ids(plan, ["c", "a"])
     assert plan["promoted_ids"] == ["b", "c", "a"]
     assert promoted_insertion_index(order, plan) == 3
+    assert has_promoted_execution_candidate(plan, ["b", "d"]) is True
+    assert has_promoted_execution_candidate(plan, ["d"]) is False
 
     prune_promoted_ids(plan, {"b", "x"})
     assert plan["promoted_ids"] == ["c", "a"]

--- a/desloppify/tests/plan/test_reconcile_pipeline.py
+++ b/desloppify/tests/plan/test_reconcile_pipeline.py
@@ -879,3 +879,61 @@ def test_fresh_boundary_empty_state_resolves_scan_phase() -> None:
     snapshot = build_queue_snapshot(state, plan=plan)
 
     assert snapshot.phase == LIFECYCLE_PHASE_SCAN
+
+
+def test_promoted_execution_survives_unscored_review_resurfacing() -> None:
+    """A boundary refresh must not let initial review starve promoted work."""
+    objective_id = "unused::obj"
+    subjective_id = "subjective::naming_quality"
+    assessment_id = "subjective_review::.::naming_quality"
+    objective = _issue(objective_id)
+    assessment = _issue(assessment_id, detector="subjective_review")
+    assessment["detail"] = {"dimension": "naming_quality"}
+    state = {
+        "issues": {objective_id: objective, assessment_id: assessment},
+        "work_items": {
+            objective_id: dict(objective),
+            assessment_id: dict(assessment),
+        },
+        "scan_count": 2,
+        "dimension_scores": {
+            "Naming quality": {
+                "score": 0.0,
+                "strict": 0.0,
+                "failing": 0,
+                "checks": 1,
+                "detectors": {
+                    "subjective_assessment": {
+                        "dimension_key": "naming_quality",
+                        "placeholder": True,
+                    }
+                },
+            }
+        },
+        "subjective_assessments": {
+            "naming_quality": {"score": 0.0, "placeholder": True}
+        },
+    }
+    plan = empty_plan()
+    plan["queue_order"] = [objective_id]
+    plan["promoted_ids"] = [objective_id]
+    plan["skipped"] = {
+        subjective_id: {
+            "issue_id": subjective_id,
+            "kind": "temporary",
+            "review_after": None,
+            "skipped_at_scan": 1,
+        }
+    }
+
+    result = reconcile_plan(plan, state, target_strict=95.0)
+    snapshot = build_queue_snapshot(state, plan=plan)
+
+    assert result.subjective is not None
+    assert result.subjective.resurfaced == [subjective_id]
+    assert result.lifecycle_phase == LIFECYCLE_PHASE_EXECUTE
+    assert snapshot.phase == LIFECYCLE_PHASE_EXECUTE
+    assert [item["id"] for item in snapshot.execution_items] == [objective_id]
+    backlog_ids = {item["id"] for item in snapshot.backlog_items}
+    assert subjective_id in backlog_ids
+    assert assessment_id in backlog_ids

--- a/desloppify/tests/plan/test_refresh_lifecycle.py
+++ b/desloppify/tests/plan/test_refresh_lifecycle.py
@@ -10,15 +10,15 @@ import pytest
 from desloppify.engine._plan.refresh_lifecycle import (
     _LEGACY_PHASE_TO_MODE,
     carry_forward_subjective_review,
+    current_lifecycle_phase,
     derive_display_phase,
     invalidate_postflight_scan,
-    current_lifecycle_phase,
     mark_postflight_scan_completed,
     migrate_legacy_phase,
     postflight_scan_pending,
 )
-from desloppify.engine._plan.sync.workflow import _subjective_review_current_for_cycle
 from desloppify.engine._plan.schema import empty_plan
+from desloppify.engine._plan.sync.workflow import _subjective_review_current_for_cycle
 
 _PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 _REFRESH_LIFECYCLE = _PACKAGE_ROOT / "engine" / "_plan" / "refresh_lifecycle.py"
@@ -289,6 +289,20 @@ def test_derive_display_phase_single_signal_cases(
 
 
 def test_derive_display_phase_respects_priority_chain() -> None:
+    assert (
+        derive_display_phase(
+            has_initial_review=True,
+            has_postflight_assessment=True,
+            has_workflow=True,
+            has_triage=True,
+            has_review_postflight=True,
+            has_execution=True,
+            fresh_boundary=True,
+            prefer_scan=True,
+            has_promoted_execution=True,
+        )
+        == "execute"
+    )
     assert (
         derive_display_phase(
             has_initial_review=True,


### PR DESCRIPTION
## Summary
- allow live, explicitly promoted objective work to enter execution while subjective initial review is pending
- reject stale, closed, and assessment-only promoted IDs as gate overrides
- document the lifecycle priority and cover reconciliation plus snapshot behavior

## Validation
- full suite: 6,837 passed, 3 skipped
- focused plan tests: 81 passed
- Ruff and diff checks pass
- verified against a real project where 25 promoted objective items had been starved behind 20 unavailable review items