### PR TITLE
fix: resolve relative scan_root in collect_exclude_dirs so bandit excludes match

### DIFF
--- a/desloppify/base/discovery/source.py
+++ b/desloppify/base/discovery/source.py
@@ -138,18 +138,27 @@ def collect_exclude_dirs(
     Combines DEFAULT_EXCLUSIONS (non-glob entries) + get_exclusions() (runtime/config),
     resolves each against *scan_root*. Filters out glob patterns (``*`` in name)
     since most CLI tools want plain directory paths.
+
+    A relative *scan_root* is resolved against the project root first: external
+    tools (e.g. bandit) are handed absolute scan targets, so relative exclude
+    paths would never match and the excludes would be silently ignored.
     """
     resolved_exclusions = (
         extra_exclusions
         if extra_exclusions is not None
         else get_exclusions(runtime=runtime)
     )
+    root = (
+        scan_root
+        if scan_root.is_absolute()
+        else get_project_root(runtime=runtime) / scan_root
+    )
     patterns = set()
     for pat in DEFAULT_EXCLUSIONS:
         if "*" not in pat:
             patterns.add(pat)
     patterns.update(p for p in resolved_exclusions if p and "*" not in p)
-    return [str(scan_root / p) for p in sorted(patterns) if p]
+    return [str(root / p) for p in sorted(patterns) if p]
 
 
 def _is_excluded_dir(name: str, rel_path: str, extra: tuple[str, ...]) -> bool:

--- a/desloppify/tests/detectors/test_external_adapters.py
+++ b/desloppify/tests/detectors/test_external_adapters.py
@@ -1010,3 +1010,22 @@ class TestCollectExcludeDirs:
             result = collect_exclude_dirs(tmp_path)
         node_entries = [p for p in result if p.endswith("/node_modules")]
         assert len(node_entries) == 1
+
+    def test_relative_scan_root_resolves_against_project_root(self, tmp_path):
+        """A relative scan_root must still yield absolute exclude paths.
+
+        External tools (bandit) receive absolute scan targets; relative
+        excludes would silently never match (venv findings leak through).
+        """
+        with patch(
+            "desloppify.base.discovery.source.get_exclusions", return_value=()
+        ), patch(
+            "desloppify.base.discovery.source.get_project_root",
+            return_value=tmp_path,
+        ):
+            result = collect_exclude_dirs(Path("agents/my-agent"))
+        assert result
+        expected_prefix = str(tmp_path / "agents" / "my-agent")
+        assert all(p.startswith(expected_prefix) for p in result)
+        basenames = {p.rsplit("/", 1)[-1] for p in result}
+        assert ".venv" in basenames


### PR DESCRIPTION
## Problem

`desloppify --lang python scan --path agents/my-agent` (any **relative** `--path`) ignores every exclude — defaults and `desloppify exclude` config alike — for the bandit security phase. On a project with an in-tree `.venv`, the scan reports thousands of vendor findings:

```
[10/17] Security...
        security: 3759 issues (4719 files scanned)   # ~90 real project files
```

All findings point into `.venv/lib/python3.13/site-packages/...` even though `.venv` is in `DEFAULT_EXCLUSIONS` and was also added via `desloppify exclude`.

Root cause: `collect_exclude_dirs()` (desloppify/base/discovery/source.py) documents *"All exclusion directories as absolute paths, for passing to external tools"* but computes `str(scan_root / p)` with `scan_root` as-given. With a relative scan root, bandit receives relative `--exclude` entries while its scan target is `path.resolve()` (absolute) in `detect_with_bandit`, so the excludes never match anything.

## Fix

Resolve a relative `scan_root` against the project root before joining patterns, restoring the documented absolute-path contract. Consumers are unaffected or fixed:

- **bandit** (absolute target): fixed — excludes now match.
- **ruff** (`ruff_smells.py`, `unused.py`): tolerant of absolute excludes.
- **jscpd** (`jscpd_adapter.py`): uses `Path(dirname).name` basenames only.

Added a regression test for the relative-root case.

## Verification

- `python -m pytest desloppify/tests/ -q` → 5811 passed, 5 skipped.
- Re-scan of the affected project: `security: 3759 issues (4719 files scanned)` → `security: 15 issues (90 files scanned)`.