### PR TITLE
fix: accept displayed reflect dimension names

### DIFF
--- a/desloppify/app/commands/plan/triage/stages/reflect.py
+++ b/desloppify/app/commands/plan/triage/stages/reflect.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 import argparse
 
 from desloppify.base.output.terminal import colorize
+from desloppify.base.subjective_dimension_catalog import DISPLAY_NAMES
 from desloppify.state_io import utc_now
 
 from ..display.dashboard import print_reflect_result
-from ..stage_queue import cascade_clear_dispositions, cascade_clear_later_confirmations, has_triage_in_queue
 from ..services import TriageServices, default_triage_services
+from ..stage_queue import (
+    cascade_clear_dispositions,
+    cascade_clear_later_confirmations,
+    has_triage_in_queue,
+)
 from ..validation.reflect_accounting import (
     BacklogDecision,
     ReflectDisposition,
@@ -33,7 +38,15 @@ def _validate_recurring_dimension_mentions(
     if not recurring_dims:
         return True
     report_lower = report.lower()
-    mentioned = [dim for dim in recurring_dims if dim.lower() in report_lower]
+    mentioned = [
+        dim
+        for dim in recurring_dims
+        if any(
+            name.lower() in report_lower
+            for name in (dim, DISPLAY_NAMES.get(dim))
+            if name
+        )
+    ]
     if mentioned:
         return True
     print(colorize("  Recurring patterns detected but not addressed in report:", "red"))

--- a/desloppify/tests/commands/plan/test_triage_stage_flow_observe_reflect_organize_direct.py
+++ b/desloppify/tests/commands/plan/test_triage_stage_flow_observe_reflect_organize_direct.py
@@ -249,3 +249,19 @@ def test_reflect_preserves_observe_auto_disposition_during_fresh_persist(
     ledger = plan["epic_triage_meta"]["triage_stages"]["reflect"]["disposition_ledger"]
     assert [entry["issue_id"] for entry in ledger] == ["review::complexity::aaaa1111"]
     assert saved
+
+
+def test_reflect_recurring_dimension_accepts_catalog_display_label() -> None:
+    assert reflect_mod._validate_recurring_dimension_mentions(
+        report="The strategy directly addresses the High elegance rework pattern.",
+        recurring_dims=["high_level_elegance"],
+        recurring={"high_level_elegance": {"open": ["open"], "resolved": ["resolved"]}},
+    )
+
+
+def test_reflect_recurring_dimension_accepts_canonical_snake_case() -> None:
+    assert reflect_mod._validate_recurring_dimension_mentions(
+        report="The strategy directly addresses the high_level_elegance rework pattern.",
+        recurring_dims=["high_level_elegance"],
+        recurring={"high_level_elegance": {"open": ["open"], "resolved": ["resolved"]}},
+    )


### PR DESCRIPTION
## Problem
Reflect prompts and dashboard output use catalog display labels such as `High elegance`, but record-time validation accepted only canonical keys such as `high_level_elegance`. A source-backed report using the tool's own display wording could therefore be rejected.

## Fix
Accept either the canonical key or its catalog display label when checking recurring-dimension mentions. Regression coverage retains canonical-key acceptance and adds displayed-label acceptance.