### PR TITLE
fix(tools): translate /dev/null stderr redirect to nul for cmd.exe

### DIFF
--- a/desloppify/languages/_framework/generic_parts/tool_runner.py
+++ b/desloppify/languages/_framework/generic_parts/tool_runner.py
@@ -36,6 +36,10 @@ class ToolRunResult:
 def _shell_argv(cmd: str) -> list[str]:
     """Return a platform-appropriate shell argv for shell-meta commands."""
     if os.name == "nt":
+        # cmd.exe has no /dev/null; translate the POSIX null-device redirect
+        # so tools that discard stderr run instead of failing with
+        # "The system cannot find the path specified." (#714)
+        cmd = cmd.replace("2>/dev/null", "2>nul")
         return ["cmd.exe", "/d", "/s", "/c", cmd]
     return ["/bin/sh", "-lc", cmd]
 

--- a/desloppify/tests/lang/common/test_generic_plugin.py
+++ b/desloppify/tests/lang/common/test_generic_plugin.py
@@ -486,6 +486,16 @@ class TestMakeToolPhase:
             argv = resolve_command_argv('"C:\\Program Files\\Tool\\tool.exe" --flag')
         assert argv == [r"C:\Program Files\Tool\tool.exe", "--flag"]
 
+    def test_resolve_command_argv_windows_translates_dev_null_redirect(self):
+        with patch("desloppify.languages._framework.generic_parts.tool_runner.os.name", "nt"):
+            argv = resolve_command_argv("npx eslint . --format json 2>/dev/null")
+        assert argv == ["cmd.exe", "/d", "/s", "/c", "npx eslint . --format json 2>nul"]
+
+    def test_resolve_command_argv_posix_keeps_dev_null_redirect(self):
+        with patch("desloppify.languages._framework.generic_parts.tool_runner.os.name", "posix"):
+            argv = resolve_command_argv("npx eslint . --format json 2>/dev/null")
+        assert argv == ["/bin/sh", "-lc", "npx eslint . --format json 2>/dev/null"]
+
 
 class TestToolSpecNormalization:
     def test_missing_fix_cmd_normalizes_to_none(self):


### PR DESCRIPTION
## Root cause

The JavaScript ESLint tool command discards stderr with `2>/dev/null`:

```python
"cmd": "npx eslint . --format json --no-error-on-unmatched-pattern 2>/dev/null",
```

`resolve_command_argv` sees the `>` shell metacharacter and routes the command through the platform shell. On Windows that is `cmd.exe`, which has no `/dev/null` path, so the redirect fails with `The system cannot find the path specified.` before eslint ever runs. The tool then reports `parser_error` (the cmd.exe error text is fed to the JSON parser as fallback input).

## Change

`_shell_argv` now translates `2>/dev/null` to `2>nul` when building the Windows `cmd.exe` argv. The POSIX path is unchanged, and tools keep discarding stderr on every platform. This fixes the ESLint adapter (and any future tool using the same redirect) without touching tool configs.

## Validation

- New unit test: `resolve_command_argv("npx eslint . --format json 2>/dev/null")` under `os.name == "nt"` resolves to `cmd.exe /c ... 2>nul` (RED before the fix — the argv kept `/dev/null`; GREEN after).
- New unit test: the POSIX path keeps `2>/dev/null` unchanged.
- `pytest desloppify/tests/lang/common/test_generic_plugin.py` — 67 passed.
- Full suite: 2914 passed; the one failure (`test_bash_unused_source_directive_is_flagged`) is pre-existing on `upstream/main` and unrelated.

I can't exercise cmd.exe from macOS, so a Windows smoke test of `desloppify scan` in a JS project would be appreciated.

Fixes #714.
