### PR TITLE
fix(runner): decode live Codex subprocess output as UTF-8

### DIFF
--- a/desloppify/app/commands/review/runner_process_impl/attempts.py
+++ b/desloppify/app/commands/review/runner_process_impl/attempts.py
@@ -125,6 +125,8 @@ def _start_runner_process(
             stderr=subprocess.PIPE,
             stdin=subprocess.PIPE if stdin_pipe else None,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,
         )
     except OSError as exc:
@@ -294,6 +296,8 @@ def _run_via_subprocess(
             run_kwargs = {
                 "capture_output": True,
                 "text": True,
+                "encoding": "utf-8",
+                "errors": "replace",
                 "timeout": deps.timeout_seconds,
             }
             if stdin_text is not None:

--- a/desloppify/tests/review/review_commands_cases.py
+++ b/desloppify/tests/review/review_commands_cases.py
@@ -950,6 +950,8 @@ class TestCmdReviewPrepare:
             text=False,
             timeout=None,
             cwd=None,
+            encoding=None,
+            errors=None,
         ):
             _ = timeout, cwd
             out_path = Path(cmd[cmd.index("-o") + 1])
@@ -1190,6 +1192,8 @@ class TestCmdReviewPrepare:
             text=False,
             timeout=None,
             cwd=None,
+            encoding=None,
+            errors=None,
         ):
             _ = capture_output, text, timeout, cwd
             out_path = Path(cmd[cmd.index("-o") + 1])
@@ -1309,6 +1313,8 @@ class TestCmdReviewPrepare:
             text=False,
             timeout=None,
             cwd=None,
+            encoding=None,
+            errors=None,
         ):
             _ = capture_output, text, timeout, cwd
             out_path = Path(cmd[cmd.index("-o") + 1])
@@ -1466,6 +1472,8 @@ class TestCmdReviewPrepare:
             text=False,
             timeout=None,
             cwd=None,
+            encoding=None,
+            errors=None,
         ):
             _ = capture_output, text, timeout, cwd
             # Simulate Codex occasionally returning JSON on stdout while failing
@@ -1576,6 +1584,8 @@ class TestCmdReviewPrepare:
             text=False,
             timeout=None,
             cwd=None,
+            encoding=None,
+            errors=None,
         ):
             _ = capture_output, text, timeout, cwd
             out_path = Path(cmd[cmd.index("-o") + 1])
@@ -1707,6 +1717,8 @@ class TestCmdReviewPrepare:
             text=False,
             timeout=None,
             cwd=None,
+            encoding=None,
+            errors=None,
         ):
             _ = capture_output, text, timeout, cwd
             return MagicMock(returncode=124, stdout="", stderr="timed out")
@@ -1775,6 +1787,8 @@ class TestCmdReviewPrepare:
             text=False,
             timeout=None,
             cwd=None,
+            encoding=None,
+            errors=None,
         ):
             _ = capture_output, text, timeout, cwd
             out_path = Path(cmd[cmd.index("-o") + 1])
@@ -1937,7 +1951,7 @@ class TestCmdReviewPrepare:
         output_file = tmp_path / "out.txt"
         live_snapshot = {"text": ""}
 
-        def fake_run(_cmd, *, capture_output, text, timeout):  # noqa: ARG001
+        def fake_run(_cmd, *, capture_output, text, timeout, encoding=None, errors=None):  # noqa: ARG001
             if log_file.exists():
                 live_snapshot["text"] = log_file.read_text()
             output_file.write_text('{"assessments": {}, "issues": []}')

--- a/desloppify/tests/review/test_runner_internals.py
+++ b/desloppify/tests/review/test_runner_internals.py
@@ -820,3 +820,71 @@ class TestOpenCodeProvenanceSupport:
         )
 
         assert "opencode" in SUPPORTED_BLIND_REVIEW_RUNNERS
+
+
+class TestLiveSubprocessUtf8Decoding:
+    """Live Codex subprocess paths must decode output as UTF-8 (#717).
+
+    ``text=True`` alone decodes with the locale encoding (cp1252 on Western
+    Windows), which raises ``UnicodeDecodeError`` on UTF-8 Codex output. The
+    persisted-log readers already pin UTF-8; the live subprocess paths must
+    match.
+    """
+
+    @staticmethod
+    def _make_ctx(tmp_path):
+        from desloppify.app.commands.review.runner_process_impl.types import (
+            _AttemptContext,
+        )
+
+        return _AttemptContext(
+            header="Codex",
+            started_at_iso="2026-08-23T00:00:00Z",
+            started_monotonic=0.0,
+            output_file=tmp_path / "output.json",
+            log_file=tmp_path / "runner.log",
+            log_sections=[],
+            safe_write_text_fn=MagicMock(),
+        )
+
+    def test_start_runner_process_requests_utf8_decoding(self, tmp_path):
+        from desloppify.app.commands.review.runner_process_impl.attempts import (
+            _start_runner_process,
+        )
+
+        captured = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        deps = _make_deps(subprocess_popen=fake_popen, use_popen_runner=True)
+        result = _start_runner_process(["codex"], deps, self._make_ctx(tmp_path))
+
+        assert not isinstance(result, _ExecutionResult)
+        assert captured.get("encoding") == "utf-8"
+        assert captured.get("errors") == "replace"
+
+    def test_run_via_subprocess_requests_utf8_decoding(self, tmp_path):
+        from desloppify.app.commands.review.runner_process_impl.attempts import (
+            _run_via_subprocess,
+        )
+        from desloppify.app.commands.review.runner_process_impl.types import (
+            _RunnerState,
+        )
+
+        captured = {}
+        fake_result = MagicMock(returncode=0, stdout="", stderr="")
+
+        def fake_run(cmd, **kwargs):
+            captured.update(kwargs)
+            return fake_result
+
+        deps = _make_deps(subprocess_run=fake_run)
+        result = _run_via_subprocess(
+            ["codex"], deps, _RunnerState(), self._make_ctx(tmp_path), interval=0.01
+        )
+
+        assert result.code == 0
+        assert captured.get("encoding") == "utf-8"
+        assert captured.get("errors") == "replace"


### PR DESCRIPTION
## Root cause

Fixes #717.

The live Codex subprocess paths — `_start_runner_process` and `_run_via_subprocess` in `runner_process_impl/attempts.py` — used `text=True` without `encoding`/`errors`. Output is therefore decoded with the locale encoding (`cp1252` on Western Windows), and UTF-8 Codex output containing non-ASCII characters raises `UnicodeDecodeError` in the stream reader before the already-safe log recovery runs.

The persisted-log readers (`io.py`, `runner_failures.py`) already pin `encoding="utf-8", errors="replace"` — the live subprocess paths were the gap (a regression of the #422/#442 UTF-8 work).

## Change

Pin `encoding="utf-8"`, `errors="replace"` on both subprocess calls, matching the persisted-log readers.

## Validation

- Two new unit tests assert both call sites request UTF-8 decoding (RED without the fix — `encoding` was `None`).
- Existing review fakes updated to accept the new kwargs.
- Full review suite green: `1081 passed`.