### PR TITLE
fix: stop reporting file-based-router entry points as orphaned

### DIFF
--- a/desloppify/engine/detectors/orphaned.py
+++ b/desloppify/engine/detectors/orphaned.py
@@ -7,78 +7,10 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
-from desloppify.base.discovery.file_paths import rel
-from desloppify.base.discovery.file_paths import count_lines
+from desloppify.base.discovery.file_paths import count_lines, rel
+from desloppify.engine.detectors.orphaned_frameworks import build_framework_context
 
 _DUNDER_ALL_RE = re.compile(r"^__all__\s*[:=]", re.MULTILINE)
-
-# ---------------------------------------------------------------------------
-# Next.js App Router convention files
-# ---------------------------------------------------------------------------
-
-# Files that are entry points when inside an app/ directory
-_NEXTJS_APP_DIR_CONVENTIONS: set[str] = {
-    "page",
-    "layout",
-    "loading",
-    "error",
-    "not-found",
-    "global-error",
-    "route",
-    "template",
-    "default",
-    "opengraph-image",
-    "twitter-image",
-    "sitemap",
-    "robots",
-    "icon",
-    "apple-icon",
-}
-
-# Files that are entry points at the project root (or src/)
-_NEXTJS_ROOT_CONVENTIONS: set[str] = {
-    "middleware",
-    "instrumentation",
-    "instrumentation-client",
-}
-
-_NEXTJS_EXTENSIONS: set[str] = {".ts", ".tsx", ".js", ".jsx"}
-
-
-def _detect_nextjs_project(path: Path) -> bool:
-    """Return True if the scan root looks like a Next.js project."""
-    for name in ("next.config.js", "next.config.mjs", "next.config.ts"):
-        if (path / name).exists():
-            return True
-    return False
-
-
-def _is_nextjs_convention_entry(rel_path: str) -> bool:
-    """Return True if *rel_path* is a Next.js App Router convention file.
-
-    Checks:
-    - Files with convention names inside any ``app/`` directory segment
-    - Root-level convention files (middleware, instrumentation)
-    """
-    p = Path(rel_path)
-    ext = p.suffix
-    if ext not in _NEXTJS_EXTENSIONS:
-        return False
-
-    stem = p.stem
-    parts = p.parts
-
-    # Root-level conventions: middleware.ts, instrumentation.ts, etc.
-    # These can live at the project root or inside src/
-    if stem in _NEXTJS_ROOT_CONVENTIONS and len(parts) <= 2:
-        return True
-
-    # App directory conventions: any file inside an app/ segment
-    if stem in _NEXTJS_APP_DIR_CONVENTIONS:
-        if "app" in parts:
-            return True
-
-    return False
 
 
 @dataclass
@@ -139,9 +71,12 @@ def detect_orphaned_files(
     dynamic_import_finder = resolved_options.dynamic_import_finder
     alias_resolver = resolved_options.alias_resolver
 
-    # Framework convention detection
-    is_nextjs = (
-        resolved_options.detect_frameworks and _detect_nextjs_project(path)
+    # Framework convention detection: a file-based router loads its handlers,
+    # pages, plugins and layouts by path, so they have no importers by design.
+    framework_context = (
+        build_framework_context(path)
+        if resolved_options.detect_frameworks
+        else None
     )
 
     dynamic_targets = (
@@ -163,7 +98,7 @@ def detect_orphaned_files(
         if basename in all_barrel_names:
             continue
 
-        if is_nextjs and _is_nextjs_convention_entry(r):
+        if framework_context is not None and framework_context.covers_file(filepath):
             continue
 
         if dynamic_targets and _is_dynamically_imported(

--- a/desloppify/engine/detectors/orphaned_frameworks.py
+++ b/desloppify/engine/detectors/orphaned_frameworks.py
@@ -1,0 +1,548 @@
+"""Entry points a file-based framework loads by path rather than by import.
+
+Nuxt/Nitro, Next.js, SvelteKit, Remix and Astro all route by filesystem
+location: an API handler, a page, a layout or a plugin is picked up because of
+where it sits, not because something imports it.  An import-graph orphan check
+sees zero importers on every one of those files and reports the application's
+own entry points as dead code.
+
+This module answers one question — does a detected framework already own this
+path? — so the orphan detector can stay a pure graph check.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Extensions a framework convention can apply to. A convention rule never fires
+# on, say, a .py file even when the rule's directory matches.
+FRAMEWORK_EXTENSIONS: frozenset[str] = frozenset(
+    {".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".vue", ".svelte", ".astro"}
+)
+
+_CONFIG_EXTENSIONS: frozenset[str] = frozenset(
+    {".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"}
+)
+
+# How far above the scan path to look for a framework config. A scan pointed at
+# ``src/`` or a workspace package still belongs to the project above it.
+_ROOT_SEARCH_DEPTH = 4
+
+
+@dataclass(frozen=True)
+class FrameworkEntryPoints:
+    """Entry-point rules contributed by one detected framework.
+
+    All paths are POSIX and relative to :attr:`root`, the directory holding the
+    framework's config file.
+    """
+
+    name: str
+    root: Path
+    dir_prefixes: tuple[str, ...] = ()
+    exact_files: tuple[str, ...] = ()
+    # (directory segment, stems): a file whose stem is in the set and which sits
+    # anywhere under a directory with that name. Next.js App Router shape.
+    stems_under_segment: tuple[tuple[str, frozenset[str]], ...] = ()
+    # (directory prefix, filename prefix): SvelteKit's ``+page``/``+server`` shape.
+    name_prefixes: tuple[tuple[str, str], ...] = ()
+
+    def covers(self, rel_path: str) -> bool:
+        """Return True if *rel_path* (relative to :attr:`root`) is an entry point."""
+        p = Path(rel_path)
+        if p.suffix not in FRAMEWORK_EXTENSIONS:
+            return False
+
+        posix = p.as_posix()
+        if posix in self.exact_files:
+            return True
+
+        for prefix in self.dir_prefixes:
+            if posix.startswith(prefix + "/"):
+                return True
+
+        parts = p.parts
+        for segment, stems in self.stems_under_segment:
+            if segment in parts and p.stem in stems:
+                return True
+
+        for dir_prefix, name_prefix in self.name_prefixes:
+            if posix.startswith(dir_prefix + "/") and p.name.startswith(name_prefix):
+                return True
+
+        return False
+
+    def covers_file(self, filepath: str | Path) -> bool:
+        """Return True if the absolute *filepath* is one of this framework's entries."""
+        try:
+            rel_path = Path(filepath).resolve().relative_to(self.root)
+        except ValueError:
+            return False
+        return self.covers(rel_path.as_posix())
+
+
+@dataclass
+class FrameworkContext:
+    """Everything the orphan detector needs to skip framework-owned files."""
+
+    frameworks: list[FrameworkEntryPoints] = field(default_factory=list)
+    # Root-relative POSIX paths named by package.json scripts. A file a script
+    # invokes is reachable by definition, whatever the import graph says.
+    script_entries: frozenset[str] = frozenset()
+    root: Path | None = None
+
+    def __bool__(self) -> bool:
+        return bool(self.frameworks or self.script_entries)
+
+    def covers_file(self, filepath: str | Path) -> bool:
+        """Return True if a framework, a package script or tooling owns *filepath*."""
+        if any(fw.covers_file(filepath) for fw in self.frameworks):
+            return True
+        if self.root is None:
+            return False
+        try:
+            rel_path = Path(filepath).resolve().relative_to(self.root).as_posix()
+        except ValueError:
+            return False
+        return rel_path in self.script_entries or is_tooling_config(rel_path)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _iter_roots(path: Path) -> list[Path]:
+    """Yield the scan path and its parents, nearest first, up to a sane depth."""
+    resolved = path.resolve()
+    roots = [resolved]
+    current = resolved
+    for _ in range(_ROOT_SEARCH_DEPTH):
+        if current.parent == current:
+            break
+        current = current.parent
+        roots.append(current)
+    return roots
+
+
+def _find_root_with(path: Path, names: tuple[str, ...]) -> Path | None:
+    """Return the nearest root (scan path or ancestor) holding one of *names*."""
+    for root in _iter_roots(path):
+        if any((root / name).is_file() for name in names):
+            return root
+    return None
+
+
+def _read_package_json(root: Path) -> dict:
+    """Return the parsed package.json for *root*, or an empty dict."""
+    manifest = root / "package.json"
+    if not manifest.is_file():
+        return {}
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8", errors="replace"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _declared_dependencies(root: Path) -> set[str]:
+    """Return every dependency name declared in *root*'s package.json."""
+    data = _read_package_json(root)
+    names: set[str] = set()
+    for key in ("dependencies", "devDependencies", "peerDependencies"):
+        section = data.get(key)
+        if isinstance(section, dict):
+            names.update(section)
+    return names
+
+
+def _find_root_with_dependency(path: Path, packages: tuple[str, ...]) -> Path | None:
+    """Return the nearest root whose package.json declares one of *packages*."""
+    for root in _iter_roots(path):
+        if _declared_dependencies(root) & set(packages):
+            return root
+    return None
+
+
+def _read_config_text(root: Path, names: tuple[str, ...]) -> str:
+    """Return the text of the first config in *names* that exists under *root*."""
+    for name in names:
+        candidate = root / name
+        if candidate.is_file():
+            try:
+                return candidate.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                return ""
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Nuxt / Nitro
+# ---------------------------------------------------------------------------
+
+_NUXT_CONFIG_NAMES = (
+    "nuxt.config.ts",
+    "nuxt.config.mts",
+    "nuxt.config.js",
+    "nuxt.config.mjs",
+    "nuxt.config.cjs",
+)
+
+# Nitro reads these from ``serverDir``; every file under them is loaded by path.
+_NITRO_DIRS = ("api", "routes", "plugins", "middleware", "tasks", "utils")
+
+# Nuxt reads these from ``srcDir``: pages, layouts and middleware are routed,
+# plugins and modules are registered, components/composables/utils are
+# auto-imported by directory convention.
+_NUXT_SRC_DIRS = (
+    "pages",
+    "layouts",
+    "middleware",
+    "plugins",
+    "modules",
+    "components",
+    "composables",
+    "utils",
+)
+
+_NUXT_SRC_FILES = ("app.vue", "error.vue", "app.config.ts", "app.config.js")
+
+_SRC_DIR_RE = re.compile(r"""\bsrcDir\s*:\s*['"]([^'"]+)['"]""")
+_SERVER_DIR_RE = re.compile(r"""\bserverDir\s*:\s*['"]([^'"]+)['"]""")
+_IMPORTS_BLOCK_RE = re.compile(r"\bimports\s*:\s*\{(.*?)\}", re.DOTALL)
+_DIRS_ARRAY_RE = re.compile(r"\bdirs\s*:\s*\[(.*?)\]", re.DOTALL)
+_QUOTED_RE = re.compile(r"""['"]([^'"]+)['"]""")
+
+
+def _clean_dir(raw: str, src_dir: str) -> str | None:
+    """Normalise one configured directory into a root-relative POSIX prefix."""
+    value = raw.strip().split("*", 1)[0].strip()
+    for alias, base in (("~~/", ""), ("@@/", ""), ("~/", src_dir), ("@/", src_dir)):
+        if value.startswith(alias):
+            value = f"{base}/{value[len(alias) :]}" if base else value[len(alias) :]
+            break
+    else:
+        value = value.removeprefix("./")
+        if src_dir and not value.startswith(f"{src_dir}/") and value != src_dir:
+            value = f"{src_dir}/{value}"
+    value = value.strip("/")
+    return value or None
+
+
+def _nuxt_auto_import_dirs(config_text: str, src_dir: str) -> tuple[str, ...]:
+    """Return directories named by ``imports.dirs`` in a nuxt.config."""
+    block = _IMPORTS_BLOCK_RE.search(config_text)
+    if not block:
+        return ()
+    dirs = _DIRS_ARRAY_RE.search(block.group(1))
+    if not dirs:
+        return ()
+    cleaned = (_clean_dir(raw, src_dir) for raw in _QUOTED_RE.findall(dirs.group(1)))
+    return tuple(sorted({d for d in cleaned if d}))
+
+
+def detect_nuxt(path: Path) -> FrameworkEntryPoints | None:
+    """Return Nuxt/Nitro entry-point rules when *path* sits in a Nuxt project."""
+    root = _find_root_with(path, _NUXT_CONFIG_NAMES)
+    if root is None:
+        root = _find_root_with_dependency(path, ("nuxt", "nuxt3", "nuxt-edge"))
+    if root is None:
+        return None
+
+    config_text = _read_config_text(root, _NUXT_CONFIG_NAMES)
+
+    src_match = _SRC_DIR_RE.search(config_text)
+    if src_match:
+        src_dir = src_match.group(1).strip("./").rstrip("/")
+    elif (root / "app").is_dir():
+        # Nuxt 4 default. Nuxt 3 keeps the app directories at the project root.
+        src_dir = "app"
+    elif (root / "src").is_dir() and not (root / "pages").is_dir():
+        src_dir = "src"
+    else:
+        src_dir = ""
+
+    server_match = _SERVER_DIR_RE.search(config_text)
+    server_dir = (
+        server_match.group(1).strip("./").rstrip("/") if server_match else "server"
+    )
+
+    def under_src(name: str) -> str:
+        return f"{src_dir}/{name}" if src_dir else name
+
+    dir_prefixes = {under_src(name) for name in _NUXT_SRC_DIRS}
+    dir_prefixes.update(f"{server_dir}/{name}" for name in _NITRO_DIRS)
+    dir_prefixes.update(_nuxt_auto_import_dirs(config_text, src_dir))
+
+    exact_files = {under_src(name) for name in _NUXT_SRC_FILES}
+    exact_files.update(_NUXT_CONFIG_NAMES)
+
+    return FrameworkEntryPoints(
+        name="nuxt",
+        root=root,
+        dir_prefixes=tuple(sorted(dir_prefixes)),
+        exact_files=tuple(sorted(exact_files)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Next.js
+# ---------------------------------------------------------------------------
+
+_NEXTJS_CONFIG_NAMES = (
+    "next.config.js",
+    "next.config.mjs",
+    "next.config.cjs",
+    "next.config.ts",
+)
+
+# Files that are entry points when inside an app/ directory
+_NEXTJS_APP_DIR_CONVENTIONS: frozenset[str] = frozenset(
+    {
+        "page",
+        "layout",
+        "loading",
+        "error",
+        "not-found",
+        "global-error",
+        "route",
+        "template",
+        "default",
+        "opengraph-image",
+        "twitter-image",
+        "sitemap",
+        "robots",
+        "icon",
+        "apple-icon",
+    }
+)
+
+# Files that are entry points at the project root (or src/)
+_NEXTJS_ROOT_CONVENTIONS: frozenset[str] = frozenset(
+    {"middleware", "instrumentation", "instrumentation-client"}
+)
+
+
+def detect_nextjs(path: Path) -> FrameworkEntryPoints | None:
+    """Return Next.js entry-point rules when *path* sits in a Next.js project."""
+    root = _find_root_with(path, _NEXTJS_CONFIG_NAMES)
+    if root is None:
+        root = _find_root_with_dependency(path, ("next",))
+    if root is None:
+        return None
+
+    exact_files: set[str] = set(_NEXTJS_CONFIG_NAMES)
+    for stem in _NEXTJS_ROOT_CONVENTIONS:
+        for ext in (".ts", ".tsx", ".js", ".jsx"):
+            exact_files.add(f"{stem}{ext}")
+            exact_files.add(f"src/{stem}{ext}")
+
+    return FrameworkEntryPoints(
+        name="nextjs",
+        root=root,
+        dir_prefixes=("pages", "src/pages", "app/api", "src/app/api"),
+        exact_files=tuple(sorted(exact_files)),
+        stems_under_segment=(("app", _NEXTJS_APP_DIR_CONVENTIONS),),
+    )
+
+
+# ---------------------------------------------------------------------------
+# SvelteKit
+# ---------------------------------------------------------------------------
+
+_SVELTE_CONFIG_NAMES = ("svelte.config.js", "svelte.config.ts", "svelte.config.mjs")
+
+
+def detect_sveltekit(path: Path) -> FrameworkEntryPoints | None:
+    """Return SvelteKit entry-point rules when *path* sits in a SvelteKit project."""
+    root = _find_root_with_dependency(path, ("@sveltejs/kit",))
+    if root is None:
+        candidate = _find_root_with(path, _SVELTE_CONFIG_NAMES)
+        if candidate is None or not (candidate / "src" / "routes").is_dir():
+            return None
+        root = candidate
+
+    exact_files: set[str] = set()
+    for stem in ("hooks.server", "hooks.client", "hooks", "service-worker"):
+        for ext in (".ts", ".js"):
+            exact_files.add(f"src/{stem}{ext}")
+
+    return FrameworkEntryPoints(
+        name="sveltekit",
+        root=root,
+        dir_prefixes=("src/params",),
+        exact_files=tuple(sorted(exact_files)),
+        # Only ``+page``/``+layout``/``+server`` files are routed; a plain
+        # component colocated in src/routes still has to be imported.
+        name_prefixes=(("src/routes", "+"),),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Remix / React Router framework mode
+# ---------------------------------------------------------------------------
+
+
+def detect_remix(path: Path) -> FrameworkEntryPoints | None:
+    """Return Remix entry-point rules when *path* sits in a Remix project."""
+    root = _find_root_with_dependency(
+        path, ("@remix-run/react", "@remix-run/node", "@remix-run/dev")
+    )
+    if root is None:
+        root = _find_root_with(
+            path, ("remix.config.js", "remix.config.ts", "remix.config.mjs")
+        )
+    if root is None:
+        return None
+
+    exact_files: set[str] = set()
+    for stem in ("root", "entry.client", "entry.server", "routes"):
+        for ext in (".ts", ".tsx", ".js", ".jsx"):
+            exact_files.add(f"app/{stem}{ext}")
+
+    return FrameworkEntryPoints(
+        name="remix",
+        root=root,
+        dir_prefixes=("app/routes",),
+        exact_files=tuple(sorted(exact_files)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Astro
+# ---------------------------------------------------------------------------
+
+_ASTRO_CONFIG_NAMES = (
+    "astro.config.mjs",
+    "astro.config.ts",
+    "astro.config.js",
+    "astro.config.cjs",
+)
+
+
+def detect_astro(path: Path) -> FrameworkEntryPoints | None:
+    """Return Astro entry-point rules when *path* sits in an Astro project."""
+    root = _find_root_with(path, _ASTRO_CONFIG_NAMES)
+    if root is None:
+        root = _find_root_with_dependency(path, ("astro",))
+    if root is None:
+        return None
+
+    exact_files: set[str] = set(_ASTRO_CONFIG_NAMES)
+    for stem in ("middleware", "content/config"):
+        for ext in (".ts", ".js"):
+            exact_files.add(f"src/{stem}{ext}")
+
+    return FrameworkEntryPoints(
+        name="astro",
+        root=root,
+        dir_prefixes=("src/pages",),
+        exact_files=tuple(sorted(exact_files)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# react-email
+# ---------------------------------------------------------------------------
+
+
+def detect_react_email(path: Path) -> FrameworkEntryPoints | None:
+    """Return react-email entry-point rules: templates are discovered by folder."""
+    root = _find_root_with_dependency(path, ("react-email",))
+    if root is None:
+        return None
+    return FrameworkEntryPoints(
+        name="react-email",
+        root=root,
+        dir_prefixes=("emails", "src/emails", "app/emails"),
+    )
+
+
+_DETECTORS = (
+    detect_nuxt,
+    detect_nextjs,
+    detect_sveltekit,
+    detect_remix,
+    detect_astro,
+    detect_react_email,
+)
+
+
+# ---------------------------------------------------------------------------
+# package.json scripts
+# ---------------------------------------------------------------------------
+
+_SCRIPT_PATH_RE = re.compile(
+    r"""(?<![\w/.-])([\w.-]+(?:/[\w.@-]+)*\.(?:ts|tsx|js|jsx|mjs|cjs|mts))"""
+)
+
+
+def package_script_entries(root: Path) -> frozenset[str]:
+    """Return root-relative files invoked by package.json ``scripts``.
+
+    ``tsx server/db/seed.ts`` makes that file reachable however empty its
+    importer list is.
+    """
+    scripts = _read_package_json(root).get("scripts")
+    if not isinstance(scripts, dict):
+        return frozenset()
+
+    found: set[str] = set()
+    for command in scripts.values():
+        if not isinstance(command, str):
+            continue
+        for match in _SCRIPT_PATH_RE.findall(command):
+            candidate = match.removeprefix("./")
+            if (root / candidate).is_file():
+                found.add(candidate)
+    return frozenset(found)
+
+
+# ---------------------------------------------------------------------------
+# Entry points that belong to no single framework
+# ---------------------------------------------------------------------------
+
+
+def is_tooling_config(rel_path: str) -> bool:
+    """Return True for a top-level ``*.config.*`` file.
+
+    Vitest, Playwright, Drizzle, ESLint and friends are loaded by their own CLI,
+    never imported.
+    """
+    p = Path(rel_path)
+    if len(p.parts) != 1 or p.suffix not in _CONFIG_EXTENSIONS:
+        return False
+    return p.stem.endswith(".config") or p.stem == "config"
+
+
+def build_framework_context(path: Path) -> FrameworkContext:
+    """Detect every framework covering *path* and collect its entry-point rules."""
+    frameworks = [found for detect in _DETECTORS if (found := detect(path))]
+    root = frameworks[0].root if frameworks else None
+    if root is None:
+        for candidate in _iter_roots(path):
+            if (candidate / "package.json").is_file():
+                root = candidate
+                break
+    script_entries = package_script_entries(root) if root is not None else frozenset()
+    return FrameworkContext(
+        frameworks=frameworks, script_entries=script_entries, root=root
+    )
+
+
+__all__ = [
+    "FrameworkContext",
+    "FrameworkEntryPoints",
+    "build_framework_context",
+    "detect_astro",
+    "detect_nextjs",
+    "detect_nuxt",
+    "detect_react_email",
+    "detect_remix",
+    "detect_sveltekit",
+    "is_tooling_config",
+    "package_script_entries",
+]

--- a/desloppify/languages/typescript/detectors/deps/framework_aliases.py
+++ b/desloppify/languages/typescript/detectors/deps/framework_aliases.py
@@ -1,0 +1,77 @@
+"""Path aliases a framework injects rather than committing to tsconfig.json.
+
+Nuxt writes its ``compilerOptions.paths`` into ``.nuxt/tsconfig.*.json``, a
+generated directory that is gitignored and absent until ``nuxt prepare`` runs.
+The committed ``tsconfig.json`` is a bare list of project references, so every
+``~/…``, ``~~/…`` and ``#shared/…`` import resolves to nothing and the files
+behind those specifiers look like they have no importers at all.
+
+Reconstruct the aliases from the project layout instead of depending on a build
+artifact being present.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_NUXT_CONFIG_NAMES = (
+    "nuxt.config.ts",
+    "nuxt.config.mts",
+    "nuxt.config.js",
+    "nuxt.config.mjs",
+    "nuxt.config.cjs",
+)
+
+_SRC_DIR_RE = re.compile(r"""\bsrcDir\s*:\s*['"]([^'"]+)['"]""")
+
+
+def _nuxt_config_text(project_root: Path) -> str | None:
+    """Return the nuxt.config source for *project_root*, or None if there is none."""
+    for name in _NUXT_CONFIG_NAMES:
+        candidate = project_root / name
+        if candidate.is_file():
+            try:
+                return candidate.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                return ""
+    return None
+
+
+def nuxt_alias_paths(project_root: Path) -> dict[str, str]:
+    """Return Nuxt's built-in aliases as tsconfig-style prefix → directory pairs."""
+    config_text = _nuxt_config_text(project_root)
+    if config_text is None:
+        return {}
+
+    match = _SRC_DIR_RE.search(config_text)
+    if match:
+        src_dir = match.group(1).strip("./").rstrip("/")
+    elif (project_root / "app").is_dir():
+        # Nuxt 4 default. Nuxt 3 keeps the app sources at the project root.
+        src_dir = "app"
+    elif (project_root / "src").is_dir() and not (project_root / "pages").is_dir():
+        src_dir = "src"
+    else:
+        src_dir = ""
+
+    src_target = f"{src_dir}/" if src_dir else ""
+    aliases = {
+        # ~~ and @@ point at the project root, ~ and @ at srcDir. Longest prefix
+        # wins in resolve_alias(), so the two-character forms cannot shadow them.
+        "~~/": "",
+        "@@/": "",
+        "~/": src_target,
+        "@/": src_target,
+    }
+    if (project_root / "shared").is_dir():
+        aliases["#shared/"] = "shared/"
+    return aliases
+
+
+def framework_alias_paths(project_root: Path) -> dict[str, str]:
+    """Return alias mappings contributed by any framework detected at the root."""
+    return nuxt_alias_paths(project_root)
+
+
+__all__ = ["framework_alias_paths", "nuxt_alias_paths"]

--- a/desloppify/languages/typescript/detectors/deps/resolve.py
+++ b/desloppify/languages/typescript/detectors/deps/resolve.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Iterator
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
-from collections.abc import Iterator
 
 from desloppify.base.output.fallbacks import log_best_effort_failure
+from desloppify.languages.typescript.detectors.deps.framework_aliases import (
+    framework_alias_paths,
+)
 
 _RESOLVE_EXTENSIONS = ("", ".ts", ".tsx", "/index.ts", "/index.tsx")
 _JS_SPECIFIER_EXTENSIONS = {".js", ".mjs", ".cjs"}
@@ -53,7 +56,12 @@ def find_tsconfig_root(scan_path: Path, project_root: Path) -> Path:
 
 def parse_tsconfig_paths(project_root: Path) -> dict[str, str]:
     """Parse tsconfig paths from disk. Internal — use ``load_tsconfig_paths``."""
-    fallback = {"@/": "src/"}
+    framework_paths = framework_alias_paths(project_root)
+    fallback = framework_paths or {"@/": "src/"}
+
+    def merged(explicit: dict[str, str]) -> dict[str, str]:
+        """Explicit tsconfig mappings win; framework defaults fill the gaps."""
+        return {**framework_paths, **explicit}
 
     for name in ("tsconfig.json", "tsconfig.app.json", "jsconfig.json"):
         config_path = project_root / name
@@ -70,7 +78,7 @@ def parse_tsconfig_paths(project_root: Path) -> dict[str, str]:
             continue
         result = extract_paths(data, project_root)
         if result is not None:
-            return result
+            return merged(result)
         extends = data.get("extends")
         if isinstance(extends, str) and not extends.startswith("@"):
             parent_path = (config_path.parent / extends).resolve()
@@ -81,7 +89,7 @@ def parse_tsconfig_paths(project_root: Path) -> dict[str, str]:
                     return fallback
                 parent_result = extract_paths(parent_data, parent_path.parent)
                 if parent_result is not None:
-                    return parent_result
+                    return merged(parent_result)
         return fallback
 
     return fallback

--- a/desloppify/languages/typescript/tests/test_ts_deps.py
+++ b/desloppify/languages/typescript/tests/test_ts_deps.py
@@ -427,6 +427,91 @@ class TestTsconfigPaths:
         assert paths == {"@/": "src/"}
 
 
+class TestNuxtAliases:
+    """Nuxt keeps its path aliases in a generated, gitignored tsconfig.
+
+    The committed tsconfig.json is a list of project references, so relying on
+    ``compilerOptions.paths`` leaves every ``~/…`` and ``~~/…`` import
+    unresolved and makes the modules behind them look unimported.
+    """
+
+    def _nuxt4(self, tmp_path):
+        _write(tmp_path, "nuxt.config.ts", "export default defineNuxtConfig({})\n")
+        _write(
+            tmp_path,
+            "tsconfig.json",
+            json.dumps({"files": [], "references": [{"path": "./.nuxt/tsconfig.json"}]}),
+        )
+        (tmp_path / "app").mkdir(exist_ok=True)
+        (tmp_path / "shared").mkdir(exist_ok=True)
+
+    def test_tilde_points_at_the_src_dir_and_double_tilde_at_the_root(self, tmp_path):
+        """~/ resolves against srcDir, ~~/ against the project root."""
+        self._nuxt4(tmp_path)
+
+        paths = deps_detector_mod._load_tsconfig_paths(tmp_path)
+
+        assert paths["~/"] == "app/"
+        assert paths["@/"] == "app/"
+        assert paths["~~/"] == ""
+        assert paths["#shared/"] == "shared/"
+
+    def test_type_only_import_through_a_nuxt_alias_creates_an_edge(self, tmp_path):
+        """`import type { X } from '~~/shared/types/x'` still counts as an importer."""
+        self._nuxt4(tmp_path)
+        _write(tmp_path, "shared/types/today.ts", "export type TodayResponse = {}\n")
+        _write(
+            tmp_path,
+            "app/composables/useDailyToday.ts",
+            "import type { TodayResponse } from '~~/shared/types/today'\n",
+        )
+
+        graph = deps_detector_mod.build_dep_graph(tmp_path)
+
+        types_key = str((tmp_path / "shared/types/today.ts").resolve())
+        composable_key = str((tmp_path / "app/composables/useDailyToday.ts").resolve())
+        assert graph[types_key]["importer_count"] == 1
+        assert composable_key in graph[types_key]["importers"]
+
+    def test_a_vue_component_importing_through_tilde_counts_as_an_importer(
+        self, tmp_path
+    ):
+        """Auto-imported components still declare explicit `~/` imports."""
+        self._nuxt4(tmp_path)
+        _write(tmp_path, "app/constants/game-icons.ts", "export const GAME_ICONS = {}\n")
+        _write(
+            tmp_path,
+            "app/components/RosterNavRail.vue",
+            "<script setup>\nimport { GAME_ICONS } from '~/constants/game-icons'\n</script>\n",
+        )
+
+        graph = deps_detector_mod.build_dep_graph(tmp_path)
+
+        icons_key = str((tmp_path / "app/constants/game-icons.ts").resolve())
+        assert graph[icons_key]["importer_count"] == 1
+
+    def test_explicit_tsconfig_paths_win_over_the_framework_defaults(self, tmp_path):
+        """A project that does commit its paths keeps them."""
+        _write(tmp_path, "nuxt.config.ts", "export default defineNuxtConfig({})\n")
+        (tmp_path / "app").mkdir(exist_ok=True)
+        _write(
+            tmp_path,
+            "tsconfig.json",
+            json.dumps({"compilerOptions": {"paths": {"~/*": ["./custom/*"]}}}),
+        )
+
+        paths = deps_detector_mod._load_tsconfig_paths(tmp_path)
+
+        assert paths["~/"] == "custom/"
+        assert paths["~~/"] == ""
+
+    def test_a_non_nuxt_project_gains_no_tilde_aliases(self, tmp_path):
+        """The defaults are Nuxt's; a plain TS project keeps the old fallback."""
+        paths = deps_detector_mod._load_tsconfig_paths(tmp_path)
+
+        assert paths == {"@/": "src/"}
+
+
 # ── Framework file support ──────────────────────────────────────
 
 

--- a/desloppify/tests/detectors/test_orphaned.py
+++ b/desloppify/tests/detectors/test_orphaned.py
@@ -7,12 +7,11 @@ from unittest.mock import patch
 
 from desloppify.engine.detectors.orphaned import (
     OrphanedDetectionOptions,
-    _detect_nextjs_project,
     _has_dunder_all,
     _is_dynamically_imported,
-    _is_nextjs_convention_entry,
     detect_orphaned_files,
 )
+from desloppify.engine.detectors.orphaned_frameworks import detect_nextjs
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -525,95 +524,106 @@ class TestHasDunderAll:
 
 
 class TestDetectNextjsProject:
-    """Unit tests for _detect_nextjs_project."""
+    """A Next.js project is recognised by its config file or its dependency."""
 
     def test_next_config_js(self, tmp_path):
         (tmp_path / "next.config.js").write_text("module.exports = {}")
-        assert _detect_nextjs_project(tmp_path) is True
+        assert detect_nextjs(tmp_path) is not None
 
     def test_next_config_mjs(self, tmp_path):
         (tmp_path / "next.config.mjs").write_text("export default {}")
-        assert _detect_nextjs_project(tmp_path) is True
+        assert detect_nextjs(tmp_path) is not None
 
     def test_next_config_ts(self, tmp_path):
         (tmp_path / "next.config.ts").write_text("export default {}")
-        assert _detect_nextjs_project(tmp_path) is True
+        assert detect_nextjs(tmp_path) is not None
 
     def test_no_next_config(self, tmp_path):
-        assert _detect_nextjs_project(tmp_path) is False
+        assert detect_nextjs(tmp_path) is None
 
 
 class TestIsNextjsConventionEntry:
-    """Unit tests for _is_nextjs_convention_entry."""
+    """App Router convention files are entry points; ordinary modules are not."""
 
-    def test_page_in_app_dir(self):
-        assert _is_nextjs_convention_entry("app/dashboard/page.tsx") is True
+    @staticmethod
+    def _covers(tmp_path, rel_path: str) -> bool:
+        (tmp_path / "next.config.js").write_text("module.exports = {}")
+        found = detect_nextjs(tmp_path)
+        assert found is not None
+        return found.covers(rel_path)
 
-    def test_layout_in_app_dir(self):
-        assert _is_nextjs_convention_entry("app/layout.tsx") is True
+    def test_page_in_app_dir(self, tmp_path):
+        assert self._covers(tmp_path, "app/dashboard/page.tsx") is True
 
-    def test_loading_in_nested_app_dir(self):
-        assert _is_nextjs_convention_entry("app/shop/items/loading.jsx") is True
+    def test_layout_in_app_dir(self, tmp_path):
+        assert self._covers(tmp_path, "app/layout.tsx") is True
 
-    def test_route_handler(self):
-        assert _is_nextjs_convention_entry("app/api/users/route.ts") is True
+    def test_loading_in_nested_app_dir(self, tmp_path):
+        assert self._covers(tmp_path, "app/shop/items/loading.jsx") is True
 
-    def test_error_boundary(self):
-        assert _is_nextjs_convention_entry("app/error.tsx") is True
+    def test_route_handler(self, tmp_path):
+        assert self._covers(tmp_path, "app/api/users/route.ts") is True
 
-    def test_not_found(self):
-        assert _is_nextjs_convention_entry("app/not-found.tsx") is True
+    def test_error_boundary(self, tmp_path):
+        assert self._covers(tmp_path, "app/error.tsx") is True
 
-    def test_global_error(self):
-        assert _is_nextjs_convention_entry("app/global-error.tsx") is True
+    def test_not_found(self, tmp_path):
+        assert self._covers(tmp_path, "app/not-found.tsx") is True
 
-    def test_template(self):
-        assert _is_nextjs_convention_entry("app/template.tsx") is True
+    def test_global_error(self, tmp_path):
+        assert self._covers(tmp_path, "app/global-error.tsx") is True
 
-    def test_default_parallel_route(self):
-        assert _is_nextjs_convention_entry("app/@modal/default.tsx") is True
+    def test_template(self, tmp_path):
+        assert self._covers(tmp_path, "app/template.tsx") is True
 
-    def test_opengraph_image(self):
-        assert _is_nextjs_convention_entry("app/opengraph-image.tsx") is True
+    def test_default_parallel_route(self, tmp_path):
+        assert self._covers(tmp_path, "app/@modal/default.tsx") is True
 
-    def test_sitemap(self):
-        assert _is_nextjs_convention_entry("app/sitemap.ts") is True
+    def test_opengraph_image(self, tmp_path):
+        assert self._covers(tmp_path, "app/opengraph-image.tsx") is True
 
-    def test_robots(self):
-        assert _is_nextjs_convention_entry("app/robots.ts") is True
+    def test_sitemap(self, tmp_path):
+        assert self._covers(tmp_path, "app/sitemap.ts") is True
 
-    def test_middleware_at_root(self):
-        assert _is_nextjs_convention_entry("middleware.ts") is True
+    def test_robots(self, tmp_path):
+        assert self._covers(tmp_path, "app/robots.ts") is True
 
-    def test_middleware_in_src(self):
-        assert _is_nextjs_convention_entry("src/middleware.ts") is True
+    def test_middleware_at_root(self, tmp_path):
+        assert self._covers(tmp_path, "middleware.ts") is True
 
-    def test_instrumentation_at_root(self):
-        assert _is_nextjs_convention_entry("instrumentation.ts") is True
+    def test_middleware_in_src(self, tmp_path):
+        assert self._covers(tmp_path, "src/middleware.ts") is True
 
-    def test_instrumentation_client(self):
-        assert _is_nextjs_convention_entry("src/instrumentation-client.js") is True
+    def test_instrumentation_at_root(self, tmp_path):
+        assert self._covers(tmp_path, "instrumentation.ts") is True
 
-    def test_page_in_src_app(self):
-        assert _is_nextjs_convention_entry("src/app/page.tsx") is True
+    def test_instrumentation_client(self, tmp_path):
+        assert self._covers(tmp_path, "src/instrumentation-client.js") is True
 
-    def test_regular_file_in_app_not_matched(self):
+    def test_page_in_src_app(self, tmp_path):
+        assert self._covers(tmp_path, "src/app/page.tsx") is True
+
+    def test_pages_router_directory(self, tmp_path):
+        """The Pages Router routes everything under pages/."""
+        assert self._covers(tmp_path, "pages/blog/[slug].tsx") is True
+
+    def test_regular_file_in_app_not_matched(self, tmp_path):
         """A non-convention file inside app/ is NOT treated as entry."""
-        assert _is_nextjs_convention_entry("app/utils/helpers.ts") is False
+        assert self._covers(tmp_path, "app/utils/helpers.ts") is False
 
-    def test_page_outside_app_not_matched(self):
+    def test_page_outside_app_not_matched(self, tmp_path):
         """page.tsx outside an app/ directory is NOT treated as entry."""
-        assert _is_nextjs_convention_entry("src/components/page.tsx") is False
+        assert self._covers(tmp_path, "src/components/page.tsx") is False
 
-    def test_middleware_too_deep_not_matched(self):
+    def test_middleware_too_deep_not_matched(self, tmp_path):
         """middleware.ts nested more than one level deep is not an entry."""
-        assert _is_nextjs_convention_entry("src/lib/middleware.ts") is False
+        assert self._covers(tmp_path, "src/lib/middleware.ts") is False
 
-    def test_non_js_extension_not_matched(self):
-        assert _is_nextjs_convention_entry("app/page.py") is False
+    def test_non_js_extension_not_matched(self, tmp_path):
+        assert self._covers(tmp_path, "app/page.py") is False
 
-    def test_css_extension_not_matched(self):
-        assert _is_nextjs_convention_entry("app/page.css") is False
+    def test_css_extension_not_matched(self, tmp_path):
+        assert self._covers(tmp_path, "app/page.css") is False
 
 
 class TestNextjsIntegration:

--- a/desloppify/tests/detectors/test_orphaned_frameworks.py
+++ b/desloppify/tests/detectors/test_orphaned_frameworks.py
@@ -1,0 +1,351 @@
+"""Tests for framework-owned entry points in the orphaned-file detector.
+
+Every rule here states the same product claim from a different angle: a file a
+file-based router loads by path is not dead code, and a file nothing reaches is
+still reported.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from desloppify.engine.detectors.orphaned import (
+    OrphanedDetectionOptions,
+    detect_orphaned_files,
+)
+from desloppify.engine.detectors.orphaned_frameworks import (
+    build_framework_context,
+    detect_nuxt,
+    is_tooling_config,
+    package_script_entries,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(root: Path, rel_path: str, lines: int = 20) -> Path:
+    """Write a dummy source file of *lines* lines and return its path."""
+    target = root / rel_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("\n".join(f"line {i}" for i in range(lines)))
+    return target
+
+
+def _package_json(root: Path, **sections) -> None:
+    """Write a package.json with the given top-level sections."""
+    (root / "package.json").write_text(json.dumps(sections))
+
+
+def _nuxt4_project(root: Path) -> None:
+    """Lay out a minimal Nuxt 4 project: nuxt.config + app/ srcDir + server/."""
+    (root / "nuxt.config.ts").write_text(
+        "export default defineNuxtConfig({\n"
+        "  imports: { dirs: ['composables/**'] },\n"
+        "})\n"
+    )
+    _package_json(root, dependencies={"nuxt": "^4.5.0"})
+    (root / "app").mkdir(exist_ok=True)
+
+
+def _orphans(root: Path, files: list[Path]) -> set[str]:
+    """Run the detector over *files*, all with zero importers, and return the hits."""
+    graph = {
+        str(f): {"imports": set(), "importer_count": 0, "importers": []} for f in files
+    }
+    entries, _total = detect_orphaned_files(root, graph, [".ts", ".vue"])
+    return {str(Path(e["file"]).relative_to(root)) for e in entries}
+
+
+# ===================================================================
+# Nuxt / Nitro
+# ===================================================================
+
+
+class TestNuxtEntryPoints:
+    """A Nuxt project's routed, registered and auto-imported files are entries."""
+
+    def test_nitro_api_route_is_not_orphaned(self, tmp_path):
+        """A server/api handler is loaded by path, so zero importers is normal."""
+        _nuxt4_project(tmp_path)
+        handler = _write(tmp_path, "server/api/puzzle/[id]/submit.post.ts", lines=40)
+
+        assert _orphans(tmp_path, [handler]) == set()
+
+    def test_every_nitro_directory_is_an_entry_point(self, tmp_path):
+        """Nitro loads routes, plugins, middleware and tasks by location."""
+        _nuxt4_project(tmp_path)
+        files = [
+            _write(tmp_path, "server/routes/health.ts"),
+            _write(tmp_path, "server/plugins/pack-sync.ts"),
+            _write(tmp_path, "server/middleware/auth.ts"),
+            _write(tmp_path, "server/tasks/daily/generate.ts"),
+        ]
+
+        assert _orphans(tmp_path, files) == set()
+
+    def test_auto_imported_app_directories_are_entry_points(self, tmp_path):
+        """Components, composables, layouts, pages and plugins auto-register."""
+        _nuxt4_project(tmp_path)
+        files = [
+            _write(tmp_path, "app/components/daily/DailyGame.vue"),
+            _write(tmp_path, "app/composables/useLeaderboard.ts"),
+            _write(tmp_path, "app/layouts/default.vue"),
+            _write(tmp_path, "app/pages/index.vue"),
+            _write(tmp_path, "app/plugins/posthog.client.ts"),
+            _write(tmp_path, "app/middleware/admin.ts"),
+            _write(tmp_path, "app/utils/format-duration.ts"),
+        ]
+
+        assert _orphans(tmp_path, files) == set()
+
+    def test_app_and_error_roots_are_entry_points(self, tmp_path):
+        """app.vue and error.vue are the application shell, not dead files."""
+        _nuxt4_project(tmp_path)
+        files = [_write(tmp_path, "app/app.vue"), _write(tmp_path, "app/error.vue")]
+
+        assert _orphans(tmp_path, files) == set()
+
+    def test_unreferenced_library_module_is_still_reported(self, tmp_path):
+        """A lib module nothing imports is dead code, Nuxt project or not."""
+        _nuxt4_project(tmp_path)
+        dead = _write(tmp_path, "server/lib/crossword/abandoned-grader.ts", lines=40)
+
+        assert _orphans(tmp_path, [dead]) == {"server/lib/crossword/abandoned-grader.ts"}
+
+    def test_lookalike_directory_outside_a_nuxt_project_is_reported(self, tmp_path):
+        """server/api/ only means something when a Nuxt project claims it."""
+        _package_json(tmp_path, dependencies={"express": "^4.0.0"})
+        handler = _write(tmp_path, "server/api/thing.post.ts", lines=40)
+
+        assert _orphans(tmp_path, [handler]) == {"server/api/thing.post.ts"}
+
+    def test_custom_imports_dirs_are_honored(self, tmp_path):
+        """A directory listed in nuxt.config imports.dirs is auto-imported."""
+        (tmp_path / "nuxt.config.ts").write_text(
+            "export default defineNuxtConfig({\n"
+            "  imports: { dirs: ['stores/**', '~/helpers'] },\n"
+            "})\n"
+        )
+        _package_json(tmp_path, dependencies={"nuxt": "^4.5.0"})
+        (tmp_path / "app").mkdir()
+        files = [
+            _write(tmp_path, "app/stores/user.ts"),
+            _write(tmp_path, "app/helpers/dates.ts"),
+        ]
+
+        assert _orphans(tmp_path, files) == set()
+
+    def test_nuxt3_layout_keeps_app_directories_at_the_root(self, tmp_path):
+        """Without an app/ srcDir, pages and components live at the project root."""
+        (tmp_path / "nuxt.config.ts").write_text("export default defineNuxtConfig({})\n")
+        _package_json(tmp_path, dependencies={"nuxt": "^3.14.0"})
+        (tmp_path / "pages").mkdir()
+        files = [
+            _write(tmp_path, "pages/index.vue"),
+            _write(tmp_path, "components/Board.vue"),
+            _write(tmp_path, "server/api/today.get.ts"),
+        ]
+
+        assert _orphans(tmp_path, files) == set()
+
+    def test_explicit_src_dir_moves_the_app_directories(self, tmp_path):
+        """srcDir in nuxt.config decides where pages and components are read from."""
+        (tmp_path / "nuxt.config.ts").write_text(
+            "export default defineNuxtConfig({ srcDir: 'client/' })\n"
+        )
+        _package_json(tmp_path, dependencies={"nuxt": "^3.14.0"})
+        routed = _write(tmp_path, "client/pages/index.vue")
+        elsewhere = _write(tmp_path, "other/pages/index.vue", lines=30)
+
+        assert _orphans(tmp_path, [routed, elsewhere]) == {"other/pages/index.vue"}
+
+    def test_detection_falls_back_to_the_package_manifest(self, tmp_path):
+        """A nuxt dependency identifies the project when the config is elsewhere."""
+        _package_json(tmp_path, devDependencies={"nuxt": "^4.5.0"})
+        (tmp_path / "app").mkdir()
+
+        found = detect_nuxt(tmp_path)
+
+        assert found is not None
+        assert "server/api" in found.dir_prefixes
+        assert "app/components" in found.dir_prefixes
+
+    def test_no_nuxt_no_rules(self, tmp_path):
+        """A project with no Nuxt signal contributes no Nuxt entry points."""
+        _package_json(tmp_path, dependencies={"react": "^18.0.0"})
+
+        assert detect_nuxt(tmp_path) is None
+
+
+# ===================================================================
+# Other file-based routers
+# ===================================================================
+
+
+class TestOtherFrameworks:
+    """The same rule generalises to the other routers desloppify supports."""
+
+    def test_sveltekit_route_files_are_entry_points(self, tmp_path):
+        """SvelteKit routes +page/+server by filename prefix."""
+        _package_json(tmp_path, devDependencies={"@sveltejs/kit": "^2.0.0"})
+        files = [
+            _write(tmp_path, "src/routes/blog/+page.svelte"),
+            _write(tmp_path, "src/routes/api/+server.ts"),
+            _write(tmp_path, "src/hooks.server.ts"),
+        ]
+
+        assert _orphans(tmp_path, files) == set()
+
+    def test_sveltekit_colocated_component_is_still_reported(self, tmp_path):
+        """A component beside a route has no + prefix, so it must be imported."""
+        _package_json(tmp_path, devDependencies={"@sveltejs/kit": "^2.0.0"})
+        helper = _write(tmp_path, "src/routes/blog/Sidebar.svelte", lines=30)
+
+        assert _orphans(tmp_path, [helper]) == {"src/routes/blog/Sidebar.svelte"}
+
+    def test_remix_route_modules_are_entry_points(self, tmp_path):
+        """Remix loads app/routes and the entry/root modules by convention."""
+        _package_json(tmp_path, dependencies={"@remix-run/react": "^2.0.0"})
+        files = [
+            _write(tmp_path, "app/routes/_index.tsx"),
+            _write(tmp_path, "app/root.tsx"),
+            _write(tmp_path, "app/entry.server.tsx"),
+        ]
+
+        assert _orphans(tmp_path, files) == set()
+
+    def test_astro_pages_are_entry_points(self, tmp_path):
+        """Astro routes everything under src/pages."""
+        (tmp_path / "astro.config.mjs").write_text("export default {}\n")
+        _package_json(tmp_path, dependencies={"astro": "^4.0.0"})
+        files = [
+            _write(tmp_path, "src/pages/index.astro"),
+            _write(tmp_path, "src/middleware.ts"),
+        ]
+
+        assert _orphans(tmp_path, files) == set()
+
+    def test_nextjs_app_router_conventions_survive_the_refactor(self, tmp_path):
+        """page/layout/route inside app/ stay entry points, as before."""
+        (tmp_path / "next.config.js").write_text("module.exports = {}\n")
+        _package_json(tmp_path, dependencies={"next": "^15.0.0"})
+        files = [
+            _write(tmp_path, "app/dashboard/page.tsx"),
+            _write(tmp_path, "app/dashboard/layout.tsx"),
+            _write(tmp_path, "app/api/hook/route.ts"),
+            _write(tmp_path, "middleware.ts"),
+        ]
+
+        assert _orphans(tmp_path, files) == set()
+
+
+# ===================================================================
+# Entry points that belong to no framework
+# ===================================================================
+
+
+class TestToolingAndScriptEntries:
+    """Config files and package scripts reach code the import graph cannot see."""
+
+    def test_top_level_tool_config_is_not_orphaned(self, tmp_path):
+        """A CLI loads its own *.config.* file; nothing imports it."""
+        _package_json(tmp_path, dependencies={"vitest": "^3.0.0"})
+        files = [
+            _write(tmp_path, "vitest.config.ts"),
+            _write(tmp_path, "playwright.config.ts"),
+            _write(tmp_path, "drizzle.config.ts"),
+        ]
+
+        assert _orphans(tmp_path, files) == set()
+
+    def test_nested_config_lookalike_is_still_reported(self, tmp_path):
+        """Only a top-level config is tool-loaded; a nested one is ordinary code."""
+        _package_json(tmp_path, dependencies={"vitest": "^3.0.0"})
+        nested = _write(tmp_path, "src/feature/feature.config.ts", lines=30)
+
+        assert _orphans(tmp_path, [nested]) == {"src/feature/feature.config.ts"}
+
+    def test_is_tooling_config_rejects_a_plain_module(self):
+        """A top-level module that is not a *.config.* file gets no exemption."""
+        assert is_tooling_config("vitest.config.ts") is True
+        assert is_tooling_config("helpers.ts") is False
+        assert is_tooling_config("app/vitest.config.ts") is False
+
+    def test_file_invoked_by_a_package_script_is_not_orphaned(self, tmp_path):
+        """`tsx server/db/seed.ts` makes that file reachable."""
+        _package_json(
+            tmp_path,
+            scripts={"db:seed": "tsx server/db/seed.ts", "lint": "eslint ."},
+        )
+        seed = _write(tmp_path, "server/db/seed.ts", lines=40)
+        unused = _write(tmp_path, "server/db/leftover.ts", lines=40)
+
+        assert _orphans(tmp_path, [seed, unused]) == {"server/db/leftover.ts"}
+
+    def test_package_script_entries_ignores_paths_that_do_not_exist(self, tmp_path):
+        """A script naming a missing file contributes nothing."""
+        _package_json(tmp_path, scripts={"build": "tsx scripts/ghost.ts"})
+
+        assert package_script_entries(tmp_path) == frozenset()
+
+    def test_react_email_templates_are_discovered_by_folder(self, tmp_path):
+        """react-email renders whatever sits in emails/, imported or not."""
+        _package_json(tmp_path, devDependencies={"react-email": "^6.9.0"})
+        template = _write(tmp_path, "emails/MagicLink.tsx", lines=40)
+
+        assert _orphans(tmp_path, [template]) == set()
+
+
+# ===================================================================
+# Opting out
+# ===================================================================
+
+
+class TestFrameworkDetectionCanBeDisabled:
+    """detect_frameworks=False restores the plain graph check."""
+
+    def test_disabled_detection_reports_framework_entry_points(self, tmp_path):
+        """With the flag off, a Nitro handler is judged on importers alone."""
+        _nuxt4_project(tmp_path)
+        handler = _write(tmp_path, "server/api/today.get.ts", lines=40)
+        graph = {
+            str(handler): {"imports": set(), "importer_count": 0, "importers": []}
+        }
+
+        entries, _total = detect_orphaned_files(
+            tmp_path,
+            graph,
+            [".ts"],
+            options=OrphanedDetectionOptions(detect_frameworks=False),
+        )
+
+        assert [e["file"] for e in entries] == [str(handler)]
+
+
+class TestFrameworkContext:
+    """The context reports which frameworks it recognised."""
+
+    def test_a_nuxt_project_with_react_email_reports_both(self, tmp_path):
+        """Frameworks stack: each contributes its own entry points."""
+        _nuxt4_project(tmp_path)
+        _package_json(
+            tmp_path,
+            dependencies={"nuxt": "^4.5.0"},
+            devDependencies={"react-email": "^6.9.0"},
+        )
+
+        context = build_framework_context(tmp_path)
+
+        assert {fw.name for fw in context.frameworks} == {"nuxt", "react-email"}
+
+    def test_a_plain_typescript_project_detects_nothing(self, tmp_path):
+        """No framework, no manifest scripts: the context is empty."""
+        _package_json(tmp_path, dependencies={"lodash": "^4.0.0"})
+
+        context = build_framework_context(tmp_path)
+
+        assert context.frameworks == []
+        assert context.script_entries == frozenset()


### PR DESCRIPTION
Withdrawn.

The measurements behind this were taken from a private codebase, and publishing its
shape was not something I had the standing to do. Body redacted for that reason.

The underlying issue is still real and worth fixing by someone: the `orphaned`
detector recognises only Next.js App Router conventions, so on any other
file-based-router framework it reports the entire routing surface as dead code —
nothing imports a route that the router loads by path. A second, separate cause is
that when a framework writes its `compilerOptions.paths` into a generated,
gitignored tsconfig, alias resolution falls back to a default that matches nothing,
so aliased imports look unresolvable.

Happy to reopen against a public fixture if a maintainer wants it.
