### PR TITLE
fix(plan): re-attribute auto-resolved findings

### DIFF
--- a/desloppify/app/commands/resolve/apply.py
+++ b/desloppify/app/commands/resolve/apply.py
@@ -57,6 +57,7 @@ def _resolve_all_patterns(
                     args.status,
                     args.note,
                     attestation=attestation,
+                    reattribute_auto_resolved=args.status == "fixed" and bool(attestation),
                 )
                 all_resolved.extend(resolved)
             continue
@@ -67,6 +68,7 @@ def _resolve_all_patterns(
             args.status,
             args.note,
             attestation=attestation,
+            reattribute_auto_resolved=args.status == "fixed" and bool(attestation),
         )
         all_resolved.extend(resolved)
     return all_resolved

--- a/desloppify/app/commands/resolve/cmd.py
+++ b/desloppify/app/commands/resolve/cmd.py
@@ -143,7 +143,26 @@ def cmd_resolve(args: argparse.Namespace) -> None:
         cluster_ctx.cluster_name is not None and not cluster_ctx.cluster_completed
     )
 
-    _print_resolve_summary(status=args.status, all_resolved=all_resolved)
+    work_items = state.get("work_items") or state.get("issues", {})
+    reattributed_count = (
+        sum(
+            1
+            for issue_id in all_resolved
+            if (
+                work_items.get(issue_id, {})
+                .get("resolution_attestation", {})
+                .get("previous_status")
+                == "auto_resolved"
+            )
+        )
+        if args.status == "fixed"
+        else 0
+    )
+    _print_resolve_summary(
+        status=args.status,
+        all_resolved=all_resolved,
+        reattributed_count=reattributed_count,
+    )
     _print_wontfix_batch_warning(
         state,
         status=args.status,

--- a/desloppify/app/commands/resolve/queue_guard.py
+++ b/desloppify/app/commands/resolve/queue_guard.py
@@ -50,7 +50,13 @@ def _filter_open_or_cluster_targets(
     return {
         issue_id
         for issue_id in resolved_ids
-        if issue_id in clusters
+        if (
+            issue_id in clusters
+            and any(
+                issues.get(member_id, {}).get("status") == "open"
+                for member_id in clusters[issue_id].get("issue_ids", [])
+            )
+        )
         or (issue_id in issues and issues[issue_id].get("status") == "open")
     }
 

--- a/desloppify/app/commands/resolve/render.py
+++ b/desloppify/app/commands/resolve/render.py
@@ -18,7 +18,16 @@ from desloppify.base.output.terminal import colorize
 from desloppify.engine.plan_state import get_uncommitted_issues, suggest_commit_message
 
 
-def _print_resolve_summary(*, status: str, all_resolved: list[str]) -> None:
+def _print_resolve_summary(
+    *, status: str, all_resolved: list[str], reattributed_count: int = 0
+) -> None:
+    if reattributed_count:
+        print(
+            colorize(
+                f"\nRe-attributed {reattributed_count} auto-resolved issue(s) as fixed",
+                "green",
+            )
+        )
     verb = "Reopened" if status == "open" else "Resolved"
     print(colorize(f"\n{verb} {len(all_resolved)} issue(s) as {status}:", "green"))
     for fid in all_resolved[:20]:

--- a/desloppify/engine/_state/resolution.py
+++ b/desloppify/engine/_state/resolution.py
@@ -117,6 +117,8 @@ def resolve_issues(
     status: str,
     note: str | None = None,
     attestation: str | None = None,
+    *,
+    reattribute_auto_resolved: bool = False,
 ) -> list[str]:
     """Set issue status for matches and return affected issue IDs."""
     ensure_state_defaults(state)
@@ -146,9 +148,20 @@ def resolve_issues(
             "detail": copy.deepcopy(original.get("detail", {})),
         }
 
-    status_filter = "all" if status == "open" else "open"
+    status_filter = (
+        "all"
+        if status == "open"
+        or (
+            status == "fixed"
+            and reattribute_auto_resolved
+            and bool(attestation)
+        )
+        else "open"
+    )
     for issue in match_issues(state, pattern, status_filter=status_filter):
         previous_status = str(issue.get("status", "open")).strip() or "open"
+        if status == "fixed" and previous_status not in {"open", "auto_resolved"}:
+            continue
         if status == "open" and previous_status == "open":
             continue
 
@@ -180,6 +193,14 @@ def resolve_issues(
             reopen_attestation["previous_status"] = previous_status
             extra_updates["resolution_attestation"] = reopen_attestation
 
+        resolution_attestation = {
+            "kind": "manual",
+            "text": attestation,
+            "attested_at": now,
+            "scan_verified": False,
+        }
+        if previous_status == "auto_resolved":
+            resolution_attestation["previous_status"] = previous_status
         updates: dict[str, object] = {
             "status": status,
             "note": note,
@@ -187,12 +208,7 @@ def resolve_issues(
             "suppressed": False,
             "suppressed_at": None,
             "suppression_pattern": None,
-            "resolution_attestation": {
-                "kind": "manual",
-                "text": attestation,
-                "attested_at": now,
-                "scan_verified": False,
-            },
+            "resolution_attestation": resolution_attestation,
         }
         updates.update(extra_updates)
         issue.update(updates)

--- a/desloppify/tests/commands/resolve/test_cmd_resolve.py
+++ b/desloppify/tests/commands/resolve/test_cmd_resolve.py
@@ -188,6 +188,150 @@ class TestCmdResolve:
         assert "Resolved 1" in out
         assert "Scores:" in out or "Score" in out
 
+    def test_attested_resolve_reattributes_auto_resolved_and_keeps_open_behavior(
+        self, monkeypatch, capsys
+    ):
+        from types import SimpleNamespace
+
+        from desloppify.app.commands.resolve.plan_load import (
+            DegradedPlanWarningState,
+            ResolvePlanAccess,
+        )
+        from desloppify.engine._state.filtering import make_issue
+        from desloppify.engine._state.schema import empty_state
+
+        state = empty_state()
+        open_issue = make_issue(
+            "unused",
+            "src/open.py",
+            "open",
+            tier=2,
+            confidence="high",
+            summary="open issue",
+        )
+        auto_issue = make_issue(
+            "unused",
+            "src/auto.py",
+            "auto",
+            tier=2,
+            confidence="high",
+            summary="auto-resolved issue",
+        )
+        auto_issue["status"] = "auto_resolved"
+        auto_issue["note"] = "no longer detected by scan"
+        wontfix_issue = make_issue(
+            "unused",
+            "src/wontfix.py",
+            "wontfix",
+            tier=2,
+            confidence="high",
+            summary="accepted debt",
+        )
+        wontfix_issue["status"] = "wontfix"
+        false_positive_issue = make_issue(
+            "unused",
+            "src/false_positive.py",
+            "false-positive",
+            tier=2,
+            confidence="high",
+            summary="false positive",
+        )
+        false_positive_issue["status"] = "false_positive"
+        state["work_items"] = {
+            open_issue["id"]: open_issue,
+            auto_issue["id"]: auto_issue,
+            wontfix_issue["id"]: wontfix_issue,
+            false_positive_issue["id"]: false_positive_issue,
+        }
+
+        monkeypatch.setattr(resolve_mod, "state_path", lambda _args: "/tmp/fake.json")
+        monkeypatch.setattr(resolve_mod, "load_state", lambda _path: state)
+        monkeypatch.setattr(resolve_mod, "save_state_or_exit", lambda *_args: None)
+        monkeypatch.setattr(
+            resolve_mod, "require_triage_current_or_exit", lambda **_kwargs: None
+        )
+        monkeypatch.setattr(resolve_mod, "_check_queue_order_guard", lambda *_a, **_kw: False)
+        monkeypatch.setattr(
+            resolve_mod,
+            "load_resolve_plan_access",
+            lambda: ResolvePlanAccess(
+                plan=None,
+                degraded=False,
+                error_kind=None,
+                warning_state=DegradedPlanWarningState(),
+            ),
+        )
+        monkeypatch.setattr(
+            resolve_mod,
+            "update_living_plan_after_resolve",
+            lambda **_kwargs: (
+                None,
+                SimpleNamespace(cluster_name=None, cluster_completed=False),
+            ),
+        )
+        monkeypatch.setattr(resolve_mod, "show_score_with_plan_context", lambda *_a: None)
+        monkeypatch.setattr(resolve_mod, "render_commit_guidance", lambda *_a: None)
+        monkeypatch.setattr(resolve_mod, "_print_subjective_reset_hint", lambda **_kw: None)
+        monkeypatch.setattr(resolve_mod, "_print_next_command", lambda _state: "")
+        monkeypatch.setattr(resolve_mod, "_write_resolve_query_entry", lambda _ctx: None)
+        monkeypatch.setattr(resolve_mod, "print_fixed_next_user_message", lambda **_kw: None)
+        monkeypatch.setattr(resolve_mod, "resolve_lang", lambda _args: None)
+        monkeypatch.setattr(
+            narrative_mod,
+            "compute_narrative",
+            lambda *_a, **_kw: {"milestone": None},
+        )
+
+        note = "Removed both unused names and verified the affected modules still run."
+        cmd_resolve(
+            argparse.Namespace(
+                status="fixed",
+                note=note,
+                attest=f"I have actually {note} I am not gaming the score.",
+                patterns=["unused"],
+                force_resolve=False,
+                lang=None,
+                path=".",
+            )
+        )
+
+        assert state["work_items"][open_issue["id"]]["status"] == "fixed"
+        reattributed = state["work_items"][auto_issue["id"]]
+        assert reattributed["status"] == "fixed"
+        assert (
+            reattributed["resolution_attestation"]["previous_status"]
+            == "auto_resolved"
+        )
+        assert wontfix_issue["status"] == "wontfix"
+        assert false_positive_issue["status"] == "false_positive"
+        assert "Re-attributed 1 auto-resolved issue(s) as fixed" in capsys.readouterr().out
+
+    def test_auto_resolved_is_not_reattributed_without_attestation(self):
+        from desloppify.engine._state.filtering import make_issue
+        from desloppify.engine._state.schema import empty_state
+
+        state = empty_state()
+        issue = make_issue(
+            "unused",
+            "src/a.py",
+            "name",
+            tier=2,
+            confidence="high",
+            summary="unused",
+        )
+        issue["status"] = "auto_resolved"
+        state["work_items"] = {issue["id"]: issue}
+
+        assert state_mod.resolve_issues(
+            state,
+            issue["id"],
+            "fixed",
+            note="This note is deliberately long enough to satisfy command requirements.",
+            attestation=None,
+            reattribute_auto_resolved=True,
+        ) == []
+        assert issue["status"] == "auto_resolved"
+
     def test_wontfix_shows_strict_cost_warning(self, monkeypatch, capsys):
         """Wontfix resolution should warn about strict score impact."""
         monkeypatch.setattr(resolve_mod, "state_path", lambda a: "/tmp/fake.json")

--- a/desloppify/tests/commands/test_queue_order_guard.py
+++ b/desloppify/tests/commands/test_queue_order_guard.py
@@ -257,6 +257,34 @@ def test_guard_cluster_with_stale_members(tmp_path, monkeypatch):
     assert blocked is False
 
 
+def test_guard_ignores_cluster_with_only_auto_resolved_members(
+    tmp_path, monkeypatch
+):
+    state = _state_with_issues("front", "a", "b")
+    state["work_items"]["a"]["status"] = "auto_resolved"
+    state["work_items"]["b"]["status"] = "auto_resolved"
+    _setup_plan(
+        tmp_path,
+        monkeypatch,
+        ["front", "a", "b"],
+        clusters={
+            "resolved-cluster": {
+                "name": "resolved-cluster",
+                "issue_ids": ["a", "b"],
+            }
+        },
+    )
+
+    assert (
+        _check_queue_order_guard(
+            state,
+            ["resolved-cluster"],
+            "fixed",
+        )
+        is False
+    )
+
+
 def test_guard_all_resolved_ids_stale(tmp_path, monkeypatch):
     """If all resolved IDs are stale, guard should not block."""
     state = _state_with_issues("a")


### PR DESCRIPTION
## Problem

Strict scoring counts `auto_resolved` findings as failures, but `plan resolve` previously matched only open findings. If a user fixed an issue and scanned before resolving it, the scan auto-resolved the finding and permanently removed the path to claim the fix. This workflow trap left strict score attribution unrecoverable.

## Fix

- Allow an attested `plan resolve` to include matching `auto_resolved` findings while preserving the normal open-item behavior.
- Record `previous_status: auto_resolved` in resolution attestation metadata and print a distinct re-attribution confirmation.
- Keep the existing full attestation and 50-character note gates, exclude all other closed statuses, and skip queue-order enforcement for auto-resolved-only targets.

## Verification

- Focused resolve, queue-order, and state tests: `75 passed`
- Full suite: `5813 passed, 5 skipped`
