### PR TITLE
fix: deduplicate backlog queue items

### DIFF
--- a/desloppify/engine/_work_queue/snapshot.py
+++ b/desloppify/engine/_work_queue/snapshot.py
@@ -14,10 +14,6 @@ from desloppify.engine._plan.constants import (
     WORKFLOW_DEFERRED_DISPOSITION_ID,
     WORKFLOW_RUN_SCAN_ID,
 )
-from desloppify.engine._plan.schema import (
-    executable_objective_ids as _executable_objective_ids,
-    live_planned_queue_ids as _live_planned_queue_ids,
-)
 from desloppify.engine._plan.refresh_lifecycle import (
     LIFECYCLE_PHASE_ASSESSMENT_POSTFLIGHT,
     LIFECYCLE_PHASE_EXECUTE,
@@ -29,12 +25,17 @@ from desloppify.engine._plan.refresh_lifecycle import (
     current_lifecycle_phase,
     derive_display_phase,
 )
+from desloppify.engine._plan.schema import (
+    executable_objective_ids as _executable_objective_ids,
+)
+from desloppify.engine._plan.schema import (
+    live_planned_queue_ids as _live_planned_queue_ids,
+)
 from desloppify.engine._plan.triage.snapshot import build_triage_snapshot
 from desloppify.engine._state.filtering import path_scoped_issues
 from desloppify.engine._state.issue_semantics import (
     counts_toward_objective_backlog,
     is_assessment_request,
-    is_review_work_item,
     is_triage_finding,
 )
 from desloppify.engine._state.schema import StateModel
@@ -505,21 +506,24 @@ def _build_backlog(
     p: _Partitions,
     execution_ids: set[str],
 ) -> list[WorkQueueItem]:
-    return [
-        item
-        for item in (
-            [
-                *p.objective_items,
-                *p.initial_review_items,
-                *p.postflight_assessment_items,
-                *p.review_issue_items,
-                *p.scan_items,
-                *p.postflight_workflow_items,
-                *p.triage_items,
-            ]
-        )
-        if item.get("id", "") not in execution_ids
-    ]
+    backlog: list[WorkQueueItem] = []
+    seen_ids = set(execution_ids)
+    for item in (
+        *p.objective_items,
+        *p.initial_review_items,
+        *p.postflight_assessment_items,
+        *p.review_issue_items,
+        *p.scan_items,
+        *p.postflight_workflow_items,
+        *p.triage_items,
+    ):
+        item_id = item.get("id", "")
+        if item_id and item_id in seen_ids:
+            continue
+        if item_id:
+            seen_ids.add(item_id)
+        backlog.append(item)
+    return backlog
 
 
 # ---------------------------------------------------------------------------

--- a/desloppify/tests/review/test_work_queue_plan_order_and_triage.py
+++ b/desloppify/tests/review/test_work_queue_plan_order_and_triage.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from desloppify.engine._plan.refresh_lifecycle import carry_forward_subjective_review
+from desloppify.engine._work_queue.core import QueueBuildOptions
+from desloppify.engine._work_queue.core import build_work_queue as _build_work_queue
 from desloppify.engine.planning.queue_policy import (
     build_backlog_queue,
     build_execution_queue,
 )
-from desloppify.engine._work_queue.core import QueueBuildOptions
-from desloppify.engine._work_queue.core import build_work_queue as _build_work_queue
 
 
 def build_work_queue(state, **kwargs):
@@ -527,6 +527,7 @@ def test_backlog_queue_excludes_execution_objective_items():
     ids = [item["id"] for item in queue["items"]]
     assert "smells::src/a.py::planned" not in ids
     assert "smells::src/b.py::unplanned" in ids
+    assert ids.count("smells::src/b.py::unplanned") == 1
     assert "workflow::run-scan" not in ids
 
 


### PR DESCRIPTION
## Problem

`desloppify backlog --count 10` can emit every mechanical finding twice. The persisted `.desloppify/query.json` likewise contains duplicate IDs, so this is queue construction rather than terminal rendering.

`_build_backlog` concatenates `objective_items` and `review_issue_items`. Review-issue partitioning intentionally includes triage findings, which can include those same mechanical items, so the combined backlog needs an identity boundary.

## Fix

Build the backlog in existing partition order while tracking IDs already present in the execution queue or an earlier backlog partition. This preserves first-occurrence ranking and existing lifecycle classification while emitting each non-empty ID once.

Add a regression assertion that an unplanned mechanical finding appears exactly once. The touched imports were also normalized by Ruff.

## Verification

- `python3 -m pytest desloppify/tests/review/test_work_queue_plan_order_and_triage.py desloppify/tests/commands/test_cmd_backlog.py desloppify/tests/commands/test_next_queue_flow_direct.py -q` — 31 passed
- Ran this branch against a real 2,034-finding monorepo: requested 10 backlog items, received 10 unique IDs
- `python3 -m ruff check` on both touched files — passed
- `python3 -m py_compile` on both touched files — passed
- `git diff --check` — passed
- Full suite — 5,809 passed, 4 skipped; the two failures are duplicate collection paths for `test_do_run_batches_dry_run_generates_packet_and_prompts`. The same assertion failure reproduces on pristine upstream commit `3a7735d5`, so it is unrelated to this change.
