### PR TITLE
fix: accept Codex batch JSON with token footer

### DIFF
--- a/desloppify/app/commands/review/runner_process_impl/io.py
+++ b/desloppify/app/commands/review/runner_process_impl/io.py
@@ -37,7 +37,8 @@ def _output_file_has_json_payload(output_file: Path) -> bool:
     if not output_file.exists():
         return False
     try:
-        payload = json.loads(output_file.read_text(encoding="utf-8", errors="replace"))
+        text = output_file.read_text(encoding="utf-8", errors="replace").lstrip()
+        payload, _ = json.JSONDecoder().raw_decode(text)
     except (OSError, json.JSONDecodeError):
         return False
     return isinstance(payload, dict)

--- a/desloppify/tests/review/test_runner_internals.py
+++ b/desloppify/tests/review/test_runner_internals.py
@@ -90,6 +90,11 @@ class TestOutputFileHasJsonPayload:
         p.write_text('{"assessments": {}}')
         assert _output_file_has_json_payload(p) is True
 
+    def test_valid_json_dict_with_codex_token_footer(self, tmp_path):
+        p = tmp_path / "out.json"
+        p.write_text('{"assessments": {}, "issues": []}\ntokens used\n1,234')
+        assert _output_file_has_json_payload(p) is True
+
     def test_json_array_rejected(self, tmp_path):
         p = tmp_path / "out.json"
         p.write_text("[1, 2, 3]")


### PR DESCRIPTION
## Summary

- accept a valid Codex batch JSON object followed by the `tokens used` footer
- add regression coverage for the footer format

## Root cause

The runner validated the entire output with `json.loads()`, although the downstream batch parser already accepts a leading JSON object with trailing text. A valid Codex result was therefore reported as missing or invalid.

## Validation

- RED: footer regression test failed before the fix
- GREEN: 76 related tests passed
- Ruff critical checks passed

Fixes #698
