### PR TITLE
fix: run ESLint directly on Next.js 16+ in next_lint tool

### DIFF
--- a/desloppify/languages/_framework/frameworks/phases.py
+++ b/desloppify/languages/_framework/frameworks/phases.py
@@ -132,25 +132,25 @@ def _framework_smells_phase(spec: FrameworkSpec) -> DetectorPhase:
 
 
 def _framework_tool_phase(spec: FrameworkSpec, tool: ToolIntegration) -> DetectorPhase:
-    tool_phase = make_tool_phase(
-        tool.label,
-        tool.cmd,
-        tool.fmt,
-        tool.id,
-        tool.tier,
-        confidence=tool.confidence,
-    )
-    tool_phase.slow = bool(tool.slow)
-
     def run(path: Path, lang: LangRuntimeContract) -> tuple[list[Issue], dict[str, int]]:
         detection = detect_ecosystem_frameworks(path, lang, spec.ecosystem)
         if spec.id not in detection.present:
             return [], {}
 
         scan_root = detection.package_root
+        cmd = tool.cmd(scan_root) if callable(tool.cmd) else tool.cmd
+        tool_phase = make_tool_phase(
+            tool.label,
+            cmd,
+            tool.fmt,
+            tool.id,
+            tool.tier,
+            confidence=tool.confidence,
+        )
+        tool_phase.slow = bool(tool.slow)
         return tool_phase.run(scan_root, lang)
 
-    return DetectorPhase(tool_phase.label, run, slow=tool_phase.slow)
+    return DetectorPhase(tool.label, run, slow=bool(tool.slow))
 
 
 def framework_phases(lang_name: str) -> list[DetectorPhase]:

--- a/desloppify/languages/_framework/frameworks/specs/nextjs.py
+++ b/desloppify/languages/_framework/frameworks/specs/nextjs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -522,6 +523,24 @@ NEXTJS_SCANNERS: tuple[ScannerRule, ...] = (
 )
 
 
+def next_lint_cmd(scan_root: Path) -> str:
+    """Resolve the lint command for the installed Next.js version.
+
+    Next.js 16 removed the ``next lint`` subcommand, so ``next lint`` is
+    parsed as ``next <dir>`` and exits without linting. On Next.js >= 16,
+    run ESLint directly instead (its JSON output has the same shape).
+    """
+    package_json = scan_root / "node_modules" / "next" / "package.json"
+    try:
+        data = json.loads(package_json.read_text(encoding="utf-8"))
+        major = int(str(data.get("version", "0")).split(".", 1)[0])
+    except (OSError, ValueError, TypeError):
+        major = 0
+    if major >= 16:
+        return "npx --no-install eslint --format json ."
+    return "npx --no-install next lint --format json"
+
+
 NEXTJS_SPEC = FrameworkSpec(
     id="nextjs",
     label="Next.js",
@@ -544,7 +563,7 @@ NEXTJS_SPEC = FrameworkSpec(
         ToolIntegration(
             id="next_lint",
             label="next lint",
-            cmd="npx --no-install next lint --format json",
+            cmd=next_lint_cmd,
             fmt="next_lint",
             tier=2,
             slow=True,
@@ -554,4 +573,4 @@ NEXTJS_SPEC = FrameworkSpec(
 )
 
 
-__all__ = ["NEXTJS_SPEC"]
+__all__ = ["NEXTJS_SPEC", "next_lint_cmd"]

--- a/desloppify/languages/_framework/frameworks/types.py
+++ b/desloppify/languages/_framework/frameworks/types.py
@@ -46,7 +46,7 @@ class ToolIntegration:
 
     id: str  # detector id (e.g. "next_lint")
     label: str
-    cmd: str
+    cmd: str | Callable[[Path], str]
     fmt: str
     tier: int
     slow: bool = False

--- a/desloppify/tests/detectors/test_next_lint.py
+++ b/desloppify/tests/detectors/test_next_lint.py
@@ -9,6 +9,11 @@ from types import SimpleNamespace
 
 import pytest
 
+from desloppify.languages._framework.frameworks.phases import _framework_tool_phase
+from desloppify.languages._framework.frameworks.specs.nextjs import (
+    NEXTJS_SPEC,
+    next_lint_cmd,
+)
 from desloppify.languages._framework.generic_parts.parsers import (
     ToolParserError,
     parse_next_lint,
@@ -184,3 +189,100 @@ def test_next_lint_tool_phase_records_coverage_warning_on_parser_error(monkeypat
     assert signals == {}
     assert lang.detector_coverage["next_lint"]["reason"] == "parser_error"
     assert lang.coverage_warnings and lang.coverage_warnings[0]["detector"] == "next_lint"
+
+
+def _write_next_project(root: Path, *, declared: str, installed: str | None) -> Path:
+    package_root = root / "app"
+    package_root.mkdir(parents=True)
+    (package_root / "package.json").write_text(
+        json.dumps({"dependencies": {"next": declared}}),
+        encoding="utf-8",
+    )
+    if installed is not None:
+        next_pkg = package_root / "node_modules" / "next"
+        next_pkg.mkdir(parents=True)
+        (next_pkg / "package.json").write_text(
+            json.dumps({"version": installed}),
+            encoding="utf-8",
+        )
+    return package_root
+
+
+def test_next_lint_cmd_runs_eslint_directly_on_next_16(tmp_path):
+    package_root = _write_next_project(tmp_path, declared="^15.0.0", installed="16.3.0")
+    assert next_lint_cmd(package_root) == "npx --no-install eslint --format json ."
+
+
+def test_next_lint_cmd_keeps_next_lint_on_next_15(tmp_path):
+    package_root = _write_next_project(tmp_path, declared="^15.0.0", installed="15.4.0")
+    assert next_lint_cmd(package_root) == "npx --no-install next lint --format json"
+
+
+def test_next_lint_cmd_falls_back_when_next_not_installed(tmp_path):
+    package_root = _write_next_project(tmp_path, declared="^15.0.0", installed=None)
+    assert next_lint_cmd(package_root) == "npx --no-install next lint --format json"
+
+
+def test_next_lint_cmd_falls_back_on_malformed_package_json(tmp_path):
+    package_root = _write_next_project(tmp_path, declared="^15.0.0", installed=None)
+    next_pkg = package_root / "node_modules" / "next"
+    next_pkg.mkdir(parents=True)
+    (next_pkg / "package.json").write_text("not json", encoding="utf-8")
+    assert next_lint_cmd(package_root) == "npx --no-install next lint --format json"
+
+
+def test_framework_tool_phase_uses_eslint_on_next_16(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    package_root = _write_next_project(tmp_path, declared="^15.0.0", installed="16.3.0")
+
+    seen_argv: list[str] = []
+
+    def fake_run(argv, *, shell, cwd, capture_output, text, timeout):
+        seen_argv.extend(argv)
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout=json.dumps(
+                [{"filePath": str(package_root / "a.js"), "messages": []}]
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(tool_runner_mod.subprocess, "run", fake_run)
+
+    phase = _framework_tool_phase(NEXTJS_SPEC, NEXTJS_SPEC.tools[0])
+    lang = SimpleNamespace(detector_coverage={}, coverage_warnings=[])
+
+    issues, signals = phase.run(package_root, lang)
+    assert issues == []
+    assert signals == {"next_lint": 1}
+    assert "eslint" in seen_argv
+    assert "lint" not in seen_argv
+
+
+def test_framework_tool_phase_uses_next_lint_on_next_15(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    package_root = _write_next_project(tmp_path, declared="^15.0.0", installed="15.4.0")
+
+    seen_argv: list[str] = []
+
+    def fake_run(argv, *, shell, cwd, capture_output, text, timeout):
+        seen_argv.extend(argv)
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout=json.dumps(
+                [{"filePath": str(package_root / "a.js"), "messages": []}]
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(tool_runner_mod.subprocess, "run", fake_run)
+
+    phase = _framework_tool_phase(NEXTJS_SPEC, NEXTJS_SPEC.tools[0])
+    lang = SimpleNamespace(detector_coverage={}, coverage_warnings=[])
+
+    issues, signals = phase.run(package_root, lang)
+    assert issues == []
+    assert signals == {"next_lint": 1}
+    assert "next" in seen_argv and "lint" in seen_argv


### PR DESCRIPTION
## Problem

Fixes #709

Next.js 16 removed the `next lint` subcommand. The hardcoded `npx --no-install next lint --format json` in `NEXTJS_SPEC` is now parsed as `next <dir>` and exits without linting:

```
Invalid project directory provided, no such directory: /path/to/project/lint
```

The tool phase records reduced coverage (`parser_error`) and reports **zero** lint issues, so a Next 16 codebase reads as lint-clean.

## Fix

- `next_lint_cmd(scan_root)` resolves the command from the **installed** Next.js major (`node_modules/next/package.json`, not the declared range — `^15.0.0` can resolve to 16). On >= 16 it runs `npx --no-install eslint --format json .` directly; ESLint's JSON output has the same shape the `next_lint` parser already consumes.
- `ToolIntegration.cmd` now accepts `str | Callable[[Path], str]`; `_framework_tool_phase` resolves it per scan root.
- Falls back to `next lint` when Next is not installed, the version is unreadable, or the major is < 16.

## Tests

- `next_lint_cmd`: Next 16 → ESLint command; Next 15 → `next lint`; missing install → fallback; malformed package.json → fallback.
- Tool-phase integration: a project with installed `next@16` executes the ESLint command (verified RED with the old static command — argv contained `lint`); `next@15` still executes `next lint`.
- `desloppify/tests/detectors` + `tests/scan`: 974 passed. Full suite: only the pre-existing `test_bash_unused_source_directive_is_flagged` failure (fails on `main` without this change too).

## Checklist

- [x] Tests added (RED before fix, GREEN after)
- [x] Existing tests pass
- [x] Syntax lint clean (`ruff --select E9,F63,F7,F82` scope)