### PR TITLE
fix: recognize CommonJS require calls in JS/TS import graph

### DIFF
--- a/desloppify/languages/_framework/treesitter/_specs.py
+++ b/desloppify/languages/_framework/treesitter/_specs.py
@@ -691,6 +691,10 @@ JS_SPEC = TreeSitterLangSpec(
     import_query="""
         (import_statement
             source: (string (string_fragment) @path)) @import
+        (call_expression
+            function: (identifier) @require_fn
+            arguments: (arguments (string (string_fragment) @path))
+            (#eq? @require_fn "require")) @import
     """,
     resolve_import=resolve_js_import,
     class_query="""
@@ -723,6 +727,10 @@ TYPESCRIPT_SPEC = TreeSitterLangSpec(
     import_query="""
         (import_statement
             source: (string (string_fragment) @path)) @import
+        (call_expression
+            function: (identifier) @require_fn
+            arguments: (arguments (string (string_fragment) @path))
+            (#eq? @require_fn "require")) @import
     """,
     resolve_import=resolve_js_import,
     class_query="""

--- a/desloppify/tests/lang/common/test_treesitter.py
+++ b/desloppify/tests/lang/common/test_treesitter.py
@@ -480,6 +480,35 @@ class TestDepGraphBuilder:
         assert str(pkg_file) in main_imports
         _GO_MODULE_CACHE.clear()
 
+    def test_js_dep_graph_includes_commonjs_require(self, tmp_path):
+        from desloppify.languages._framework.treesitter._imports import (
+            ts_build_dep_graph,
+        )
+        from desloppify.languages._framework.treesitter._specs import JS_SPEC
+
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        main_file = src_dir / "app.js"
+        dep_file = src_dir / "values.js"
+
+        main_file.write_text(
+            "const values = require('./values');\n"
+            "const _ = require('lodash');\n"
+            "logger('./not-an-import');\n"
+            "module.exports = values;\n"
+        )
+        dep_file.write_text("module.exports = [1, 2, 3];\n")
+
+        graph = ts_build_dep_graph(
+            tmp_path, JS_SPEC, [str(main_file), str(dep_file)]
+        )
+        assert len(graph) == 2
+        main_imports = graph[str(main_file)]["imports"]
+        # The relative require edge is kept.
+        assert str(dep_file) in main_imports
+        # The npm package and the non-require call do not create edges.
+        assert len(main_imports) == 1
+
     def test_no_import_query_returns_empty(self, tmp_path):
         from desloppify.languages._framework.treesitter._imports import (
             ts_build_dep_graph,


### PR DESCRIPTION
## Problem

`JS_SPEC.import_query` (and `TYPESCRIPT_SPEC`) only matches ESM `import_statement`, so a CommonJS `require('./module')` call produces no import edge. Files imported only via `require` are reported with zero importers and show up as false `orphaned` findings. This is the second half of #715; #696 fixes the relative/absolute path-space mismatch in the same graph builder.

## Fix

Add a second pattern to the JS/TS import query that matches `require()` calls, using an `#eq?` predicate so other calls with string arguments are not treated as imports:

```
(call_expression
    function: (identifier) @require_fn
    arguments: (arguments (string (string_fragment) @path))
    (#eq? @require_fn "require")) @import
```

`resolve_js_import` already skips bare package names, so `require('lodash')` does not create an edge.

## Test

`test_js_dep_graph_includes_commonjs_require` builds a graph for a file with a relative `require`, a package `require`, and a non-require call, and asserts only the relative edge is kept. Fails without the query change, passes with it.