### PR TITLE
fix: fail empty plan skip

### DIFF
--- a/desloppify/app/commands/plan/override/skip.py
+++ b/desloppify/app/commands/plan/override/skip.py
@@ -222,8 +222,7 @@ def cmd_plan_skip(args: argparse.Namespace) -> None:
     plan = load_plan(plan_file)
     issue_ids = resolve_ids_from_patterns(state, patterns, plan=plan)
     if not issue_ids:
-        print(colorize("  No matching issues found.", "yellow"))
-        return
+        raise CommandError("No matching issues found.", exit_code=1)
 
     _warn_or_block_bulk_skip(issue_ids, confirm=bool(getattr(args, "confirm", False)))
 

--- a/desloppify/tests/commands/plan/test_plan_overrides_direct.py
+++ b/desloppify/tests/commands/plan/test_plan_overrides_direct.py
@@ -692,6 +692,32 @@ def test_override_skip_helpers_and_commands(monkeypatch, capsys) -> None:
         lambda *_a, **_k: [f"i{n}" for n in range(6)],
     )
 
+    monkeypatch.setattr(
+        override_skip_mod,
+        "resolve_ids_from_patterns",
+        lambda *_a, **_k: [],
+    )
+    with pytest.raises(CommandError) as excinfo:
+        override_skip_mod.cmd_plan_skip(
+            argparse.Namespace(
+                patterns=["missing"],
+                reason=None,
+                review_after=None,
+                permanent=False,
+                false_positive=False,
+                note=None,
+                attest=None,
+                confirm=False,
+            )
+        )
+    assert excinfo.value.exit_code == 1
+
+    monkeypatch.setattr(
+        override_skip_mod,
+        "resolve_ids_from_patterns",
+        lambda *_a, **_k: [f"i{n}" for n in range(6)],
+    )
+
     with pytest.raises(CommandError):
         override_skip_mod.cmd_plan_skip(
             argparse.Namespace(


### PR DESCRIPTION
Fixes #674

Root cause: `plan skip` printed a warning and returned normally when no issue matched, so automation observed exit 0.

Change: raise `CommandError` with exit code 1 and cover the no-match path.

Validation: 58 related tests passed.