### PR TITLE
fix: harden TypeScript project and async detection

### DIFF
--- a/desloppify/languages/typescript/detectors/smells/detector_flow.py
+++ b/desloppify/languages/typescript/detectors/smells/detector_flow.py
@@ -31,9 +31,68 @@ from .detector_core import (
 )
 from .helpers import (
     _code_text,
+    _extract_block_body,
     _strip_ts_comments,
     _track_brace_body,
 )
+
+
+def _extract_async_declaration_body(lines: list[str], index: int) -> str | None:
+    """Extract an async declaration body without mistaking typed parameter braces for it."""
+    fragment = "\n".join(lines[index : index + 2000])
+    code = _code_text(fragment)
+    opening_paren = code.find("(")
+    if opening_paren == -1:
+        return None
+
+    paren_depth = 0
+    closing_paren = None
+    for cursor in range(opening_paren, len(code)):
+        char = code[cursor]
+        if char == "(":
+            paren_depth += 1
+        elif char == ")":
+            paren_depth -= 1
+            if paren_depth == 0:
+                closing_paren = cursor
+                break
+    if closing_paren is None:
+        return None
+
+    cursor = closing_paren + 1
+    while cursor < len(code) and code[cursor].isspace():
+        cursor += 1
+    has_return_type = cursor < len(code) and code[cursor] == ":"
+    if has_return_type:
+        cursor += 1
+        while cursor < len(code) and code[cursor].isspace():
+            cursor += 1
+    direct_object_return = has_return_type and cursor < len(code) and code[cursor] == "{"
+
+    angle_depth = 0
+    square_depth = 0
+    type_brace_depth = 0
+    for body_cursor in range(cursor, len(code)):
+        char = code[body_cursor]
+        if char == "<" and type_brace_depth == 0:
+            angle_depth += 1
+        elif char == ">" and angle_depth > 0 and type_brace_depth == 0:
+            angle_depth -= 1
+        elif char == "[" and type_brace_depth == 0:
+            square_depth += 1
+        elif char == "]" and square_depth > 0 and type_brace_depth == 0:
+            square_depth -= 1
+        elif char == "{" and angle_depth == 0 and square_depth == 0:
+            if direct_object_return or type_brace_depth > 0:
+                type_brace_depth += 1
+                direct_object_return = False
+            else:
+                return _extract_block_body(
+                    fragment, body_cursor, max_scan=len(fragment) - body_cursor
+                )
+        elif char == "}" and type_brace_depth > 0:
+            type_brace_depth -= 1
+    return None
 
 
 def _detect_async_no_await(ctx, smell_counts: dict[str, list[dict]]) -> None:
@@ -44,7 +103,11 @@ def _detect_async_no_await(ctx, smell_counts: dict[str, list[dict]]) -> None:
         if not match:
             continue
         name = match.group(1) or match.group(2)
-        body = _extract_function_body(ctx.lines, index)
+        body = (
+            _extract_async_declaration_body(ctx.lines, index)
+            if match.group(1)
+            else _extract_function_body(ctx.lines, index)
+        )
         if body is not None and not re.search(r"\bawait\b", _code_text(body)):
             _emit(
                 smell_counts,

--- a/desloppify/languages/typescript/detectors/unused.py
+++ b/desloppify/languages/typescript/detectors/unused.py
@@ -78,20 +78,44 @@ def _run_tsc_unused_check(
     )
 
 
+def _find_nearest_tsconfig(path: Path) -> Path | None:
+    """Return the closest TypeScript config that owns ``path``.
+
+    Prefer an application config when both conventional config names exist in
+    the same directory. Walking upward keeps scans of monorepo projects scoped
+    to that project's config instead of assuming the repository root is a
+    single application.
+    """
+    current = path.resolve()
+    if current.is_file():
+        current = current.parent
+
+    for directory in (current, *current.parents):
+        for config_name in ("tsconfig.app.json", "tsconfig.json"):
+            candidate = directory / config_name
+            if candidate.is_file():
+                return candidate
+    return None
+
+
 def detect_unused(path: Path, category: str = "all") -> tuple[list[dict], int]:
     ts_files = find_ts_and_tsx_files(path)
     total_files = len(ts_files)
     if _should_use_deno_fallback(path, ts_files):
         return _detect_unused_fallback(path, category)
 
+    base_tsconfig = _find_nearest_tsconfig(path)
+    if base_tsconfig is None:
+        return _detect_unused_fallback(path, category)
+
     tmp_tsconfig = {
-        "extends": "./tsconfig.app.json",
+        "extends": f"./{base_tsconfig.name}",
         "compilerOptions": {
             "noUnusedLocals": True,
             "noUnusedParameters": True,
         },
     }
-    tmp_path = get_project_root() / "tsconfig.desloppify.json"
+    tmp_path = base_tsconfig.parent / "tsconfig.desloppify.json"
     try:
         safe_write_text(tmp_path, json.dumps(tmp_tsconfig, indent=2))
         try:

--- a/desloppify/languages/typescript/tests/smells/test_ts_smell_helpers.py
+++ b/desloppify/languages/typescript/tests/smells/test_ts_smell_helpers.py
@@ -357,6 +357,31 @@ class TestDetectAsyncNoAwait:
         _detect_async_no_await(_ctx(content), counts)
         assert len(counts["async_no_await"]) == 0
 
+    def test_multiline_typed_parameter_does_not_hide_await(self):
+        content = (
+            "export async function fetchData(args: {\n"
+            "  readonly path: string;\n"
+            "  readonly timeout: number;\n"
+            "}): Promise<void> {\n"
+            "  await fetch(args.path);\n"
+            "}\n"
+        )
+        counts = _make_counts()
+        _detect_async_no_await(_ctx(content), counts)
+        assert len(counts["async_no_await"]) == 0
+
+    def test_multiline_typed_parameter_without_await_is_flagged(self):
+        content = (
+            "export async function fetchData(args: {\n"
+            "  readonly path: string;\n"
+            "}): Promise<string> {\n"
+            "  return args.path;\n"
+            "}\n"
+        )
+        counts = _make_counts()
+        _detect_async_no_await(_ctx(content), counts)
+        assert len(counts["async_no_await"]) == 1
+
 
 class TestDetectErrorNoThrow:
     def test_flags_error_without_throw(self):

--- a/desloppify/languages/typescript/tests/test_ts_unused.py
+++ b/desloppify/languages/typescript/tests/test_ts_unused.py
@@ -4,6 +4,7 @@ Note: detect_unused depends on tsc (TypeScript compiler) and a real project setu
 so we test what is feasible: the helper function _categorize_unused and module imports.
 """
 
+import json
 from pathlib import Path
 
 import pytest
@@ -224,6 +225,7 @@ class TestDenoFallback:
 
     def test_detect_unused_non_deno_keeps_tsc_path(self, tmp_path, monkeypatch):
         """Regular TypeScript projects should still parse TS6133/TS6192 from tsc."""
+        _write(tmp_path, "tsconfig.json", "{}\n")
         _write(tmp_path, "src/app.ts", "const x = 1;\n")
 
         class _Result:
@@ -254,6 +256,7 @@ class TestDenoFallback:
     ):
         """A repo-level deno.lock alone should not disable tsc-based unused detection."""
         _write(tmp_path, "deno.lock", "{}\n")
+        _write(tmp_path, "tsconfig.json", "{}\n")
         _write(tmp_path, "src/app.ts", "const x = 1;\n")
 
         class _Result:
@@ -278,3 +281,39 @@ class TestDenoFallback:
         assert calls["count"] == 1
         assert total == 1
         assert entries and entries[0]["name"] == "x"
+
+    def test_detect_unused_uses_nearest_monorepo_tsconfig(self, tmp_path, monkeypatch):
+        """A nested project must not inherit an unrelated root app config."""
+        _write(tmp_path, "tsconfig.app.json", "{}\n")
+        _write(tmp_path, "libs/contracts/tsconfig.json", "{}\n")
+        _write(tmp_path, "libs/contracts/src/index.ts", "const x = 1;\n")
+
+        recorded: dict[str, object] = {}
+
+        class _Result:
+            stdout = ""
+            stderr = ""
+
+        def _fake_run(project_root, tsconfig_path):
+            recorded["project_root"] = project_root
+            recorded["tsconfig_path"] = tsconfig_path
+            recorded["config"] = json.loads(tsconfig_path.read_text())
+            return _Result()
+
+        monkeypatch.setattr(ts_unused_mod, "_run_tsc_unused_check", _fake_run)
+
+        entries, total = detect_unused(tmp_path / "libs/contracts")
+
+        assert entries == []
+        assert total == 1
+        assert recorded["tsconfig_path"] == (
+            tmp_path / "libs/contracts/tsconfig.desloppify.json"
+        )
+        assert recorded["config"] == {
+            "extends": "./tsconfig.json",
+            "compilerOptions": {
+                "noUnusedLocals": True,
+                "noUnusedParameters": True,
+            },
+        }
+        assert not (tmp_path / "libs/contracts/tsconfig.desloppify.json").exists()


### PR DESCRIPTION
## Problems

1. Running `desloppify scan --path libs/cognito-deploy-contracts` in a TypeScript monorepo creates `tsconfig.desloppify.json` at the repository root with a hard-coded `extends: ./tsconfig.app.json`. Library projects commonly own `tsconfig.json` instead, so the unused detector type-checks the wrong project or falls back after a timeout.
2. The `async_no_await` smell detector treats the first `{` in a multiline typed parameter as the function body. It therefore flags async declarations that contain direct `await` expressions whenever their argument uses an inline object type.

## Fixes

- Locate the nearest owning `tsconfig.app.json` or `tsconfig.json`, create the temporary override beside it, and extend that config. If no TypeScript config exists, use the existing source-based fallback directly.
- Parse the complete parameter list before locating an async declaration body, including multiline inline-object parameters and return types, then inspect the real body for `await`.
- Add regression coverage for both defects.

## Validation

- `pytest desloppify/languages/typescript/tests/test_ts_unused.py -q` — 19 passed
- `pytest desloppify/languages/typescript/tests/ -q` — 429 passed
- Focused async smell helper suite — 89 passed
- `python -m pytest desloppify/tests/ -q` — 5651 passed, 153 skipped, 3 unrelated Bash failures
- The same 3 Bash failures reproduce without these changes
- Verified against WorkOrderGuard: library-local TypeScript config resolution works, and false `async_no_await` findings fell from 10 to 0
