### PR TITLE
fix(review): make claude a real prompt-only batch runner

### DIFF
--- a/desloppify/app/cli_support/parser_groups_admin_review_options_batch.py
+++ b/desloppify/app/cli_support/parser_groups_admin_review_options_batch.py
@@ -14,9 +14,13 @@ def _add_batch_execution_options(p_review: argparse.ArgumentParser) -> None:
     )
     g_batch.add_argument(
         "--runner",
-        choices=["codex", "opencode", "rovodev"],
+        choices=["claude", "codex", "opencode", "rovodev"],
         default="codex",
-        help="Subagent runner backend (default: codex)",
+        help=(
+            "Subagent runner backend (default: codex). 'claude' is prompt-only: "
+            "prompts are written for the calling harness to execute, and the "
+            "results are imported with --import-run --attested-external"
+        ),
     )
     g_batch.add_argument(
         "--parallel", action="store_true", help="Run selected batches in parallel"

--- a/desloppify/app/commands/review/batch/execution_dry_run.py
+++ b/desloppify/app/commands/review/batch/execution_dry_run.py
@@ -6,6 +6,8 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
+from .scope import is_prompt_only_runner
+
 
 def maybe_handle_dry_run(
     *,
@@ -23,13 +25,24 @@ def maybe_handle_dry_run(
     append_run_log,
 ) -> bool:
     """Write dry-run artifacts and guidance. Returns True when handled."""
-    if not getattr(args, "dry_run", False):
+    runner = str(getattr(args, "runner", "") or "").strip().lower()
+    prompt_only = is_prompt_only_runner(runner)
+    if not getattr(args, "dry_run", False) and not prompt_only:
         return False
 
+    # Record the runner that will execute these prompts rather than the literal
+    # "dry-run".  The import trust gate matches provenance.runner against the
+    # supported-runner set, so a placeholder here makes the resulting artifact
+    # permanently unimportable for scores -- which silently broke the
+    # prompt-only (Claude subagent) path entirely.  `dry_run` stays in the
+    # summary so the artifact still records that desloppify skipped execution;
+    # assessments from this path are never auto-applied (that requires an
+    # in-process run), so they still demand --attested-external at import.
     dry_summary: dict[str, object] = {
         "created_at": datetime.now(UTC).isoformat(timespec="seconds"),
         "run_stamp": stamp,
-        "runner": "dry-run",
+        "runner": runner or "dry-run",
+        "dry_run": True,
         "parallel": False,
         "selected_batches": [idx + 1 for idx in selected_indexes],
         "successful_batches": [idx + 1 for idx in selected_indexes],
@@ -51,11 +64,13 @@ def maybe_handle_dry_run(
     safe_write_text_fn(dry_summary_path, json.dumps(dry_summary, indent=2) + "\n")
 
     n = len(selected_indexes)
-    print(
-        colorize_fn(
-            f"  Dry run: {n} prompt(s) generated, runner execution skipped.", "yellow"
-        )
+    label = (
+        f"  Prompt-only runner '{runner}': {n} prompt(s) generated, "
+        "execution left to the calling harness."
+        if prompt_only
+        else f"  Dry run: {n} prompt(s) generated, runner execution skipped."
     )
+    print(colorize_fn(label, "yellow"))
     print(colorize_fn(f"  Run directory: {run_dir}", "dim"))
     print(colorize_fn(f"  Immutable packet: {immutable_packet_path}", "dim"))
     print(colorize_fn(f"  Blind packet: {prompt_packet_path}", "dim"))
@@ -69,13 +84,16 @@ def maybe_handle_dry_run(
             "bold",
         )
     )
-    print(
-        colorize_fn(
-            f"  Then: desloppify review --import-run {run_dir} --scan-after-import",
-            "bold",
+    import_cmd = f"  Then: desloppify review --import-run {run_dir} --scan-after-import"
+    if prompt_only:
+        # Assessments from a prompt-only run are never auto-applied; without the
+        # attestation the import silently downgrades to issues-only.
+        import_cmd += (
+            ' --attested-external --attest "I validated this review was '
+            'completed without awareness of overall score and is unbiased."'
         )
-    )
-    append_run_log("run-finished dry-run")
+    print(colorize_fn(import_cmd, "bold"))
+    append_run_log(f"run-finished {'prompt-only' if prompt_only else 'dry-run'}")
     return True
 
 

--- a/desloppify/app/commands/review/batch/orchestrator.py
+++ b/desloppify/app/commands/review/batch/orchestrator.py
@@ -66,6 +66,7 @@ from ..runtime_paths import (
 from .core_merge_support import assessment_weight  # noqa: F401 — re-exported
 from .core_models import BatchResultPayload
 from .scope import (
+    is_prompt_only_runner,
     normalize_dimension_list,
     scored_dimensions_for_lang,
 )
@@ -89,8 +90,26 @@ def _select_batch_runner(runner: str):
     Falls back to ``run_codex_batch`` for unknown runner strings; the
     caller has already validated the runner via ``validate_runner`` by
     the time the dispatch helper is reached during normal flows.
+
+    Prompt-only runners never reach a subprocess: ``maybe_handle_dry_run``
+    returns early for them.  The dispatch function is bound eagerly while
+    building deps, though, so the guard has to fail on *invocation* rather
+    than on selection -- otherwise preparing a prompt-only run would abort
+    before it ever emitted its prompts.  Falling through to the codex
+    dispatcher would silently run a different agent than requested.
     """
     normalized = (runner or "").strip().lower()
+    if is_prompt_only_runner(normalized):
+
+        def _refuse_prompt_only_batch(*_args, **_kwargs):
+            raise CommandError(
+                f"Error: runner '{normalized}' is prompt-only and cannot be "
+                "executed as a subprocess; prompts should have been emitted "
+                "instead",
+                exit_code=2,
+            )
+
+        return _refuse_prompt_only_batch
     if normalized == "opencode":
         return run_opencode_batch
     if normalized == "rovodev":

--- a/desloppify/app/commands/review/batch/scope.py
+++ b/desloppify/app/commands/review/batch/scope.py
@@ -14,7 +14,21 @@ from desloppify.intelligence.review.feedback_contract import (
 )
 
 
-_SUPPORTED_RUNNERS = {"codex", "opencode", "rovodev"}
+# Runners desloppify drives itself as a subprocess.
+_SUBPROCESS_RUNNERS = {"codex", "opencode", "rovodev"}
+
+# Runners whose batches are executed by the calling harness rather than by
+# desloppify: we emit prompts and stop.  Results come back through
+# `--import-run`, and their assessments always require `--attested-external`
+# (see ATTESTED_EXTERNAL_RUNNERS in review/importing/policy.py).
+PROMPT_ONLY_RUNNERS = {"claude"}
+
+_SUPPORTED_RUNNERS = _SUBPROCESS_RUNNERS | PROMPT_ONLY_RUNNERS
+
+
+def is_prompt_only_runner(runner: str) -> bool:
+    """True when the runner's batches are executed outside desloppify."""
+    return (runner or "").strip().lower() in PROMPT_ONLY_RUNNERS
 
 
 def validate_runner(runner: str, *, colorize_fn) -> None:

--- a/desloppify/tests/commands/review/test_review_batch_execution_helpers_direct.py
+++ b/desloppify/tests/commands/review/test_review_batch_execution_helpers_direct.py
@@ -12,6 +12,7 @@ from desloppify.app.commands.review.batch import execution_dry_run as dry_run_mo
 from desloppify.app.commands.review.batch import execution_progress as progress_mod
 from desloppify.app.commands.review.batch import execution_results as results_mod
 from desloppify.app.commands.review.batch import orchestrator as orchestrator_mod
+from desloppify.app.commands.review.importing import policy as policy_mod
 from desloppify.app.commands.review.runner_parallel import BatchProgressEvent
 from desloppify.base.exception_sets import CommandError
 
@@ -69,6 +70,64 @@ def test_maybe_handle_dry_run_writes_summary(tmp_path: Path) -> None:
     assert summary["runner"] == "dry-run"
     assert summary["selected_batches"] == [1, 3]
     assert "run-finished dry-run" in logs
+
+
+def _run_prompt_only(tmp_path: Path, args) -> tuple[bool, dict, list[str]]:
+    run_dir = tmp_path / "run"
+    logs: list[str] = []
+    handled = dry_run_mod.maybe_handle_dry_run(
+        args=args,
+        stamp="s3",
+        selected_indexes=[0],
+        run_dir=run_dir,
+        logs_dir=run_dir / "logs",
+        immutable_packet_path=tmp_path / "immutable.json",
+        prompt_packet_path=tmp_path / "prompt.json",
+        prompt_files={0: run_dir / "prompts" / "batch-1.md"},
+        output_files={0: run_dir / "results" / "batch-1.json"},
+        safe_write_text_fn=_safe_write_text,
+        colorize_fn=lambda text, _tone=None: text,
+        append_run_log=logs.append,
+    )
+    summary_path = run_dir / "run_summary.json"
+    summary = json.loads(summary_path.read_text()) if summary_path.exists() else {}
+    return handled, summary, logs
+
+
+def test_prompt_only_runner_emits_prompts_without_dry_run_flag(tmp_path: Path) -> None:
+    """`--runner claude` is prompt-only: it must stop before any subprocess."""
+    handled, summary, logs = _run_prompt_only(
+        tmp_path, SimpleNamespace(dry_run=False, runner="claude")
+    )
+    assert handled is True
+    assert summary["dry_run"] is True
+    assert "run-finished prompt-only" in logs
+
+
+def test_prompt_only_runner_provenance_passes_import_trust_gate(tmp_path: Path) -> None:
+    """Regression: the stamped runner must be importable for scores.
+
+    A placeholder runner here makes every Claude-subagent review permanently
+    unimportable, because the import trust gate matches provenance.runner
+    against the supported-runner set.
+    """
+    _handled, summary, _logs = _run_prompt_only(
+        tmp_path, SimpleNamespace(dry_run=True, runner="claude")
+    )
+    assert summary["runner"] == "claude"
+    assert summary["runner"] in policy_mod.SUPPORTED_BLIND_REVIEW_RUNNERS
+    assert summary["runner"] in policy_mod.ATTESTED_EXTERNAL_RUNNERS
+
+
+def test_prompt_only_runner_never_dispatches_a_subprocess() -> None:
+    """Falling through to the codex dispatcher would run the wrong agent.
+
+    Selection happens eagerly while binding deps, so it must stay callable and
+    only refuse when actually invoked.
+    """
+    run_batch = orchestrator_mod._select_batch_runner("claude")
+    with pytest.raises(CommandError):
+        run_batch()
 
 
 def test_progress_reporter_tracks_lifecycle_and_stalls(tmp_path: Path) -> None:

--- a/desloppify/tests/commands/review/test_review_batch_execution_phases_direct.py
+++ b/desloppify/tests/commands/review/test_review_batch_execution_phases_direct.py
@@ -122,7 +122,11 @@ def test_prepare_batch_run_returns_none_for_dry_run(tmp_path: Path) -> None:
     summary_path = run_root / "stamp" / "run_summary.json"
     summary = json.loads(summary_path.read_text())
     assert result is None
-    assert summary["runner"] == "dry-run"
+    # The summary records which runner will execute the prompts (the import
+    # trust gate matches provenance.runner against the supported-runner set);
+    # `dry_run` is what marks that desloppify skipped execution.
+    assert summary["runner"] == "codex"
+    assert summary["dry_run"] is True
     assert summary["selected_batches"] == [1]
     assert summary["successful_batches"] == [1]
     assert summary["failed_batches"] == []


### PR DESCRIPTION
## Problem

`review/importing/policy.py` names `claude` as the **only** runner allowed to apply assessments through `--attested-external`:

```python
SUPPORTED_BLIND_REVIEW_RUNNERS = {"codex", "claude", "opencode", "rovodev"}
ATTESTED_EXTERNAL_RUNNERS = {"claude"}
```

But no code path can produce that value:

- `--runner` only accepts `{codex, opencode, rovodev}` (`parser_groups_admin_review_options_batch.py`), and `validate_runner` rejects `claude`.
- The only way to emit prompts for harness-driven subagents is `--run-batches --dry-run`, and `execution_dry_run.py` hardcodes `"runner": "dry-run"` into `run_summary.json`.
- `_assessment_provenance_status` then rejects that as `unsupported runner in provenance: dry-run`.

So the documented Claude-subagent flow (skill overlay: *"Claude / other agent: `review --run-batches --dry-run` → launch one subagent per prompt file → `review --import-run <run-dir>`"*) cannot use `--attested-external` at all. The failure is also hard to diagnose, because the hint printed on rejection is verbatim the command that just failed:

```
Error: --attested-external requires valid blind packet provenance (current status: unsupported runner in provenance: dry-run)
Hint: if provenance is valid, rerun with:
  `desloppify review --import ... --attested-external --attest "..."`
```

Repro:

```bash
desloppify review --run-batches --dry-run --dimensions design_coherence
# ... run the subagent, write results/batch-1.raw.txt ...
desloppify review --import <run>/holistic_issues_merged.json \
  --attested-external --attest "I validated this review was completed without awareness of overall score and is unbiased."
# Error: --attested-external requires valid blind packet provenance
#        (current status: unsupported runner in provenance: dry-run)
```

## Fix

Make `claude` a first-class **prompt-only** runner — desloppify writes prompts, the calling harness executes them, results return via `--import-run`.

- Add `PROMPT_ONLY_RUNNERS = {"claude"}` in `batch/scope.py`; `_SUPPORTED_RUNNERS` is now `_SUBPROCESS_RUNNERS | PROMPT_ONLY_RUNNERS`.
- Accept `claude` in `--runner`, documented as prompt-only.
- `maybe_handle_dry_run` also handles prompt-only runners without `--dry-run`, and prints an import command that includes `--attested-external`.
- Record the runner that will execute the prompts in `run_summary.json` instead of the `"dry-run"` placeholder, adding a `dry_run: true` flag so the artifact still records that desloppify skipped execution.
- `_select_batch_runner` refuses a prompt-only runner instead of falling through to `run_codex_batch`. The guard raises on **invocation**, not selection, because the dispatch function is bound eagerly in a `partial(...)` while building `BatchRunDeps` — raising at selection time aborts before any prompts are written (caught while verifying against a real project).

### This does not widen assessment trust

- `trusted_internal` still requires `trusted_assessment_source`, set only by an in-process run.
- `_apply_issues_only_policy` clears assessments unconditionally, so trusted provenance alone never applies scores.
- The attested path still verifies the blind-packet SHA256, the runner set, and the `"without awareness"` / `"unbiased"` phrases.

Existing `--dry-run` callers that pass no runner keep the `"dry-run"` value (`runner or "dry-run"`).

## Tests

`python -m pytest desloppify/tests/ -q` → **5811 passed**, 5 skipped.

Four new tests in `test_review_batch_execution_helpers_direct.py`:
- prompt-only runner emits prompts without `--dry-run`
- stamped runner is in both `SUPPORTED_BLIND_REVIEW_RUNNERS` and `ATTESTED_EXTERNAL_RUNNERS` (the actual regression)
- prompt-only runner never dispatches a subprocess
- plus the eager-binding case

Updated `test_prepare_batch_run_returns_none_for_dry_run`, which asserted the placeholder literal, to the new contract (`runner == "codex"`, `dry_run is True`).

Verified end-to-end against a real project (a Rust + TypeScript repo):

```
$ desloppify review --run-batches --dry-run --runner claude --dimensions design_coherence
  Prompt-only runner 'claude': 1 prompt(s) generated, execution left to the calling harness.
  Then: desloppify review --import-run <run> --scan-after-import --attested-external --attest "..."

$ jq '.runner, .dry_run' <run>/run_summary.json
"claude"
true
```

## Pre-existing failures (not from this change)

Two tests fail on a clean `main` checkout as well, both on `assert "Previously flagged issues" in prompt_text`:

- `tests/review/test_review_commands.py::TestCmdReviewPrepare::test_do_run_batches_dry_run_generates_packet_and_prompts`
- `tests/review/integration/test_review_commands.py::TestCmdReviewPrepare::test_do_run_batches_dry_run_generates_packet_and_prompts`

Confirmed by stashing this branch's changes and rerunning. Left alone as unrelated.

## Related observation (no change made)

While verifying, I noticed `--import-run <dir> --allow-partial` grants `trusted internal (durable scores)` for a **dry-run** directory whose `results/` were written by hand, with no attestation and no provenance check — `trusted_assessment_source` is set by the replay path regardless of `provenance.runner`. That may be intentional for replaying interrupted real runs, but combined with `--dry-run` it means hand-authored scores import as trusted. The new `dry_run` flag in `run_summary.json` would give you a cheap hook to distinguish replaying a real run from replaying a dry run, if you want to tighten it. Flagging rather than changing, since it is a design call and altering it would break a flow people currently rely on.