### PR TITLE
fix: recognize sourced bash library usage in unused-import detector

### DIFF
--- a/desloppify/languages/_framework/treesitter/analysis/unused_imports.py
+++ b/desloppify/languages/_framework/treesitter/analysis/unused_imports.py
@@ -7,6 +7,7 @@ imports whose names don't appear elsewhere in the file.
 from __future__ import annotations
 
 import logging
+import os
 import re
 from typing import TYPE_CHECKING
 
@@ -20,6 +21,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _ECMASCRIPT_IMPORT_NODE_TYPE = "import_statement"
+
+# Symbols a sourced Bash file defines for the sourcing script: functions
+# (both `name() {}` and `function name {}` forms, global regardless of
+# nesting) and top-level variable assignments (including `export`/`declare`
+# wrappers). Function-local `local`/`declare` assignments are excluded.
+_BASH_DEFINITION_QUERY = """
+    (function_definition
+        name: (word) @name)
+    (program
+        (variable_assignment
+            name: (variable_name) @name))
+    (program
+        (declaration_command
+            (variable_assignment
+                name: (variable_name) @name)))
+"""
 
 # Identifier-ish nodes that represent a reference to a binding in JavaScript/TypeScript.
 # JSX tag names are typically represented as `identifier` in tree-sitter-javascript/tsx,
@@ -72,6 +89,7 @@ def detect_unused_imports(
 
     query = _make_query(language, spec.import_query)
     entries: list[dict] = []
+    sourced_symbol_cache: dict[str, frozenset[str]] = {}
 
     for filepath in file_list:
         cached = get_or_parse_tree(filepath, parser, spec.grammar)
@@ -126,6 +144,21 @@ def detect_unused_imports(
             if not name:
                 continue
 
+            # Bash `source`/`.` loads a library whose *defined* functions and
+            # variables are what the sourcing script uses — the sourced file's
+            # basename almost never reappears in the script body. Treat the
+            # import as used when any symbol the library defines is referenced.
+            if spec.grammar == "bash":
+                symbols = _bash_sourced_symbols(
+                    raw_path, filepath, spec, parser, language,
+                    sourced_symbol_cache,
+                )
+                if any(
+                    re.search(r'\b' + re.escape(symbol) + r'\b', rest)
+                    for symbol in symbols
+                ):
+                    continue
+
             # Check if the name appears in the rest of the file.
             if not re.search(r'\b' + re.escape(name) + r'\b', rest):
                 entries.append({
@@ -135,6 +168,54 @@ def detect_unused_imports(
                 })
 
     return entries
+
+
+def _bash_sourced_symbols(
+    raw_path: str,
+    filepath: str,
+    spec: TreeSitterLangSpec,
+    parser,
+    language,
+    cache: dict[str, frozenset[str]],
+) -> frozenset[str]:
+    """Extract the function/variable names a sourced Bash file defines.
+
+    Resolves ``raw_path`` relative to the sourcing script. Returns an empty
+    set when the sourced file cannot be resolved (variable-based paths,
+    missing files) so the caller falls back to the basename heuristic.
+    """
+    resolver = spec.resolve_import
+    if resolver is None:
+        return frozenset()
+    try:
+        resolved = resolver(raw_path, filepath, os.path.dirname(filepath))
+    except (OSError, ValueError):
+        return frozenset()
+    if not resolved:
+        return frozenset()
+
+    resolved = os.path.abspath(resolved)
+    cached_symbols = cache.get(resolved)
+    if cached_symbols is not None:
+        return cached_symbols
+
+    symbols: frozenset[str] = frozenset()
+    parsed = get_or_parse_tree(resolved, parser, spec.grammar)
+    if parsed is not None:
+        _source, tree = parsed
+        definition_query = _make_query(language, _BASH_DEFINITION_QUERY)
+        names: set[str] = set()
+        for _pattern_idx, captures in _run_query(definition_query, tree.root_node):
+            name_node = _unwrap_node(captures.get("name"))
+            if name_node is None:
+                continue
+            text = _node_text(name_node)
+            if text:
+                names.add(text)
+        symbols = frozenset(names)
+
+    cache[resolved] = symbols
+    return symbols
 
 
 def _detect_unused_imports_ecmascript(

--- a/desloppify/tests/lang/common/test_bash_unused_imports.py
+++ b/desloppify/tests/lang/common/test_bash_unused_imports.py
@@ -5,15 +5,32 @@ from __future__ import annotations
 import textwrap
 
 
-def _detect(tmp_path, contents: str):
+def _detect(tmp_path, contents: str, libraries: dict[str, str] | None = None):
     from desloppify.languages._framework.treesitter.analysis.unused_imports import (
         detect_unused_imports,
     )
     from desloppify.languages._framework.treesitter.specs.scripting import BASH_SPEC
 
+    for lib_name, lib_contents in (libraries or {}).items():
+        (tmp_path / lib_name).write_text(textwrap.dedent(lib_contents).lstrip())
     script = tmp_path / "script.sh"
     script.write_text(textwrap.dedent(contents).lstrip())
     return detect_unused_imports([str(script)], BASH_SPEC)
+
+
+_LIB_ACCEPTANCE = """
+    #!/usr/bin/env bash
+    API=${API:-http://localhost:8080}
+    export TOKEN="abc"
+    declare -r LIMIT=5
+    function legacy_helper {
+      local inner=1
+      echo "$inner"
+    }
+    require_server() {
+      curl -fsS "$API/health" >/dev/null
+    }
+"""
 
 
 def test_bash_shell_flags_are_not_imports(tmp_path):
@@ -86,3 +103,90 @@ def test_bash_used_source_directive_is_not_flagged(tmp_path):
     )
 
     assert findings == []
+
+
+def test_bash_source_calling_library_function_is_not_flagged(tmp_path):
+    findings = _detect(
+        tmp_path,
+        """
+        #!/bin/bash
+        set -euo pipefail
+        cd "$(dirname "$0")"
+        source ./lib-acceptance.sh
+        require_server
+        """,
+        libraries={"lib-acceptance.sh": _LIB_ACCEPTANCE},
+    )
+
+    assert findings == []
+
+
+def test_bash_source_using_function_keyword_definition_is_not_flagged(tmp_path):
+    findings = _detect(
+        tmp_path,
+        """
+        #!/bin/bash
+        source ./lib-acceptance.sh
+        legacy_helper
+        """,
+        libraries={"lib-acceptance.sh": _LIB_ACCEPTANCE},
+    )
+
+    assert findings == []
+
+
+def test_bash_source_using_library_variable_is_not_flagged(tmp_path):
+    findings = _detect(
+        tmp_path,
+        """
+        #!/bin/bash
+        source ./lib-acceptance.sh
+        curl -fsS "$API/workflows" >/dev/null
+        """,
+        libraries={"lib-acceptance.sh": _LIB_ACCEPTANCE},
+    )
+
+    assert findings == []
+
+
+def test_bash_source_using_exported_variable_is_not_flagged(tmp_path):
+    findings = _detect(
+        tmp_path,
+        """
+        #!/bin/bash
+        source ./lib-acceptance.sh
+        echo "token: ${TOKEN}"
+        """,
+        libraries={"lib-acceptance.sh": _LIB_ACCEPTANCE},
+    )
+
+    assert findings == []
+
+
+def test_bash_source_with_no_library_symbol_used_is_flagged(tmp_path):
+    findings = _detect(
+        tmp_path,
+        """
+        #!/bin/bash
+        source ./lib-acceptance.sh
+        echo body
+        """,
+        libraries={"lib-acceptance.sh": _LIB_ACCEPTANCE},
+    )
+
+    assert [entry["name"] for entry in findings] == ["lib-acceptance"]
+
+
+def test_bash_source_local_variable_in_library_function_is_not_usage(tmp_path):
+    findings = _detect(
+        tmp_path,
+        """
+        #!/bin/bash
+        source ./lib-acceptance.sh
+        inner=2
+        echo "$inner"
+        """,
+        libraries={"lib-acceptance.sh": _LIB_ACCEPTANCE},
+    )
+
+    assert [entry["name"] for entry in findings] == ["lib-acceptance"]


### PR DESCRIPTION
## Problem

The bash unused-import detector flags `source ./lib.sh` directives in scripts that demonstrably use the sourced library. Usage was recognized only when the sourced file's *basename* reappeared in the script body — but scripts that source a function library call its functions and read its variables; they never repeat the basename.

Repro (project with 30 shell scripts, 28 of which `source ./lib-acceptance.sh` and then call functions it defines, e.g. `require_server`, or read variables like `$API`):

```
$ desloppify --lang bash scan --path .
```

Before this fix, all 28 sourcing scripts are flagged, e.g.:

```
unused::scripts/acceptance-step-simulator.sh::unused_import::7   "Unused import: lib-acceptance"
```

...even though line 8 of that script calls `require_server`, defined in `scripts/lib-acceptance.sh`. In other words the detector produced a false positive for essentially every bash script that sources a shared function library.

## Fix

In `detect_unused_imports`, for `spec.grammar == "bash"`: resolve the sourced path relative to the sourcing script (reusing the spec's `resolve_import` / `resolve_bash_source`), parse the sourced file, and collect the symbols it defines:

- function definitions in both `name() {}` and `function name {}` forms (global regardless of nesting), and
- top-level variable assignments, including `export FOO=...` / `declare -r FOO=...` wrappers, while excluding function-local `local`/`declare` assignments.

The source directive counts as used when any defined symbol is referenced in the rest of the script. When the sourced path cannot be resolved (variable-based paths, missing files), the existing basename heuristic is kept, so current behavior — including all existing tests — is unchanged for unresolvable sources. Defined-symbol sets are cached per run since many scripts typically source the same library.

Verified on the repro project: 28 `unused_import` findings before, 0 after; the remaining 111 work items from other detectors are unaffected. Full test suite passes (the two pre-existing `test_do_run_batches_dry_run_generates_packet_and_prompts` failures reproduce identically on a clean checkout of `main` in this environment).

Note: while investigating I also checked a suspected companion issue — findings surviving rescans after their file is deleted. That is already handled on current `main` (`verify_disappeared` auto-resolves with "source file no longer exists"); confirmed empirically by deleting a file with 11 open findings and rescanning.
