### PR TITLE
fix: resolve absolute imports through conventional src/ package layouts

### DIFF
--- a/desloppify/languages/python/detectors/deps_resolution.py
+++ b/desloppify/languages/python/detectors/deps_resolution.py
@@ -107,19 +107,24 @@ def resolve_relative_import(module_path: str, source_dir: Path) -> str | None:
 
 
 def resolve_absolute_import(module_path: str, scan_root: Path) -> str | None:
-    """Resolve an absolute import within scan root first, then project root."""
-    parts = module_path.split(".")
-    target_base = scan_root.resolve()
-    for part in parts:
-        target_base = target_base / part
-    resolved = try_resolve_path(target_base)
-    if resolved:
-        return resolved
+    """Resolve an absolute import within scan root first, then project root.
 
-    target_base = get_project_root()
-    for part in parts:
-        target_base = target_base / part
-    return try_resolve_path(target_base)
+    Each root is probed directly (``<root>/<parts>``) and through the
+    conventional src layout (``<root>/src/<parts>``), so packages living
+    under ``src/<package>/`` resolve without special configuration. The
+    scan root is probed before the project root, keeping resolution pinned
+    to the scanned project in monorepos with sibling projects.
+    """
+    parts = module_path.split(".")
+    for root in (scan_root.resolve(), get_project_root()):
+        for base in (root, root / "src"):
+            target_base = base
+            for part in parts:
+                target_base = target_base / part
+            resolved = try_resolve_path(target_base)
+            if resolved:
+                return resolved
+    return None
 
 
 def try_resolve_path(target_base: Path) -> str | None:

--- a/desloppify/tests/lang/python/test_deps_resolution_src_layout.py
+++ b/desloppify/tests/lang/python/test_deps_resolution_src_layout.py
@@ -1,0 +1,77 @@
+"""Absolute-import resolution for conventional ``src/`` package layouts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from desloppify.languages.python.detectors.deps_resolution import (
+    resolve_absolute_import,
+)
+
+
+def _mk(root: Path, rel: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("")
+    return path
+
+
+def _patched_project_root(project_root: Path):
+    return patch(
+        "desloppify.languages.python.detectors.deps_resolution.get_project_root",
+        return_value=project_root,
+    )
+
+
+class TestResolveAbsoluteImportSrcLayout:
+    def test_resolves_module_under_scan_root_src(self, tmp_path):
+        """<scan_root>/src/<pkg>/... resolves without special configuration."""
+        scan_root = tmp_path / "agents" / "my-agent"
+        target = _mk(scan_root, "src/my_pkg/orchestration/showcase.py")
+        _mk(scan_root, "src/my_pkg/__init__.py")
+        _mk(scan_root, "src/my_pkg/orchestration/__init__.py")
+        with _patched_project_root(tmp_path):
+            resolved = resolve_absolute_import(
+                "my_pkg.orchestration.showcase", scan_root
+            )
+        assert resolved == str(target.resolve())
+
+    def test_resolves_package_init_under_src(self, tmp_path):
+        scan_root = tmp_path / "proj"
+        init = _mk(scan_root, "src/my_pkg/__init__.py")
+        with _patched_project_root(tmp_path):
+            resolved = resolve_absolute_import("my_pkg", scan_root)
+        assert resolved == str(init.resolve())
+
+    def test_plain_layout_wins_over_src_layout(self, tmp_path):
+        """Direct <root>/<pkg> resolution keeps precedence over <root>/src/<pkg>."""
+        scan_root = tmp_path / "proj"
+        plain = _mk(scan_root, "my_pkg/mod.py")
+        _mk(scan_root, "src/my_pkg/mod.py")
+        with _patched_project_root(tmp_path):
+            resolved = resolve_absolute_import("my_pkg.mod", scan_root)
+        assert resolved == str(plain.resolve())
+
+    def test_scan_root_src_beats_project_root_src(self, tmp_path):
+        """Monorepo: the scanned project's src wins over a sibling at project root."""
+        scan_root = tmp_path / "agents" / "my-agent"
+        ours = _mk(scan_root, "src/shared_pkg/mod.py")
+        _mk(tmp_path, "src/shared_pkg/mod.py")
+        with _patched_project_root(tmp_path):
+            resolved = resolve_absolute_import("shared_pkg.mod", scan_root)
+        assert resolved == str(ours.resolve())
+
+    def test_project_root_src_is_fallback(self, tmp_path):
+        scan_root = tmp_path / "tools" / "cli"
+        scan_root.mkdir(parents=True)
+        target = _mk(tmp_path, "src/root_pkg/mod.py")
+        with _patched_project_root(tmp_path):
+            resolved = resolve_absolute_import("root_pkg.mod", scan_root)
+        assert resolved == str(target.resolve())
+
+    def test_unresolvable_returns_none(self, tmp_path):
+        scan_root = tmp_path / "proj"
+        scan_root.mkdir(parents=True)
+        with _patched_project_root(tmp_path):
+            assert resolve_absolute_import("missing_pkg.mod", scan_root) is None


### PR DESCRIPTION
## Problem

Scanning any Python project with a conventional `src/` layout (`<project>/src/<package>/...`) produces an empty dependency graph: `resolve_absolute_import` probes `<scan_root>/<module_parts>` and `<project_root>/<module_parts>` but never `<root>/src/<module_parts>`, so every absolute import (`from my_pkg.x import y`) resolves to `None`.

Observed on a 90-file src-layout project:

```
[4/17] Coupling + cycles + orphaned...
       orphaned: 39 files with zero importers      # every production module
       facades: 9 re-export facade issues          # every one "(0 importers)"
[6/17] Test coverage...
       test coverage: 15 issues                    # tested modules reported untested
```

`showcase.py` (4 real importers), `base.py` (imported by every connector) — all reported as orphaned dead files. Following the tool's guidance ("delete dead files") would delete the codebase.

## Fix

Probe each root both directly and through the conventional `src/` layout, scan root before project root:

- plain `<root>/<parts>` keeps precedence over `<root>/src/<parts>`;
- the scanned project's `src/` wins over a project-root `src/` (monorepo safety — sibling projects cannot capture the scanned project's imports).

## Verification

- `python -m pytest desloppify/tests/ -q` → 5816 passed, 5 skipped (6 new regression tests).
- Affected project re-probe: 55 src modules → 2 zero-importer (the two genuinely unimported package facades); `showcase.py` correctly shows 4 importers.