### PR TITLE
fix(orphaned): recognise Django convention modules as entry points

### DIFF
--- a/desloppify/engine/detectors/orphaned.py
+++ b/desloppify/engine/detectors/orphaned.py
@@ -81,6 +81,72 @@ def _is_nextjs_convention_entry(rel_path: str) -> bool:
     return False
 
 
+# ---------------------------------------------------------------------------
+# Django convention files
+# ---------------------------------------------------------------------------
+
+# Modules Django and Celery load by dotted-string reference or autodiscovery
+# rather than a source-level import, so they always show zero importers.
+_DJANGO_AUTOLOADED_MODULES: set[str] = {
+    "admin",  # django.contrib.admin autodiscover
+    "apps",   # AppConfig named from INSTALLED_APPS
+    "celery",  # Celery app module loaded at startup
+    "checks",  # system check framework registration
+    "context_processors",  # TEMPLATES OPTIONS strings
+    "middleware",  # MIDDLEWARE strings
+    "models",  # imported implicitly by the app registry
+    "receivers",  # signal receivers wired in AppConfig.ready()
+    "routers",  # DATABASE_ROUTERS strings
+    "signals",  # signal handlers wired in AppConfig.ready()
+    "tasks",  # celery autodiscover_tasks()
+}
+
+# Directories whose modules are resolved by name at runtime.
+_DJANGO_AUTOLOADED_DIRS: set[str] = {
+    "templatetags",  # {% load %}
+    "management",  # manage.py subcommand discovery
+    "migrations",  # migration executor
+}
+
+
+def _detect_django_project(path: Path) -> bool:
+    """Return True if the scan root looks like a Django project."""
+    if (path / "manage.py").exists():
+        return True
+    candidates = list(path.glob("*/settings.py")) + list(path.glob("*/settings/base.py"))
+    for settings_path in candidates:
+        try:
+            text = settings_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if "INSTALLED_APPS" in text:
+            return True
+    return False
+
+
+def _is_django_convention_entry(rel_path: str) -> bool:
+    """Return True if *rel_path* is a Django/Celery convention module.
+
+    These are reached through dotted strings (``ROOT_URLCONF``, ``MIDDLEWARE``,
+    ``include("app.urls")``) or autodiscovery, never through an import
+    statement, so importer counts say nothing about whether they are live.
+    """
+    p = Path(rel_path)
+    if p.suffix != ".py":
+        return False
+
+    if _DJANGO_AUTOLOADED_DIRS.intersection(p.parts[:-1]):
+        return True
+
+    stem = p.stem
+    if stem in _DJANGO_AUTOLOADED_MODULES:
+        return True
+
+    # URLconfs: urls.py plus the common urls_staff.py / staff_urls.py splits,
+    # each pulled in by include("app.<module>").
+    return stem == "urls" or stem.startswith("urls_") or stem.endswith("_urls")
+
+
 @dataclass
 class OrphanedDetectionOptions:
     """Optional behavior flags for orphaned-file detection."""
@@ -140,9 +206,9 @@ def detect_orphaned_files(
     alias_resolver = resolved_options.alias_resolver
 
     # Framework convention detection
-    is_nextjs = (
-        resolved_options.detect_frameworks and _detect_nextjs_project(path)
-    )
+    detect_frameworks = resolved_options.detect_frameworks
+    is_nextjs = detect_frameworks and _detect_nextjs_project(path)
+    is_django = detect_frameworks and _detect_django_project(path)
 
     dynamic_targets = (
         dynamic_import_finder(path, extensions) if dynamic_import_finder else set()
@@ -164,6 +230,9 @@ def detect_orphaned_files(
             continue
 
         if is_nextjs and _is_nextjs_convention_entry(r):
+            continue
+
+        if is_django and _is_django_convention_entry(r):
             continue
 
         if dynamic_targets and _is_dynamically_imported(

--- a/desloppify/languages/python/phases.py
+++ b/desloppify/languages/python/phases.py
@@ -97,6 +97,7 @@ PY_ENTRY_PATTERNS = [
     "config.py",
     "wsgi.py",
     "asgi.py",
+    "gunicorn.conf.py",  # Server config, executed by gunicorn — never imported
     "cli.py",  # CLI entry points (loaded via framework/importlib)
     "/commands/",  # CLI subcommands (loaded dynamically)
     "/fixers/",  # Fixer modules (loaded dynamically)

--- a/desloppify/tests/detectors/test_orphaned.py
+++ b/desloppify/tests/detectors/test_orphaned.py
@@ -7,8 +7,10 @@ from unittest.mock import patch
 
 from desloppify.engine.detectors.orphaned import (
     OrphanedDetectionOptions,
+    _detect_django_project,
     _detect_nextjs_project,
     _has_dunder_all,
+    _is_django_convention_entry,
     _is_dynamically_imported,
     _is_nextjs_convention_entry,
     detect_orphaned_files,
@@ -679,6 +681,172 @@ class TestNextjsIntegration:
                 tmp_path,
                 graph,
                 [".tsx"],
+                options=OrphanedDetectionOptions(detect_frameworks=False),
+            )
+
+        assert len(entries) == 1
+
+
+# ===================================================================
+# Django framework awareness
+# ===================================================================
+
+
+class TestDetectDjangoProject:
+    """Unit tests for _detect_django_project."""
+
+    def test_manage_py_at_root(self, tmp_path):
+        (tmp_path / "manage.py").write_text("import django\n")
+        assert _detect_django_project(tmp_path) is True
+
+    def test_settings_with_installed_apps(self, tmp_path):
+        settings = tmp_path / "config" / "settings.py"
+        settings.parent.mkdir(parents=True)
+        settings.write_text("INSTALLED_APPS = ['django.contrib.admin']\n")
+        assert _detect_django_project(tmp_path) is True
+
+    def test_split_settings_package(self, tmp_path):
+        settings = tmp_path / "config" / "settings" / "base.py"
+        settings.parent.mkdir(parents=True)
+        settings.write_text("INSTALLED_APPS = []\n")
+        assert _detect_django_project(tmp_path) is True
+
+    def test_settings_without_installed_apps(self, tmp_path):
+        settings = tmp_path / "pkg" / "settings.py"
+        settings.parent.mkdir(parents=True)
+        settings.write_text("DEBUG = True\n")
+        assert _detect_django_project(tmp_path) is False
+
+    def test_plain_python_project(self, tmp_path):
+        (tmp_path / "setup.py").write_text("from setuptools import setup\n")
+        assert _detect_django_project(tmp_path) is False
+
+
+class TestIsDjangoConventionEntry:
+    """Unit tests for _is_django_convention_entry."""
+
+    def test_urls(self):
+        assert _is_django_convention_entry("connectivity/urls.py") is True
+
+    def test_urls_prefixed_split(self):
+        assert _is_django_convention_entry("sonus/urls_page.py") is True
+
+    def test_urls_suffixed_split(self):
+        assert _is_django_convention_entry("rps/staff_urls.py") is True
+
+    def test_root_urlconf(self):
+        assert _is_django_convention_entry("config/urls.py") is True
+
+    def test_admin(self):
+        assert _is_django_convention_entry("backup/admin.py") is True
+
+    def test_apps_config(self):
+        assert _is_django_convention_entry("core/apps.py") is True
+
+    def test_middleware(self):
+        assert _is_django_convention_entry("core/middleware.py") is True
+
+    def test_celery_tasks(self):
+        assert _is_django_convention_entry("certs/tasks.py") is True
+
+    def test_models(self):
+        assert _is_django_convention_entry("licenses/models.py") is True
+
+    def test_signals(self):
+        assert _is_django_convention_entry("core/signals.py") is True
+
+    def test_context_processors(self):
+        assert _is_django_convention_entry("core/context_processors.py") is True
+
+    def test_database_routers(self):
+        assert _is_django_convention_entry("core/routers.py") is True
+
+    def test_templatetag_module(self):
+        assert _is_django_convention_entry("core/templatetags/perms_tags.py") is True
+
+    def test_management_command(self):
+        assert (
+            _is_django_convention_entry("app/management/commands/prewarm.py") is True
+        )
+
+    def test_migration(self):
+        assert _is_django_convention_entry("core/migrations/0023_auditlog.py") is True
+
+    def test_ordinary_module_not_matched(self):
+        assert _is_django_convention_entry("core/helpers.py") is False
+
+    def test_views_not_matched(self):
+        """views.py is imported by its URLconf, so orphan status is meaningful."""
+        assert _is_django_convention_entry("core/views.py") is False
+
+    def test_forms_not_matched(self):
+        assert _is_django_convention_entry("core/forms.py") is False
+
+    def test_url_substring_not_matched(self):
+        """A module merely containing 'urls' in its name is not a URLconf."""
+        assert _is_django_convention_entry("core/urlshortener.py") is False
+
+    def test_non_python_not_matched(self):
+        assert _is_django_convention_entry("core/templatetags/tags.html") is False
+
+
+class TestDjangoIntegration:
+    """Integration tests for Django orphan detection in detect_orphaned_files."""
+
+    def test_django_convention_files_not_orphaned(self, tmp_path):
+        """Convention modules are excluded when the root looks like Django."""
+        (tmp_path / "manage.py").write_text("import django\n")
+        urls = _write_file(tmp_path / "connectivity" / "urls.py", lines=30)
+        staff_urls = _write_file(tmp_path / "rps" / "staff_urls.py", lines=40)
+        admin = _write_file(tmp_path / "backup" / "admin.py", lines=25)
+        middleware = _write_file(tmp_path / "core" / "middleware.py", lines=60)
+        tags = _write_file(tmp_path / "core" / "templatetags" / "perms.py", lines=20)
+        orphan = _write_file(tmp_path / "core" / "leftover.py", lines=35)
+
+        graph = {
+            str(f): _graph_entry(importer_count=0)
+            for f in (urls, staff_urls, admin, middleware, tags, orphan)
+        }
+
+        with patch(
+            "desloppify.engine.detectors.orphaned.rel",
+            side_effect=lambda p: str(Path(p).relative_to(tmp_path)),
+        ):
+            entries, total = detect_orphaned_files(tmp_path, graph, [".py"])
+
+        assert total == 6
+        assert len(entries) == 1
+        assert entries[0]["file"] == str(orphan)
+
+    def test_no_django_markers_no_exclusion(self, tmp_path):
+        """Without Django markers, urls.py IS reported as orphaned."""
+        urls = _write_file(tmp_path / "pkg" / "urls.py", lines=30)
+
+        graph = {str(urls): _graph_entry(importer_count=0)}
+
+        with patch(
+            "desloppify.engine.detectors.orphaned.rel",
+            side_effect=lambda p: str(Path(p).relative_to(tmp_path)),
+        ):
+            entries, total = detect_orphaned_files(tmp_path, graph, [".py"])
+
+        assert len(entries) == 1
+
+    def test_detect_frameworks_false_disables_django(self, tmp_path):
+        """Setting detect_frameworks=False skips Django detection."""
+        (tmp_path / "manage.py").write_text("import django\n")
+        urls = _write_file(tmp_path / "pkg" / "urls.py", lines=30)
+
+        graph = {str(urls): _graph_entry(importer_count=0)}
+
+        with patch(
+            "desloppify.engine.detectors.orphaned.rel",
+            side_effect=lambda p: str(Path(p).relative_to(tmp_path)),
+        ):
+            entries, total = detect_orphaned_files(
+                tmp_path,
+                graph,
+                [".py"],
                 options=OrphanedDetectionOptions(detect_frameworks=False),
             )
 


### PR DESCRIPTION
Fixes #678.

## Problem

`detect_orphaned_files` decides a file is orphaned from **importer count alone**. Django and Celery load most of an app's modules by dotted-string reference or autodiscovery, never through an import statement — so those modules have zero importers by construction and every one is reported as dead code.

| Module | How it is loaded |
|---|---|
| `urls.py`, `urls_staff.py`, `staff_urls.py` | `ROOT_URLCONF`, `include("app.urls")` |
| `admin.py` | `django.contrib.admin.autodiscover()` |
| `apps.py` | `INSTALLED_APPS` string |
| `middleware.py` | `MIDDLEWARE` strings |
| `models.py` | app registry |
| `tasks.py` | Celery `autodiscover_tasks()` |
| `templatetags/*.py` | `{% load %}` |
| `context_processors.py` | `TEMPLATES["OPTIONS"]` strings |
| `routers.py` | `DATABASE_ROUTERS` strings |
| `gunicorn.conf.py` | executed by gunicorn |

On the 305-production-file Django project where I hit this, the detector produced **45 orphaned findings, ~40 of them false positives** — all live, routed code. `next` then surfaces them as `T3 [medium] Orphaned file: zero importers, not an entry point — delete dead files or relocate`. Acting on that advice takes the site down.

## Fix

Mirrors the Next.js App Router support already in this module, gated behind the same `detect_frameworks` flag:

- **`_detect_django_project(path)`** — `manage.py` at root, or a `*/settings.py` / `*/settings/base.py` defining `INSTALLED_APPS`.
- **`_is_django_convention_entry(rel_path)`** — autoloaded module stems (`admin`, `apps`, `celery`, `checks`, `context_processors`, `middleware`, `models`, `receivers`, `routers`, `signals`, `tasks`), autoloaded directories (`templatetags/`, `management/`, `migrations/`), and URLconfs.
- **`gunicorn.conf.py`** added to `PY_ENTRY_PATTERNS` — executed by gunicorn, never imported.

Two deliberate scoping decisions:

- **`views.py` and `forms.py` are NOT entry points.** They are reached through ordinary imports, so a zero-importer result there is a real signal and stays reportable.
- **URLconfs match on stem boundaries**, not substring: `stem == "urls" or stem.startswith("urls_") or stem.endswith("_urls")`. This covers the common `urls_staff.py` / `staff_urls.py` splits while leaving an unrelated module like `urlshortener.py` reportable.

## Tests

20 new tests in `desloppify/tests/detectors/test_orphaned.py`, following the structure of the existing Next.js tests — `TestDetectDjangoProject`, `TestIsDjangoConventionEntry`, `TestDjangoIntegration` — including negative cases (no Django markers, `detect_frameworks=False`, `views.py`, `forms.py`, `urlshortener.py`).

```
desloppify/tests/detectors/test_orphaned.py    87 passed
desloppify/tests/                            5836 passed, 5 skipped, 2 failed
```

The 2 failures are `test_do_run_batches_dry_run_generates_packet_and_prompts` (in both `tests/review/` and `tests/review/integration/`). They reproduce on a clean `main` checkout with this branch stashed, so they are pre-existing and unrelated.

## Verification against the affected project

Before — 45 orphaned findings including:

```
config/urls.py                      core/middleware.py
core/admin_urls.py                  core/auth_urls.py
core/templatetags/perms_tags.py     core/templatetags/components.py
core/templatetags/sidebar_tags.py   core/templatetags/console_extras.py
rps/staff_urls.py                   rps/urls_portal.py
backup/admin.py                     backup/urls_staff.py
directory/staff_urls.py             directory/urls.py
audiocodes/urls.py                  connectivity/urls.py
reports/staff_urls.py               sonus/urls_page.py
gunicorn.conf.py
```

After — zero matches for `urls|templatetags|middleware|admin\.py|gunicorn|apps\.py|tasks\.py|models\.py`, with genuinely unreferenced modules still reported.