### PR TITLE
fix: don't flag Kotlin delegation/destructuring imports as unused

### DIFF
--- a/desloppify/languages/_framework/treesitter/analysis/unused_imports.py
+++ b/desloppify/languages/_framework/treesitter/analysis/unused_imports.py
@@ -48,6 +48,22 @@ _ECMASCRIPT_DECLARATION_NAME_NODE_TYPES = frozenset({
 })
 
 
+def _is_implicitly_used(name: str, body: str, spec: TreeSitterLangSpec) -> bool:
+    """Return True if ``name`` is resolved by language convention rather than by name.
+
+    Some languages resolve imports through syntax that never spells the imported
+    symbol out — Kotlin's property delegation (``var x by remember { ... }``) requires
+    ``getValue``/``setValue`` imports, and destructuring requires ``componentN``.
+    A plain identifier search reports those as unused, and removing them breaks the
+    build. ``spec.implicit_import_uses`` declares those conventions per language.
+    """
+    # getattr keeps duck-typed spec stubs (used in tests) working.
+    for name_pattern, body_pattern in getattr(spec, "implicit_import_uses", ()):
+        if re.search(name_pattern, name) and re.search(body_pattern, body):
+            return True
+    return False
+
+
 def detect_unused_imports(
     file_list: list[str],
     spec: TreeSitterLangSpec,
@@ -108,6 +124,7 @@ def detect_unused_imports(
                 unused_names = [
                     n for n in grouped_names
                     if not re.search(r'\b' + re.escape(n) + r'\b', rest)
+                    and not _is_implicitly_used(n, rest, spec)
                 ]
                 if unused_names:
                     entries.append({
@@ -127,7 +144,10 @@ def detect_unused_imports(
                 continue
 
             # Check if the name appears in the rest of the file.
-            if not re.search(r'\b' + re.escape(name) + r'\b', rest):
+            if (
+                not re.search(r'\b' + re.escape(name) + r'\b', rest)
+                and not _is_implicitly_used(name, rest, spec)
+            ):
                 entries.append({
                     "file": filepath,
                     "line": import_node.start_point[0] + 1,

--- a/desloppify/languages/_framework/treesitter/specs/compiled.py
+++ b/desloppify/languages/_framework/treesitter/specs/compiled.py
@@ -117,6 +117,14 @@ KOTLIN_SPEC = TreeSitterLangSpec(
             (type_identifier) @name
             (class_body) @body) @class
     """,
+    implicit_import_uses=(
+        # Property delegation (`var x by remember { mutableStateOf(0) }`) resolves the
+        # getValue/setValue/provideDelegate operators through imported extensions that
+        # are never spelled out in the body. Pervasive in Compose Multiplatform.
+        (r"^(?:getValue|setValue|provideDelegate)$", r"(?<![\w.])by\s"),
+        # Destructuring declarations (`val (a, b) = pair`) call componentN() implicitly.
+        (r"^component\d+$", r"(?m)^\s*(?:val|var)\s*\("),
+    ),
     log_patterns=(
         r"^\s*(?:println\(|print\(|Logger\.|log\.)",
     ),

--- a/desloppify/languages/_framework/treesitter/types.py
+++ b/desloppify/languages/_framework/treesitter/types.py
@@ -20,6 +20,14 @@ class TreeSitterLangSpec:
 
     class_query: str = ""
 
+    # Imports that a language resolves by *convention* rather than by name, so the
+    # imported symbol never appears in the file body. Each entry is a
+    # ``(name_pattern, body_pattern)`` pair: when an import's simple name matches
+    # ``name_pattern`` and ``body_pattern`` is found in the file body, the import is
+    # treated as used. Example: Kotlin's ``import ...getValue`` is required by
+    # ``var x by remember { ... }`` but "getValue" is never written out.
+    implicit_import_uses: tuple[tuple[str, str], ...] = ()
+
     log_patterns: tuple[str, ...] = (
         r"^\s*(?:fmt\.Print|log\.)",
         r"^\s*(?:println!|eprintln!|dbg!)",

--- a/desloppify/tests/lang/common/test_kotlin_unused_imports.py
+++ b/desloppify/tests/lang/common/test_kotlin_unused_imports.py
@@ -1,0 +1,128 @@
+"""Regression tests for Kotlin unused import detection.
+
+Kotlin resolves some imports by convention rather than by name, so the imported
+symbol never appears in the file body. Flagging those as unused is actively
+harmful: removing them breaks compilation.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+
+def _detect(tmp_path, contents: str, name: str = "Screen.kt"):
+    from desloppify.languages._framework.treesitter.analysis.unused_imports import (
+        detect_unused_imports,
+    )
+    from desloppify.languages._framework.treesitter.specs.compiled import KOTLIN_SPEC
+
+    source = tmp_path / name
+    source.write_text(textwrap.dedent(contents).lstrip())
+    return detect_unused_imports([str(source)], KOTLIN_SPEC)
+
+
+def _names(findings) -> set[str]:
+    return {f["name"] for f in findings}
+
+
+def test_delegation_imports_are_not_flagged_when_by_is_used(tmp_path):
+    """`var x by remember { ... }` needs getValue/setValue even though it never names them."""
+    findings = _detect(
+        tmp_path,
+        """
+        package com.example
+
+        import androidx.compose.runtime.Composable
+        import androidx.compose.runtime.getValue
+        import androidx.compose.runtime.mutableStateOf
+        import androidx.compose.runtime.remember
+        import androidx.compose.runtime.setValue
+
+        @Composable
+        fun Screen() {
+            var expanded by remember { mutableStateOf(false) }
+            if (expanded) {
+                expanded = false
+            }
+        }
+        """,
+    )
+
+    assert _names(findings) == set()
+
+
+def test_delegation_imports_are_flagged_without_by(tmp_path):
+    """No delegation in the file means the operator imports really are dead."""
+    findings = _detect(
+        tmp_path,
+        """
+        package com.example
+
+        import androidx.compose.runtime.Composable
+        import androidx.compose.runtime.getValue
+        import androidx.compose.runtime.setValue
+
+        @Composable
+        fun Screen() {
+            Text("static")
+        }
+        """,
+    )
+
+    assert _names(findings) == {"getValue", "setValue"}
+
+
+def test_identifier_ending_in_by_does_not_mask_dead_delegation_imports(tmp_path):
+    """`nearby` / `standby.set(...)` must not be mistaken for the `by` keyword."""
+    findings = _detect(
+        tmp_path,
+        """
+        package com.example
+
+        import androidx.compose.runtime.getValue
+
+        fun render(nearby: String) {
+            println(nearby)
+        }
+        """,
+    )
+
+    assert _names(findings) == {"getValue"}
+
+
+def test_component_imports_are_not_flagged_with_destructuring(tmp_path):
+    findings = _detect(
+        tmp_path,
+        """
+        package com.example
+
+        import com.example.geo.component1
+        import com.example.geo.component2
+
+        fun render(point: GeoPoint) {
+            val (lat, lon) = point
+            println("$lat $lon")
+        }
+        """,
+    )
+
+    assert _names(findings) == set()
+
+
+def test_genuinely_unused_import_is_still_flagged(tmp_path):
+    findings = _detect(
+        tmp_path,
+        """
+        package com.example
+
+        import androidx.compose.foundation.background
+        import androidx.compose.runtime.Composable
+
+        @Composable
+        fun Screen() {
+            Text("hello")
+        }
+        """,
+    )
+
+    assert _names(findings) == {"background"}


### PR DESCRIPTION
## Problem

Kotlin resolves some imports by *convention* rather than by name, so the imported symbol never appears in the file body. The most common case is property delegation:

```kotlin
import androidx.compose.runtime.getValue
import androidx.compose.runtime.setValue
...
var expanded by remember { mutableStateOf(false) }
```

`getValue`/`setValue` are required for `by` to compile, but neither name is ever written out. `detect_unused_imports` does a plain identifier search, so it reports both as unused in every Compose file.

```
$ desloppify scan --path .   # Compose Multiplatform project
...
Remove 73 unused issues
  - Unused import: getValue
  - Unused import: setValue
```

37 of those 73 findings were this false positive — over half the detector's output for that language. Acting on them breaks the build:

```
e: ... 'getValue' operator is required for delegation
```

Destructuring has the same shape: `val (lat, lon) = point` calls `component1()`/`component2()` without naming them.

## Fix

Adds `TreeSitterLangSpec.implicit_import_uses` — a tuple of `(name_pattern, body_pattern)` pairs. When an import's simple name matches `name_pattern` **and** `body_pattern` is found in the file body, the import counts as used.

Kotlin declares two conventions:
- `getValue|setValue|provideDelegate`, guarded on the `by` keyword
- `componentN`, guarded on a destructuring declaration

The guards matter: an unused `getValue` import in a file with no delegation is still reported, so real dead imports aren't hidden. The `(?<![\w.])` lookbehind keeps identifiers like `nearby` from masking them.

The field defaults to `()`, so every other language is unaffected. The lookup uses `getattr` so duck-typed spec stubs in the existing tests keep working.

## Verification

- New regression tests in `desloppify/tests/lang/common/test_kotlin_unused_imports.py` (5 cases, covering both the false positives and the negative cases that must still be flagged).
- Full suite: `5816 passed, 4 skipped`.
- Against the original project: the 37 false positives drop to 0, while the 35 genuinely-unused imports in the same codebase are still reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCWKUYMUFfgPFW9brzaPVn