### PR TITLE
fix(java): use PMD -f text instead of unparseable textcolor

### DIFF
--- a/desloppify/languages/java/__init__.py
+++ b/desloppify/languages/java/__init__.py
@@ -22,7 +22,7 @@ def _pmd_threads_arg(raw: str | None = None) -> str:
 
 PMD_COMMAND = (
     "pmd check -d . -R rulesets/java/quickstart.xml "
-    f"{_pmd_threads_arg()} -f textcolor 2>&1"
+    f"{_pmd_threads_arg()} -f text 2>&1"
 )
 
 generic_lang(


### PR DESCRIPTION
## Problem
`desloppify scan` on a Java project reports `pmd tooling unavailable (tool_failed_unparsed_output)` even when PMD 7 is installed and on PATH. The java language module runs `pmd check ... -f textcolor` but declares `fmt: "gnu"` for the detector — textcolor emits a multi-line human report that the gnu parser cannot read, so every PMD scan fails as "unparsed output" and the pmd_violation detector silently reports nothing.

Command used: `desloppify scan --path .` in a Java/Gradle project with PMD 7.26 installed via Homebrew.

## Fix
Change the format flag from `textcolor` to `text` in `PMD_COMMAND` (desloppify/languages/java/__init__.py). `pmd check -f text` emits one-line `file:line:\trule:\tmessage` records that the gnu parser consumes correctly.

Verified against a scratch Java project: with the fix, the pmd tool step completes and UnusedPrivateField/ControlStatementBraces violations are detected; no coverage-reduced warning. Full test suite: 5660 passed; the 3 failing tests in `test_bash_unused_imports.py` fail identically on main (pre-existing, unrelated).