### PR TITLE
fix: ignore duplicate constants in versioned migrations

### DIFF
--- a/desloppify/languages/python/detectors/smells_ast/_source_detectors.py
+++ b/desloppify/languages/python/detectors/smells_ast/_source_detectors.py
@@ -11,6 +11,12 @@ logger = logging.getLogger(__name__)
 
 ConstantLocations = dict[tuple[str, str], list[tuple[str, int]]]
 SmellCounts = dict[str, list[dict[str, object]]]
+_VERSIONED_MIGRATION_DIRECTORY_PAIRS = frozenset(
+    {
+        ("alembic", "versions"),
+        ("migrations", "versions"),
+    }
+)
 
 
 def _is_within(root: Path, candidate: Path) -> bool:
@@ -20,6 +26,17 @@ def _is_within(root: Path, candidate: Path) -> bool:
         return True
     except ValueError:
         return False
+
+
+def _is_versioned_migration_path(filepath: str) -> bool:
+    """Return whether a file is an immutable versioned schema migration."""
+    path_parts = tuple(
+        part.casefold() for part in re.split(r"[\\/]+", filepath) if part
+    )
+    return any(
+        path_parts[index : index + 2] in _VERSIONED_MIGRATION_DIRECTORY_PAIRS
+        for index in range(len(path_parts) - 1)
+    )
 
 
 def collect_module_constants(
@@ -32,6 +49,9 @@ def collect_module_constants(
     Only collects UPPER_CASE or _UPPER_CASE names assigned to simple literals
     (dicts, lists, sets, tuples, numbers, strings).
     """
+    if _is_versioned_migration_path(filepath):
+        return
+
     try:
         tree = ast.parse(content, filename=filepath)
     except SyntaxError as exc:

--- a/desloppify/languages/python/tests/test_py_smells_crossfile.py
+++ b/desloppify/languages/python/tests/test_py_smells_crossfile.py
@@ -5,6 +5,9 @@ from pathlib import Path
 
 from desloppify.languages.python.detectors import smells as smells_mod
 from desloppify.languages.python.detectors.smells import detect_smells
+from desloppify.languages.python.detectors.smells_ast._source_detectors import (
+    collect_module_constants,
+)
 
 # ── Helpers ────────────────────────────────────────────────
 
@@ -104,6 +107,31 @@ class TestDuplicateConstants:
         (tmp_path / "b.py").write_text("MAX_RETRIES = 3\n")
         entries, _ = detect_smells(tmp_path)
         assert "duplicate_constant" in _smell_ids(entries)
+
+    def test_versioned_migration_constant_is_ignored(self, tmp_path):
+        migration_dir = tmp_path / "migrations" / "versions"
+        migration_dir.mkdir(parents=True)
+        (migration_dir / "a1_add_constraint.py").write_text("SHA256_CHECK = 'sql'\n")
+        (tmp_path / "model.py").write_text("SHA256_CHECK = 'sql'\n")
+
+        entries, _ = detect_smells(tmp_path)
+
+        assert "duplicate_constant" not in _smell_ids(entries)
+
+    def test_versioned_migration_paths_are_separator_independent(self):
+        for filepath in (
+            "migrations/versions/a1.py",
+            r"migrations\versions\a1.py",
+            "alembic/versions/a1.py",
+            r"alembic\versions\a1.py",
+        ):
+            constants_by_key = {}
+
+            collect_module_constants(
+                filepath, "SHA256_CHECK = 'sql'\n", constants_by_key
+            )
+
+            assert constants_by_key == {}
 
     def test_different_constants_ok(self, tmp_path):
         (tmp_path / "a.py").write_text("MAX_RETRIES = 3\n")


### PR DESCRIPTION
## Problem

The Python duplicate-constant detector reports an identical SQL constraint when it appears in both an immutable versioned migration and the current runtime model. Centralizing that value would make the historical migration depend on runtime code.

## Fix

Skip duplicate-constant collection only for conventional `migrations/versions` and `alembic/versions` paths, recognizing both path separators. Ordinary source-module detection remains unchanged.

## Verification

- `python3 -m pytest -q -p no:cacheprovider desloppify/languages/python/tests/test_py_smells_crossfile.py desloppify/tests/lang/python/test_py_smells_ast_api_direct.py`
- `ruff check desloppify/languages/python/detectors/smells_ast/_source_detectors.py desloppify/languages/python/tests/test_py_smells_crossfile.py`
- `ruff format --check desloppify/languages/python/detectors/smells_ast/_source_detectors.py desloppify/languages/python/tests/test_py_smells_crossfile.py`