### PR TITLE
fix: bound Rust coverage dependency resolution

### DIFF
--- a/desloppify/app/commands/plan/triage/confirmations/enrich.py
+++ b/desloppify/app/commands/plan/triage/confirmations/enrich.py
@@ -14,8 +14,7 @@ from .shared import (
     finalize_stage_confirmation,
 )
 from ..services import TriageServices, default_triage_services
-from ..stages.helpers import scoped_manual_clusters_with_issues
-from ..review_coverage import active_triage_issue_ids
+from ..stages.helpers import active_triage_issue_scope, scoped_manual_clusters_with_issues
 from ..validation.enrich_quality import (
     EnrichQualityIssue as _ConfirmationCheckIssue,
     EnrichQualityReport as _ConfirmationCheckReport,
@@ -179,7 +178,7 @@ def confirm_enrich(
     checks = _collect_enrich_level_confirmation_checks(
         plan,
         include_stale_issue_ref_warning=True,
-        triage_issue_ids=active_triage_issue_ids(plan, state) or None,
+        triage_issue_ids=active_triage_issue_scope(plan, state),
     )
 
     print(colorize("  Stage: ENRICH — Make steps executor-ready (detail, refs)", "bold"))
@@ -232,7 +231,7 @@ def confirm_sense_check(
     checks = _collect_enrich_level_confirmation_checks(
         plan,
         include_stale_issue_ref_warning=False,
-        triage_issue_ids=active_triage_issue_ids(plan, state) or None,
+        triage_issue_ids=active_triage_issue_scope(plan, state),
     )
 
     print(colorize("  Stage: SENSE-CHECK — Verify accuracy & cross-cluster deps", "bold"))

--- a/desloppify/app/commands/plan/triage/runner/stage_validation.py
+++ b/desloppify/app/commands/plan/triage/runner/stage_validation.py
@@ -24,7 +24,6 @@ from ..validation.enrich_checks import (
 from ..completion_flow import count_log_activity_since
 from ..observe_batches import observe_dimension_breakdown
 from ..review_coverage import (
-    active_triage_issue_ids,
     cluster_issue_ids,
     open_review_ids_from_state,
 )
@@ -238,7 +237,7 @@ def _validate_enrich_stage(
         plan,
         repo_root,
         phase_label="enrich",
-        triage_issue_ids=active_triage_issue_ids(plan, state) or None,
+        triage_issue_ids=active_triage_issue_scope(plan, state),
     )
     if failures:
         return False, failures[0].message
@@ -260,8 +259,8 @@ def _validate_sense_check_stage(
     if len(report) < 100:
         return False, f"Sense-check report too short ({len(report)} chars, need 100+)."
     manual_clusters = scoped_manual_clusters_with_issues(plan, state)
-    triage_issue_ids = active_triage_issue_ids(plan, state) or None
     triage_scope = active_triage_issue_scope(plan, state)
+    triage_issue_ids = triage_scope
     open_review_ids = open_review_ids_from_state(state) if triage_scope is None else triage_scope
     if not open_review_ids and not manual_clusters:
         return True, ""

--- a/desloppify/app/commands/plan/triage/stages/enrich.py
+++ b/desloppify/app/commands/plan/triage/stages/enrich.py
@@ -12,6 +12,7 @@ from desloppify.base.output.user_message import print_user_message
 from desloppify.engine.plan_triage import compute_triage_progress
 
 from .records import record_enrich_stage, resolve_reusable_report
+from .helpers import active_triage_issue_scope
 from ..validation.enrich_quality import evaluate_enrich_quality
 from ..validation.enrich_checks import (
     _enrich_report_or_error,
@@ -21,10 +22,7 @@ from ..validation.enrich_checks import (
     _underspecified_steps,
 )
 from ..completion_flow import count_log_activity_since
-from ..review_coverage import (
-    active_triage_issue_ids,
-    open_review_ids_from_state,
-)
+from ..review_coverage import open_review_ids_from_state
 from ..stage_queue import has_triage_in_queue, print_cascade_clear_feedback
 from ..services import TriageServices, default_triage_services
 
@@ -268,7 +266,7 @@ def run_stage_enrich(
     if get_project_root is None:
         from desloppify.base.discovery.paths import get_project_root
 
-    triage_ids = active_triage_issue_ids(plan, state) or None
+    triage_ids = active_triage_issue_scope(plan, state)
     quality_report = evaluate_enrich_quality(
         plan,
         get_project_root(),

--- a/desloppify/app/commands/plan/triage/stages/helpers.py
+++ b/desloppify/app/commands/plan/triage/stages/helpers.py
@@ -61,9 +61,10 @@ def active_triage_issue_scope(
     `None` means "do not scope" for legacy/non-triage flows.
     An empty set means a frozen triage run exists but none of its issues are live.
     """
-    frozen = active_triage_issue_ids(plan, state)
-    if not frozen:
+    meta = plan.get("epic_triage_meta", {})
+    if not isinstance(meta, dict) or "active_triage_issue_ids" not in meta:
         return None
+    frozen = active_triage_issue_ids(plan, state)
     if state is None:
         return frozen
     return live_active_triage_issue_ids(plan, state)

--- a/desloppify/app/commands/plan/triage/stages/sense_check.py
+++ b/desloppify/app/commands/plan/triage/stages/sense_check.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from desloppify.base.output.terminal import colorize
 
 from .records import record_sense_check_stage, resolve_reusable_report
-from .helpers import value_check_targets
+from .helpers import active_triage_issue_scope, value_check_targets
 from ..validation.enrich_quality import evaluate_enrich_quality
 from ..validation.enrich_checks import (
     _steps_missing_issue_refs,
@@ -19,7 +19,7 @@ from ..validation.enrich_checks import (
     _steps_without_effort,
     _underspecified_steps,
 )
-from ..review_coverage import active_triage_issue_ids, open_review_ids_from_state
+from ..review_coverage import open_review_ids_from_state
 from ..stage_queue import has_triage_in_queue, print_cascade_clear_feedback
 from ..services import TriageServices, default_triage_services
 from .enrich import ColorizeFn
@@ -66,7 +66,7 @@ def _sense_check_quality_problems(
         from desloppify.base.discovery.paths import get_project_root
 
     repo_root = get_project_root()
-    triage_ids = active_triage_issue_ids(plan, state) or None
+    triage_ids = active_triage_issue_scope(plan, state)
     quality_report = evaluate_enrich_quality(
         plan,
         repo_root,
@@ -118,13 +118,17 @@ def _sense_check_evidence_failures(
         validate_report_has_file_paths,
         validate_report_references_clusters,
     )
-    from ..review_coverage import manual_clusters_with_issues
+    from .helpers import scoped_manual_clusters_with_issues
 
     failures: list[object] = []
-    if open_review_ids_from_state(state):
+    triage_scope = active_triage_issue_scope(plan, state)
+    open_review_ids = (
+        open_review_ids_from_state(state) if triage_scope is None else triage_scope
+    )
+    if open_review_ids:
         failures.extend(validate_report_has_file_paths(report) or [])
 
-    cluster_names = manual_clusters_with_issues(plan)
+    cluster_names = scoped_manual_clusters_with_issues(plan, state)
     if cluster_names:
         failures.extend(validate_report_references_clusters(report, cluster_names) or [])
 

--- a/desloppify/app/commands/plan/triage/validation/enrich_quality.py
+++ b/desloppify/app/commands/plan/triage/validation/enrich_quality.py
@@ -87,8 +87,10 @@ def _scoped_plan(plan: dict, triage_issue_ids: set[str] | None) -> dict:
 
     Returns the original plan unchanged when no triage scoping is needed.
     """
-    if not triage_issue_ids:
+    if triage_issue_ids is None:
         return plan
+    if not triage_issue_ids:
+        return {**plan, "clusters": {}}
     active = _active_cluster_names(plan, triage_issue_ids)
     return {
         **plan,

--- a/desloppify/app/commands/review/batch/scope.py
+++ b/desloppify/app/commands/review/batch/scope.py
@@ -235,7 +235,8 @@ def enforce_trusted_import_coverage_gate(
     colorize_fn,
 ) -> None:
     """Block trusted assessment import when selected assessment dimensions are missing."""
-    if not selected_dims or not missing_dims:
+    missing_selected_dims = [dim for dim in selected_dims if dim in set(missing_dims)]
+    if not missing_selected_dims:
         return
     if allow_partial:
         print(
@@ -247,9 +248,9 @@ def enforce_trusted_import_coverage_gate(
         )
         return
 
-    preview = ", ".join(missing_dims[:5])
-    if len(missing_dims) > 5:
-        preview = f"{preview}, +{len(missing_dims) - 5} more"
+    preview = ", ".join(missing_selected_dims[:5])
+    if len(missing_selected_dims) > 5:
+        preview = f"{preview}, +{len(missing_selected_dims) - 5} more"
     print(colorize_fn(f"  Missing dimensions: {preview}", "yellow"), file=sys.stderr)
     print(
         colorize_fn(
@@ -262,7 +263,7 @@ def enforce_trusted_import_coverage_gate(
     print(
         colorize_fn(
             "  Suggested rerun: "
-            f"`{missing_dimensions_command(missing_dims=missing_dims, scan_path=scan_path)}`",
+            f"`{missing_dimensions_command(missing_dims=missing_selected_dims, scan_path=scan_path)}`",
             "dim",
         ),
         file=sys.stderr,

--- a/desloppify/engine/_plan/triage/snapshot.py
+++ b/desloppify/engine/_plan/triage/snapshot.py
@@ -46,7 +46,7 @@ def coverage_open_ids(plan: PlanModel, state: StateModel) -> set[str]:
     """Return the frozen or live open review IDs covered by this triage run."""
     meta = plan.get("epic_triage_meta", {})
     active_ids = _normalized_issue_id_list(meta.get("active_triage_issue_ids"))
-    if active_ids:
+    if "active_triage_issue_ids" in meta:
         return set(active_ids)
     has_completed_scan = bool(state.get("last_scan"))
     review_ids = open_review_ids(state)
@@ -59,7 +59,7 @@ def active_triage_issue_ids(plan: PlanModel, state: StateModel | None = None) ->
     """Return the frozen review issue set for the current triage run."""
     meta = plan.get("epic_triage_meta", {})
     active_ids = _normalized_issue_id_list(meta.get("active_triage_issue_ids"))
-    if active_ids:
+    if "active_triage_issue_ids" in meta:
         return set(active_ids)
     if state is None:
         return set()

--- a/desloppify/engine/_state/resolution.py
+++ b/desloppify/engine/_state/resolution.py
@@ -146,10 +146,12 @@ def resolve_issues(
             "detail": copy.deepcopy(original.get("detail", {})),
         }
 
-    status_filter = "all" if status == "open" else "open"
+    status_filter = "all" if status in {"open", "fixed"} else "open"
     for issue in match_issues(state, pattern, status_filter=status_filter):
         previous_status = str(issue.get("status", "open")).strip() or "open"
         if status == "open" and previous_status == "open":
+            continue
+        if status == "fixed" and previous_status not in {"open", "auto_resolved"}:
             continue
 
         extra_updates: dict[str, object] = {}

--- a/desloppify/engine/detectors/coverage/mapping.py
+++ b/desloppify/engine/detectors/coverage/mapping.py
@@ -6,6 +6,22 @@ import logging
 import os
 
 from desloppify.base.discovery.paths import get_project_root
+from desloppify.engine.detectors.coverage.mapping_analysis import (
+    _build_prod_by_module,
+    transitive_coverage,
+)
+from desloppify.engine.detectors.coverage.mapping_analysis import (
+    analyze_test_quality as _analyze_test_quality,
+)
+from desloppify.engine.detectors.coverage.mapping_analysis import (
+    build_production_test_index as _build_production_test_index,
+)
+from desloppify.engine.detectors.coverage.mapping_analysis import (
+    build_test_import_index as _build_test_import_index,
+)
+from desloppify.engine.detectors.coverage.mapping_analysis import (
+    get_test_files_for_prod as _get_test_files_for_prod,
+)
 from desloppify.engine.detectors.coverage.mapping_imports import (
     _infer_lang_name,
     _load_lang_test_coverage_module,
@@ -13,13 +29,6 @@ from desloppify.engine.detectors.coverage.mapping_imports import (
     _resolve_barrel_reexports,
 )
 from desloppify.engine.detectors.test_coverage.io import read_coverage_file
-from desloppify.engine.detectors.coverage.mapping_analysis import (
-    _build_prod_by_module,
-    analyze_test_quality as _analyze_test_quality,
-    build_test_import_index as _build_test_import_index,
-    get_test_files_for_prod as _get_test_files_for_prod,
-    transitive_coverage,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -243,8 +252,27 @@ def build_test_import_index(
     )
 
 
+def build_production_test_index(
+    test_files: set[str],
+    production_files: set[str],
+    graph: dict,
+    lang_name: str,
+    parsed_imports_by_test: dict[str, set[str]],
+) -> dict[str, list[str]]:
+    """Index direct tests by production file without quadratic resolution."""
+    return _build_production_test_index(
+        test_files,
+        production_files,
+        graph,
+        lang_name,
+        parsed_imports_by_test,
+        map_test_to_source_fn=_map_test_to_source,
+    )
+
+
 __all__ = [
     "analyze_test_quality",
+    "build_production_test_index",
     "build_test_import_index",
     "get_test_files_for_prod",
     "import_based_mapping",

--- a/desloppify/engine/detectors/coverage/mapping.py
+++ b/desloppify/engine/detectors/coverage/mapping.py
@@ -194,6 +194,20 @@ def naming_based_mapping(
     return tested
 
 
+def promote_owner_coverage(
+    directly_tested: set[str],
+    transitively_tested: set[str],
+    production_files: set[str],
+    lang_name: str,
+) -> set[str]:
+    """Promote language-specific child modules covered through an owner boundary."""
+    mod = _load_lang_test_coverage_module(lang_name)
+    promoter = getattr(mod, "promote_owner_covered_files", None)
+    if not callable(promoter):
+        return set()
+    return set(promoter(directly_tested, transitively_tested, production_files))
+
+
 def _strip_test_markers(basename: str, lang_name: str) -> str | None:
     """Strip test naming markers from a basename to derive source basename."""
     mod = _load_lang_test_coverage_module(lang_name)
@@ -277,6 +291,7 @@ __all__ = [
     "get_test_files_for_prod",
     "import_based_mapping",
     "naming_based_mapping",
+    "promote_owner_coverage",
     "transitive_coverage",
     "_build_prod_module_index",
     "_map_test_to_source",

--- a/desloppify/engine/detectors/coverage/mapping_analysis.py
+++ b/desloppify/engine/detectors/coverage/mapping_analysis.py
@@ -244,9 +244,42 @@ def build_test_import_index(
     return index
 
 
+def build_production_test_index(
+    test_files: set[str],
+    production_files: set[str],
+    graph: dict,
+    lang_name: str,
+    parsed_imports_by_test: dict[str, set[str]],
+    *,
+    map_test_to_source_fn: Callable[[str, set[str], str], str | None],
+) -> dict[str, list[str]]:
+    """Build production-file -> direct-test mapping in one pass over tests."""
+    related: dict[str, list[str]] = {}
+    for test_path in sorted(test_files):
+        covered = set(parsed_imports_by_test.get(test_path, set()))
+        entry = graph.get(test_path)
+        if entry:
+            covered.update(
+                imported
+                for imported in entry.get("imports", set())
+                if imported in production_files
+            )
+        named_source = map_test_to_source_fn(
+            test_path,
+            production_files,
+            lang_name,
+        )
+        if named_source is not None:
+            covered.add(named_source)
+        for production_file in covered:
+            related.setdefault(production_file, []).append(test_path)
+    return related
+
+
 
 __all__ = [
     "analyze_test_quality",
+    "build_production_test_index",
     "build_test_import_index",
     "get_test_files_for_prod",
     "transitive_coverage",

--- a/desloppify/engine/detectors/test_coverage/_issue_generation.py
+++ b/desloppify/engine/detectors/test_coverage/_issue_generation.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from desloppify.engine.detectors.coverage.mapping import (
+    build_production_test_index,
     build_test_import_index,
-    get_test_files_for_prod,
 )
 
 from ._issue_gaps import transitive_coverage_gap_issue, untested_module_issue
@@ -31,6 +31,13 @@ def generate_issues(
         production_scope,
         lang_name,
     )
+    related_tests_by_production = build_production_test_index(
+        test_files,
+        production_scope,
+        graph,
+        lang_name,
+        parsed_imports_by_test,
+    )
 
     for filepath in scorable:
         loc = _file_loc(filepath)
@@ -38,16 +45,9 @@ def generate_issues(
         loc_weight = _loc_weight(loc)
 
         if filepath in directly_tested:
-            related_tests = get_test_files_for_prod(
-                filepath,
-                test_files,
-                graph,
-                lang_name,
-                parsed_imports_by_test=parsed_imports_by_test,
-            )
             issue = select_direct_test_quality_issue(
                 prod_file=filepath,
-                related_tests=related_tests,
+                related_tests=related_tests_by_production.get(filepath, []),
                 test_quality=test_quality,
                 loc_weight=loc_weight,
             )

--- a/desloppify/engine/detectors/test_coverage/detector.py
+++ b/desloppify/engine/detectors/test_coverage/detector.py
@@ -6,6 +6,7 @@ from desloppify.engine.detectors.coverage.mapping import (
     analyze_test_quality,
     import_based_mapping,
     naming_based_mapping,
+    promote_owner_coverage,
     transitive_coverage,
 )
 from desloppify.engine.detectors.coverage.mapping_imports import (
@@ -22,7 +23,6 @@ from .heuristics import _has_inline_tests
 from .issues import (
     _generate_issues,
 )
-
 
 
 def detect_test_coverage(
@@ -73,6 +73,14 @@ def detect_test_coverage(
         directly_tested |= naming_based_mapping(test_files, production_files, lang_name)
 
     transitively_tested = transitive_coverage(directly_tested, graph, production_files)
+    owner_covered = promote_owner_coverage(
+        directly_tested,
+        transitively_tested,
+        production_files,
+        lang_name,
+    )
+    directly_tested |= owner_covered
+    transitively_tested -= owner_covered
     test_quality = analyze_test_quality(test_files, lang_name)
 
     entries = _generate_issues(

--- a/desloppify/engine/policy/zones.py
+++ b/desloppify/engine/policy/zones.py
@@ -11,6 +11,7 @@ import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
+from fnmatch import fnmatch
 
 from desloppify.base.output.fallbacks import log_best_effort_failure
 from desloppify.engine.policy.zones_data import (
@@ -78,6 +79,7 @@ class ZoneRule:
       - ".ext"    → basename ends-with (suffix/extension, e.g. ".d.ts", ".test.")
       - "prefix_" → basename starts-with (trailing underscore)
       - "name.py" → basename exact match (has extension, no /)
+      - "*_tests/*" → glob match on the full relative path
       - fallback  → substring on full path
     """
 
@@ -91,6 +93,9 @@ def _match_pattern(rel_path: str, pattern: str) -> bool:
     See ZoneRule docstring for pattern type conventions.
     """
     basename = os.path.basename(rel_path)
+
+    if "*" in pattern:
+        return fnmatch(rel_path, pattern)
 
     # Directory pattern: "/dir/" → substring on padded path
     if pattern.startswith("/") and pattern.endswith("/"):

--- a/desloppify/languages/_framework/base/shared_phases_review.py
+++ b/desloppify/languages/_framework/base/shared_phases_review.py
@@ -11,17 +11,15 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger(__name__)
-
 from desloppify.base.discovery.file_paths import rel
 from desloppify.base.output.terminal import log
+from desloppify.engine._state.filtering import make_issue
 from desloppify.engine.detectors.dupes import detect_duplicates
 from desloppify.engine.detectors.jscpd_adapter import detect_with_jscpd
 from desloppify.engine.detectors.security.detector import (
     detect_security_issues as _detect_security_issues_default,
 )
 from desloppify.engine.detectors.test_coverage.detector import detect_test_coverage
-from desloppify.engine._state.filtering import make_issue
 from desloppify.engine.policy.zones import EXCLUDED_ZONES, filter_entries
 from desloppify.languages._framework.base.types import (
     DetectorCoverageStatus,
@@ -40,6 +38,8 @@ from .shared_phases_helpers import (
     _log_phase_summary,
     _record_detector_coverage,
 )
+
+logger = logging.getLogger(__name__)
 
 # Compatibility export for language phase modules that still import the raw
 # security detector symbol from this module.
@@ -463,6 +463,12 @@ def phase_boilerplate_duplication(
     if entries is None:
         return [], {}
     entries = _filter_boilerplate_entries_by_zone(entries, lang.zone_map)
+    minimum_lines = max(1, int(getattr(lang, "boilerplate_min_lines", 4)))
+    entries = [
+        entry
+        for entry in entries
+        if int(entry.get("window_size", 0)) >= minimum_lines
+    ]
 
     issues: list[Issue] = []
     for entry in entries:

--- a/desloppify/languages/_framework/base/types.py
+++ b/desloppify/languages/_framework/base/types.py
@@ -17,9 +17,9 @@ from desloppify.languages._framework.base.lang_config_runtime import (
 from desloppify.languages._framework.base.types_shared import (
     BoundaryRule,
     CoverageStatus,
-    DetectorEntry,
     DetectorCoverageRecord,
     DetectorCoverageStatus,
+    DetectorEntry,
     FixerConfig,
     FixResult,
     LangSecurityResult,
@@ -141,6 +141,7 @@ class LangConfig:
     large_threshold: int = 500
     complexity_threshold: int = 15
     props_threshold: int = 14
+    boilerplate_min_lines: int = 4
     default_scan_profile: str = "full"
 
     # Language-specific persisted settings and per-run runtime options.

--- a/desloppify/languages/rust/__init__.py
+++ b/desloppify/languages/rust/__init__.py
@@ -61,7 +61,10 @@ RUST_ENTRY_PATTERNS = [
 
 RUST_ZONE_RULES = [
     ZoneRule(Zone.PRODUCTION, ["/src/bin/"]),
-    ZoneRule(Zone.TEST, ["/tests/", "_tests.rs", "test_"]),
+    ZoneRule(
+        Zone.TEST,
+        ["/tests/", "*_tests/*", "tests.rs", "test.rs", "_tests.rs", "test_"],
+    ),
     ZoneRule(Zone.SCRIPT, ["/examples/", "/benches/", "/fuzz/", "build.rs"]),
     ZoneRule(Zone.CONFIG, ["Cargo.toml", "Cargo.lock", "/.cargo/"]),
 ] + COMMON_ZONE_RULES
@@ -106,6 +109,7 @@ class RustConfig(LangConfig):
             file_finder=find_rust_files,
             large_threshold=500,
             complexity_threshold=15,
+            boilerplate_min_lines=8,
             default_scan_profile="full",
             detect_markers=["Cargo.toml"],
             external_test_dirs=["tests"],

--- a/desloppify/languages/rust/detectors/api.py
+++ b/desloppify/languages/rust/detectors/api.py
@@ -10,12 +10,13 @@ from desloppify.languages.rust.support import (
     describe_rust_file,
     find_rust_files,
     has_public_api_markers,
+    is_publishable_package,
     read_text_or_none,
     strip_rust_comments,
 )
 
 from ._shared import (
-    _argument_count,
+    _ENUM_VARIANT_RE,
     _GETTER_RE,
     _INTO_RE,
     _NON_EXHAUSTIVE_RE,
@@ -23,8 +24,9 @@ from ._shared import (
     _PUBLIC_FIELD_RE,
     _USE_STATEMENT_RE,
     _WRAPPER_GETTER_NAMES,
-    _ENUM_VARIANT_RE,
+    _argument_count,
     _entry,
+    _group_files_by_manifest,
     _has_manual_thread_contract,
     _has_public_panic_path,
     _has_python_binding_attrs,
@@ -34,12 +36,11 @@ from ._shared import (
     _is_test_content,
     _iter_public_functions,
     _iter_public_types,
+    _line_number,
     _looks_like_ffi_surface,
     _looks_like_plain_getter,
-    _line_number,
     _should_skip_future_proofing,
     _starts_with_same_crate_import,
-    _group_files_by_manifest,
 )
 
 
@@ -141,7 +142,6 @@ def detect_error_boundaries(path: Path) -> tuple[list[dict], int]:
         context = describe_rust_file(absolute)
         if not _is_library_api_file(context):
             continue
-
         for block in _iter_public_functions(content):
             if _PUBLIC_ERROR_RE.search(block.signature):
                 entries.append(
@@ -183,6 +183,8 @@ def detect_future_proofing(path: Path) -> tuple[list[dict], int]:
             continue
         context = describe_rust_file(absolute)
         if not _is_library_api_file(context):
+            continue
+        if not is_publishable_package(context.manifest_dir):
             continue
 
         for block in _iter_public_types(content):
@@ -227,7 +229,7 @@ def detect_thread_safety_contracts(path: Path) -> tuple[list[dict], int]:
     """Flag manual Send/Sync contracts without visible assertion tests."""
     entries: list[dict] = []
     by_manifest = _group_files_by_manifest(path)
-    for manifest_dir, files in by_manifest.items():
+    for _manifest_dir, files in by_manifest.items():
         corpus_parts: list[str] = []
         for filepath in files:
             absolute = Path(resolve_path(filepath))

--- a/desloppify/languages/rust/detectors/deps.py
+++ b/desloppify/languages/rust/detectors/deps.py
@@ -33,7 +33,7 @@ def build_dep_graph(
 
     file_set = set(graph.keys())
     production_index = build_production_file_index(file_set)
-    package_index = build_workspace_package_index()
+    package_index = build_workspace_package_index(path)
     for filepath in files:
         content = read_text_or_none(filepath)
         if content is None:

--- a/desloppify/languages/rust/support.py
+++ b/desloppify/languages/rust/support.py
@@ -377,6 +377,33 @@ def read_library_crate_name(manifest_dir: Path) -> str | None:
     return normalize_crate_name(package.get("name"))
 
 
+def is_publishable_package(manifest_dir: Path) -> bool:
+    """Return whether Cargo permits publishing the package at ``manifest_dir``.
+
+    Public-shape compatibility rules matter for distributable crates, but they
+    create noise and harmful churn for explicitly private workspace packages.
+    Cargo defaults ``package.publish`` to publishable; workspace inheritance is
+    applied only when the member opts in with ``publish.workspace = true``.
+    """
+    data = _read_manifest_data(manifest_dir)
+    package = data.get("package")
+    if not isinstance(package, dict):
+        return False
+
+    publish = package.get("publish")
+    if publish is False:
+        return False
+    if isinstance(publish, dict) and publish.get("workspace") is True:
+        workspace_data = _read_manifest_data(find_workspace_root(manifest_dir))
+        workspace = workspace_data.get("workspace")
+        workspace_package = (
+            workspace.get("package") if isinstance(workspace, dict) else None
+        )
+        if isinstance(workspace_package, dict):
+            return workspace_package.get("publish") is not False
+    return True
+
+
 def _read_manifest_data(manifest_dir: Path) -> dict[str, Any]:
     """Parse a Cargo manifest into a dictionary."""
     data = _load_toml_dict(manifest_dir / "Cargo.toml")
@@ -1057,6 +1084,7 @@ __all__ = [
     "find_rust_files",
     "find_workspace_root",
     "has_public_api_markers",
+    "is_publishable_package",
     "iter_mod_declarations",
     "iter_mod_targets",
     "iter_pub_use_specs",

--- a/desloppify/languages/rust/support.py
+++ b/desloppify/languages/rust/support.py
@@ -11,7 +11,12 @@ from typing import Any
 
 from desloppify.base.discovery.file_paths import rel, resolve_path
 from desloppify.base.discovery.paths import get_project_root
-from desloppify.base.discovery.source import SourceDiscoveryOptions, find_source_files
+from desloppify.base.discovery.source import (
+    SourceDiscoveryOptions,
+    find_source_files,
+    get_exclusions,
+)
+
 RUST_FILE_EXCLUSIONS = ["target", ".git", "node_modules", "vendor"]
 USE_STATEMENT_RE = re.compile(r"(?m)^\s*(?:pub(?:\([^)]*\))?\s+)?use\s+([^;]+);")
 PUB_USE_STATEMENT_RE = re.compile(r"(?m)^\s*pub(?:\([^)]*\))?\s+use\s+([^;]+);")
@@ -41,6 +46,7 @@ class RustProductionFileIndex:
 
     project_root: Path
     by_absolute: dict[str, str]
+    by_lexical_absolute: dict[str, str]
     by_relative: dict[str, str]
 
 
@@ -71,12 +77,15 @@ def build_production_file_index(
     """Build O(1) absolute/relative lookup maps for production files."""
     root = (project_root or get_project_root()).resolve()
     by_absolute: dict[str, str] = {}
+    by_lexical_absolute: dict[str, str] = {}
     by_relative: dict[str, str] = {}
     for production_file in production_files:
         prod_path = Path(production_file)
+        lexical = prod_path if prod_path.is_absolute() else root / prod_path
         resolved = (
             prod_path.resolve() if prod_path.is_absolute() else (root / prod_path).resolve()
         )
+        by_lexical_absolute.setdefault(str(lexical.absolute()), production_file)
         resolved_str = str(resolved)
         by_absolute.setdefault(resolved_str, production_file)
         try:
@@ -88,6 +97,7 @@ def build_production_file_index(
     return RustProductionFileIndex(
         project_root=root,
         by_absolute=by_absolute,
+        by_lexical_absolute=by_lexical_absolute,
         by_relative=by_relative,
     )
 
@@ -376,16 +386,28 @@ def _read_manifest_data(manifest_dir: Path) -> dict[str, Any]:
 def build_workspace_package_index(scan_root: Path | None = None) -> dict[str, Path]:
     """Return local crate-name -> Cargo manifest dir for the active project root."""
     root = find_workspace_root(scan_root) if scan_root is not None else get_project_root()
-    return _build_workspace_package_index_cached(root)
+    exclusions = tuple(get_exclusions())
+    return _build_workspace_package_index_cached(root, exclusions)
 
 
 @functools.lru_cache(maxsize=8)
-def _build_workspace_package_index_cached(root: Path) -> dict[str, Path]:
+def _build_workspace_package_index_cached(
+    root: Path,
+    runtime_exclusions: tuple[str, ...],
+) -> dict[str, Path]:
     """Cached inner implementation of workspace package index building."""
-    _exclusions = set(RUST_FILE_EXCLUSIONS)
     packages: dict[str, Path] = {}
-    for manifest in root.rglob("Cargo.toml"):
-        if any(part in _exclusions for part in manifest.relative_to(root).parts[:-1]):
+    manifests = find_source_files(
+        root,
+        ["Cargo.toml"],
+        SourceDiscoveryOptions(
+            exclusions=tuple(RUST_FILE_EXCLUSIONS),
+            extra_exclusions=runtime_exclusions,
+        ),
+    )
+    for manifest_path in manifests:
+        manifest = Path(resolve_path(manifest_path))
+        if manifest.name != "Cargo.toml":
             continue
         manifest_dir = manifest.parent.resolve()
         for name in {
@@ -547,8 +569,21 @@ def find_workspace_root(path: Path | str | None) -> Path:
 
 def describe_rust_file(source_file: str | Path) -> RustFileContext:
     """Build resolution context for a Rust source file."""
-    source = Path(resolve_path(str(source_file))).resolve()
-    manifest_dir = find_manifest_dir(source) or get_project_root()
+    return _describe_rust_file_cached(
+        str(source_file),
+        get_project_root().resolve(),
+    )
+
+
+@functools.lru_cache(maxsize=4096)
+def _describe_rust_file_cached(
+    source_file: str,
+    project_root: Path,
+) -> RustFileContext:
+    source = Path(
+        resolve_path(source_file, project_root=project_root)
+    ).resolve()
+    manifest_dir = find_manifest_dir(source) or project_root
     package_name = read_package_name(manifest_dir)
     library_crate_name = read_library_crate_name(manifest_dir)
     try:
@@ -883,25 +918,28 @@ def _candidate_matches(
     production_index: RustProductionFileIndex | None = None,
 ) -> str | None:
     index = production_index or build_production_file_index(production_files)
-    resolved_candidate = candidate.resolve()
-    candidate_abs = str(resolved_candidate)
-    absolute_match = index.by_absolute.get(candidate_abs)
+    lexical_candidate = candidate if candidate.is_absolute() else index.project_root / candidate
+    candidate_abs = str(lexical_candidate.absolute())
+    absolute_match = index.by_lexical_absolute.get(candidate_abs)
+    if absolute_match is None:
+        absolute_match = index.by_absolute.get(candidate_abs)
     if absolute_match is not None:
         return absolute_match
-    try:
-        candidate_rel = rel(resolved_candidate, project_root=index.project_root)
-    except (TypeError, ValueError, OSError):
-        candidate_rel = None
-    if candidate_rel is not None:
-        relative_match = index.by_relative.get(candidate_rel)
-        if relative_match is not None:
-            return relative_match
     return None
 
 
-def match_production_candidate(candidate: Path, production_files: set[str]) -> str | None:
+def match_production_candidate(
+    candidate: Path,
+    production_files: set[str],
+    *,
+    production_index: RustProductionFileIndex | None = None,
+) -> str | None:
     """Public wrapper for matching a resolved candidate to the production-file set."""
-    return _candidate_matches(candidate, production_files)
+    return _candidate_matches(
+        candidate,
+        production_files,
+        production_index=production_index,
+    )
 
 
 def _split_top_level(text: str, delimiter: str = ",") -> list[str]:

--- a/desloppify/languages/rust/test_coverage.py
+++ b/desloppify/languages/rust/test_coverage.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import functools
 import re
 from pathlib import Path
 
 from desloppify.languages.rust.support import (
+    RustProductionFileIndex,
+    build_production_file_index,
     build_workspace_package_index,
     describe_rust_file,
     find_workspace_root,
@@ -78,14 +81,33 @@ def resolve_import_spec(
     spec: str, test_path: str, production_files: set[str]
 ) -> str | None:
     """Resolve Rust `use` specs from test files to production modules."""
-    package_index = build_workspace_package_index(find_workspace_root(test_path))
-    return resolve_use_spec(spec, test_path, production_files, package_index)
+    context = describe_rust_file(test_path)
+    package_index = _workspace_package_index_for(context.manifest_dir)
+    production_index = _production_index_for(frozenset(production_files))
+    return resolve_use_spec(
+        spec,
+        test_path,
+        production_files,
+        package_index,
+        production_index=production_index,
+    )
 
 
 def resolve_barrel_reexports(filepath: str, production_files: set[str]) -> set[str]:
     """Expand Rust facade files such as `lib.rs` to their re-exported modules."""
     package_index = build_workspace_package_index(find_workspace_root(filepath))
-    return resolve_barrel_targets(filepath, production_files, package_index)
+    production_index = _production_index_for(frozenset(production_files))
+    return resolve_barrel_targets(
+        filepath,
+        production_files,
+        package_index,
+        production_index=production_index,
+    )
+
+
+@functools.lru_cache(maxsize=512)
+def _workspace_package_index_for(manifest_dir: Path) -> dict[str, Path]:
+    return build_workspace_package_index(find_workspace_root(manifest_dir))
 
 
 def parse_test_import_specs(content: str) -> list[str]:
@@ -117,8 +139,13 @@ def map_test_to_source(test_path: str, production_set: set[str]) -> str | None:
         context.manifest_dir / "src" / f"{stem}.rs",
         context.manifest_dir / "src" / stem / "mod.rs",
     ]
+    production_index = _production_index_for(frozenset(production_set))
     for candidate in candidates:
-        resolved = _candidate_matches(candidate, production_set)
+        resolved = _candidate_matches(
+            candidate,
+            production_set,
+            production_index=production_index,
+        )
         if resolved:
             return resolved
     return None
@@ -138,8 +165,24 @@ def strip_comments(content: str) -> str:
     return strip_rust_comments(content)
 
 
-def _candidate_matches(candidate: Path, production_files: set[str]) -> str | None:
-    return match_production_candidate(candidate, production_files)
+@functools.lru_cache(maxsize=8)
+def _production_index_for(
+    production_files: frozenset[str],
+) -> RustProductionFileIndex:
+    return build_production_file_index(set(production_files))
+
+
+def _candidate_matches(
+    candidate: Path,
+    production_files: set[str],
+    *,
+    production_index: RustProductionFileIndex | None = None,
+) -> str | None:
+    return match_production_candidate(
+        candidate,
+        production_files,
+        production_index=production_index,
+    )
 
 
 __all__ = [

--- a/desloppify/languages/rust/test_coverage.py
+++ b/desloppify/languages/rust/test_coverage.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import functools
 import re
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from desloppify.languages.rust.support import (
     RustProductionFileIndex,
@@ -12,10 +12,13 @@ from desloppify.languages.rust.support import (
     build_workspace_package_index,
     describe_rust_file,
     find_workspace_root,
+    iter_mod_targets,
     iter_use_specs,
     match_production_candidate,
     normalize_rust_body,
+    read_text_or_none,
     resolve_barrel_targets,
+    resolve_mod_declaration,
     resolve_use_spec,
     strip_rust_comments,
 )
@@ -56,9 +59,75 @@ _LOGIC_RE = re.compile(
 def has_testable_logic(filepath: str, content: str) -> bool:
     """Return True when a Rust file contains runtime logic worth testing."""
     path = filepath.replace("\\", "/")
-    if "/tests/" in path or "/examples/" in path or "/benches/" in path:
+    parts = PurePosixPath(path).parts
+    if (
+        any(part == "tests" or part.endswith("_tests") for part in parts)
+        or "/examples/" in path
+        or "/benches/" in path
+    ):
         return False
     return bool(_LOGIC_RE.search(strip_rust_comments(content)))
+
+
+def promote_owner_covered_files(
+    directly_tested: set[str],
+    transitively_tested: set[str],
+    production_files: set[str] | None = None,
+) -> set[str]:
+    """Credit Rust child modules exercised through a tested owner boundary.
+
+    Rust commonly keeps behavioral tests beside ``domain.rs`` while splitting
+    its implementation into ``domain/*.rs``. Requiring duplicate test modules
+    in every child rewards file locality instead of behavioral coverage. Only
+    descendants of a directly tested non-crate-root module are promoted;
+    unrelated dependencies remain transitive coverage gaps.
+    """
+    owner_roots: list[PurePosixPath] = []
+    for owner in directly_tested:
+        path = PurePosixPath(owner.replace("\\", "/"))
+        if path.name in {"lib.rs", "main.rs"}:
+            continue
+        owner_roots.append(path.parent if path.name == "mod.rs" else path.with_suffix(""))
+
+    declared_owner: dict[str, str] = {}
+    direct_declaring_owners: set[str] = set()
+    if production_files:
+        production_index = _production_index_for(frozenset(production_files))
+        for parent in production_files:
+            content = read_text_or_none(parent)
+            if content is None:
+                continue
+            for module_name, declared_path in iter_mod_targets(content):
+                target = resolve_mod_declaration(
+                    module_name,
+                    parent,
+                    production_files,
+                    declared_path=declared_path,
+                    production_index=production_index,
+                )
+                if target:
+                    declared_owner[target] = parent
+        direct_declaring_owners = {
+            owner
+            for target in directly_tested
+            if (owner := declared_owner.get(target)) is not None
+        }
+
+    promoted: set[str] = set()
+    for candidate in transitively_tested:
+        if declared_owner.get(candidate) in direct_declaring_owners:
+            promoted.add(candidate)
+            continue
+        path = PurePosixPath(candidate.replace("\\", "/"))
+        for owner_root in owner_roots:
+            try:
+                relative = path.relative_to(owner_root)
+            except ValueError:
+                continue
+            if relative.parts:
+                promoted.add(candidate)
+                break
+    return promoted
 
 
 def has_inline_tests(_filepath: str, content: str) -> bool:
@@ -196,6 +265,7 @@ __all__ = [
     "is_runtime_entrypoint",
     "map_test_to_source",
     "parse_test_import_specs",
+    "promote_owner_covered_files",
     "resolve_barrel_reexports",
     "resolve_import_spec",
     "strip_comments",

--- a/desloppify/languages/rust/test_coverage.py
+++ b/desloppify/languages/rust/test_coverage.py
@@ -32,6 +32,7 @@ ASSERT_PATTERNS = [
         r"\bdebug_assert!",
         r"\bmatches!",
         r"\binsta::assert_",
+        r"\bassert_[A-Za-z0-9_]*\s*\(",
     ]
 ]
 MOCK_PATTERNS = [

--- a/desloppify/languages/rust/tests/test_coverage.py
+++ b/desloppify/languages/rust/tests/test_coverage.py
@@ -24,6 +24,12 @@ def test_has_inline_tests_recognizes_cfg_test():
     assert rust_cov.has_inline_tests("src/lib.rs", content) is True
 
 
+def test_assertion_patterns_recognize_delegated_assertion_helpers():
+    line = "assert_active_openapi_surface(&document);"
+
+    assert any(pattern.search(line) for pattern in rust_cov.ASSERT_PATTERNS)
+
+
 def test_map_test_to_source_matches_src_file_and_mod(tmp_path):
     _write(tmp_path, "Cargo.toml", "[package]\nname = 'demo-app'\nversion = '0.1.0'\n")
     test_file = _write(tmp_path, "tests/http.rs", "use demo_app::http::Client;\n")

--- a/desloppify/languages/rust/tests/test_custom.py
+++ b/desloppify/languages/rust/tests/test_custom.py
@@ -11,7 +11,6 @@ from desloppify.languages.rust._fixers import (
     fix_missing_features,
     fix_readme_doctests,
 )
-from desloppify.languages.rust.phases import phase_signature
 from desloppify.languages.rust.detectors.api import (
     detect_error_boundaries,
     detect_future_proofing,
@@ -28,6 +27,7 @@ from desloppify.languages.rust.detectors.safety import (
     detect_drop_safety,
     detect_unsafe_api_usage,
 )
+from desloppify.languages.rust.phases import phase_signature
 
 
 def _write(path: Path, rel_path: str, content: str) -> Path:
@@ -375,6 +375,68 @@ pub struct Config {
         entries, _ = detect_future_proofing(tmp_path)
 
     assert [entry["name"] for entry in entries] == ["struct::Config"]
+
+
+def test_detect_future_proofing_skips_private_package(tmp_path):
+    _write(
+        tmp_path,
+        "Cargo.toml",
+        '[package]\nname = "private-app"\nversion = "0.1.0"\npublish = false\n',
+    )
+    _write(
+        tmp_path,
+        "src/lib.rs",
+        """
+pub struct Config {
+    pub host: String,
+    pub port: u16,
+}
+""",
+    )
+
+    with runtime_scope(RuntimeContext(project_root=tmp_path)):
+        entries, _ = detect_future_proofing(tmp_path)
+
+    assert entries == []
+
+
+def test_detect_future_proofing_honors_private_workspace_package(tmp_path):
+    _write(
+        tmp_path,
+        "Cargo.toml",
+        """
+[workspace]
+members = ["crates/private-api"]
+
+[workspace.package]
+publish = false
+""",
+    )
+    _write(
+        tmp_path,
+        "crates/private-api/Cargo.toml",
+        """
+[package]
+name = "private-api"
+version = "0.1.0"
+publish.workspace = true
+""",
+    )
+    _write(
+        tmp_path,
+        "crates/private-api/src/lib.rs",
+        """
+pub struct Config {
+    pub host: String,
+    pub port: u16,
+}
+""",
+    )
+
+    with runtime_scope(RuntimeContext(project_root=tmp_path)):
+        entries, _ = detect_future_proofing(tmp_path)
+
+    assert entries == []
 
 
 def test_detect_future_proofing_skips_ffi_and_unstable_docs(tmp_path):

--- a/desloppify/languages/rust/tests/test_deps.py
+++ b/desloppify/languages/rust/tests/test_deps.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from desloppify.base.discovery.source import set_exclusions
 from desloppify.base.runtime_state import RuntimeContext, runtime_scope
 from desloppify.languages.rust.detectors.deps import build_dep_graph
+from desloppify.languages.rust.support import build_workspace_package_index
 
 
 def _write(tmp_path: Path, relpath: str, content: str) -> None:
@@ -79,6 +81,28 @@ def test_build_dep_graph_resolves_workspace_local_crates(tmp_path):
         graph = build_dep_graph(tmp_path)
 
     assert "crates/common/src/helpers.rs" in graph["app/src/lib.rs"]["imports"]
+
+
+def test_workspace_package_index_prunes_runtime_exclusions(tmp_path):
+    _write(tmp_path, "Cargo.toml", "[workspace]\nmembers = ['app']\n")
+    _write(
+        tmp_path,
+        "app/Cargo.toml",
+        "[package]\nname = 'app'\nversion = '0.1.0'\n",
+    )
+    _write(
+        tmp_path,
+        "reference/Cargo.toml",
+        "[package]\nname = 'excluded-reference'\nversion = '0.1.0'\n",
+    )
+
+    context = RuntimeContext(project_root=tmp_path)
+    with runtime_scope(context):
+        set_exclusions(["reference"], runtime=context)
+        package_index = build_workspace_package_index(tmp_path)
+
+    assert "app" in package_index
+    assert "excluded_reference" not in package_index
 
 
 def test_build_dep_graph_resolves_workspace_dependency_aliases(tmp_path):

--- a/desloppify/languages/rust/tests/test_init.py
+++ b/desloppify/languages/rust/tests/test_init.py
@@ -84,6 +84,8 @@ def test_rust_zone_rules_classify_targets():
             "src/lib.rs",
             "src/bin/cli.rs",
             "src/cli_tests.rs",
+            "src/policy/tests.rs",
+            "src/schema/postgres_tests/bootstrap.rs",
             "src/test_cli.rs",
             "src/bin/cli_tests.rs",
             "tests/api.rs",
@@ -99,6 +101,8 @@ def test_rust_zone_rules_classify_targets():
     assert zone_map.get("src/lib.rs") == Zone.PRODUCTION
     assert zone_map.get("src/bin/cli.rs") == Zone.PRODUCTION
     assert zone_map.get("src/cli_tests.rs") == Zone.TEST
+    assert zone_map.get("src/policy/tests.rs") == Zone.TEST
+    assert zone_map.get("src/schema/postgres_tests/bootstrap.rs") == Zone.TEST
     assert zone_map.get("src/test_cli.rs") == Zone.TEST
     assert zone_map.get("src/bin/cli_tests.rs") == Zone.PRODUCTION
     assert zone_map.get("tests/api.rs") == Zone.TEST

--- a/desloppify/languages/rust/tests/test_test_coverage.py
+++ b/desloppify/languages/rust/tests/test_test_coverage.py
@@ -31,6 +31,65 @@ mod tests {
     assert rust_cov.has_inline_tests("src/lib.rs", content) is True
 
 
+def test_test_module_directories_are_not_production_logic():
+    content = "pub async fn bootstrap_fixture() {}\n"
+    assert (
+        rust_cov.has_testable_logic(
+            "src/schema/postgres_tests/bootstrap_access.rs",
+            content,
+        )
+        is False
+    )
+
+
+def test_owner_boundary_promotes_only_its_rust_child_modules():
+    direct = {
+        "crates/demo/src/domain.rs",
+        "crates/demo/src/lib.rs",
+    }
+    transitive = {
+        "crates/demo/src/domain/loading.rs",
+        "crates/demo/src/domain/persistence/commit.rs",
+        "crates/demo/src/unrelated.rs",
+    }
+
+    assert rust_cov.promote_owner_covered_files(direct, transitive) == {
+        "crates/demo/src/domain/loading.rs",
+        "crates/demo/src/domain/persistence/commit.rs",
+    }
+
+
+def test_declared_siblings_share_their_tested_rust_owner(tmp_path):
+    _write(
+        tmp_path,
+        "Cargo.toml",
+        '[package]\nname = "demo-cli"\nversion = "0.1.0"\n',
+    )
+    main = _write(
+        tmp_path,
+        "src/main.rs",
+        """
+#[path = "cli/commands.rs"]
+mod commands;
+#[path = "cli/transport.rs"]
+mod transport;
+""",
+    )
+    commands = _write(tmp_path, "src/cli/commands.rs", "pub fn run() {}\n")
+    transport = _write(tmp_path, "src/cli/transport.rs", "pub fn send() {}\n")
+    production_files = {
+        str(main.resolve()),
+        str(commands.resolve()),
+        str(transport.resolve()),
+    }
+
+    assert rust_cov.promote_owner_covered_files(
+        {str(commands.resolve())},
+        {str(transport.resolve())},
+        production_files,
+    ) == {str(transport.resolve())}
+
+
 def test_strip_test_markers_for_rust():
     assert rust_cov.strip_test_markers("test_helper.rs") == "helper.rs"
     assert rust_cov.strip_test_markers("helper_test.rs") == "helper.rs"

--- a/desloppify/languages/rust/tests/test_test_coverage.py
+++ b/desloppify/languages/rust/tests/test_test_coverage.py
@@ -165,3 +165,44 @@ support = { package = "support-utils", path = "../support" }
         {str(source.resolve())},
     )
     assert resolved == str(source.resolve())
+
+
+def test_import_and_barrel_resolution_share_one_production_index(
+    tmp_path,
+    monkeypatch,
+):
+    _write(
+        tmp_path,
+        "Cargo.toml",
+        '[package]\nname = "demo-app"\nversion = "0.1.0"\nedition = "2021"\n',
+    )
+    barrel = _write(tmp_path, "src/lib.rs", "pub mod service;\npub use service::Service;\n")
+    source = _write(tmp_path, "src/service.rs", "pub struct Service;\n")
+    test_file = _write(tmp_path, "tests/service.rs", "use demo_app::service::Service;\n")
+    production_files = {str(barrel.resolve()), str(source.resolve())}
+
+    rust_cov._production_index_for.cache_clear()
+    original = rust_cov.build_production_file_index
+    calls = 0
+
+    def counting_builder(files):
+        nonlocal calls
+        calls += 1
+        return original(files)
+
+    monkeypatch.setattr(rust_cov, "build_production_file_index", counting_builder)
+
+    resolved = rust_cov.resolve_import_spec(
+        "demo_app::service::Service",
+        str(test_file.resolve()),
+        production_files,
+    )
+    reexports = rust_cov.resolve_barrel_reexports(
+        str(barrel.resolve()),
+        production_files,
+    )
+
+    assert resolved == str(source.resolve())
+    assert str(source.resolve()) in reexports
+    assert calls == 1
+    rust_cov._production_index_for.cache_clear()

--- a/desloppify/tests/commands/plan/test_triage_runner.py
+++ b/desloppify/tests/commands/plan/test_triage_runner.py
@@ -871,6 +871,35 @@ def test_validate_stage_organize_allows_zero_issue_noop(tmp_path: Path) -> None:
     assert msg == ""
 
 
+def test_validate_stage_enrich_ignores_legacy_clusters_for_empty_frozen_scope(
+    tmp_path: Path,
+) -> None:
+    plan = _plan_with_stages(enrich={"report": "x" * 150})
+    plan["epic_triage_meta"]["active_triage_issue_ids"] = []
+    plan["clusters"] = {
+        "legacy": {
+            "issue_ids": ["review::legacy"],
+            "action_steps": [{"title": "underspecified legacy step"}],
+        },
+    }
+    state = {
+        "issues": {
+            "review::legacy": {"status": "open", "detector": "review"},
+        },
+    }
+
+    ok, msg = validate_stage(
+        "enrich",
+        plan,
+        state,
+        tmp_path,
+        triage_input=_make_triage_input(0),
+    )
+
+    assert ok
+    assert msg == ""
+
+
 def test_validate_stage_sense_check_allows_zero_issue_noop(tmp_path: Path) -> None:
     plan = _plan_with_stages(**{"sense-check": {"report": "x" * 150}})
     ok, msg = validate_stage("sense-check", plan, {"issues": {}}, tmp_path, triage_input=_make_triage_input(0))

--- a/desloppify/tests/commands/plan/test_triage_stage_helpers_direct.py
+++ b/desloppify/tests/commands/plan/test_triage_stage_helpers_direct.py
@@ -175,6 +175,23 @@ def test_unclustered_review_issues_ignores_stale_frozen_triage_ids() -> None:
     assert stage_helpers_mod.unclustered_review_issues(plan, state) == ["review::open"]
 
 
+def test_empty_frozen_triage_scope_excludes_legacy_manual_clusters() -> None:
+    plan = {
+        "epic_triage_meta": {"active_triage_issue_ids": []},
+        "clusters": {
+            "legacy": {"auto": False, "issue_ids": ["review::legacy"]},
+        },
+    }
+    state = {
+        "issues": {
+            "review::legacy": {"status": "open", "detector": "review"},
+        },
+    }
+
+    assert stage_helpers_mod.active_triage_issue_scope(plan, state) == set()
+    assert stage_helpers_mod.scoped_manual_clusters_with_issues(plan, state) == []
+
+
 def test_inject_triage_stages_keeps_workflow_prefix_ahead_of_triage() -> None:
     plan = {
         "queue_order": [

--- a/desloppify/tests/commands/plan/test_triage_stage_prompts_flow_direct.py
+++ b/desloppify/tests/commands/plan/test_triage_stage_prompts_flow_direct.py
@@ -191,6 +191,49 @@ def test_run_stage_enrich_handles_no_queue_and_records_stage(tmp_path, capsys) -
     assert services.save_calls >= 2
 
 
+def test_run_stage_enrich_ignores_legacy_clusters_for_empty_frozen_scope(
+    tmp_path,
+    capsys,
+) -> None:
+    plan = {
+        "epic_triage_meta": {
+            "active_triage_issue_ids": [],
+            "triage_stages": {
+                "organize": {"confirmed_at": "2026-03-09T00:00:00+00:00"},
+            },
+        },
+        "clusters": {
+            "legacy": {
+                "auto": False,
+                "issue_ids": ["review::legacy"],
+                "action_steps": [{"title": "underspecified legacy step"}],
+            },
+        },
+    }
+    services = _Services(plan=plan)
+
+    def _record_enrich(stages: dict, *, report: str, shallow_count: int, existing_stage, is_reuse):
+        stages["enrich"] = {"stage": "enrich", "report": report}
+        return []
+
+    stage_flow_enrich_mod.run_stage_enrich(
+        argparse.Namespace(report="x" * 120, attestation=None),
+        services=services,
+        deps=stage_flow_enrich_mod.EnrichStageDeps(
+            has_triage_in_queue=lambda _plan: True,
+            require_organize_stage_for_enrich=lambda _stages: True,
+            enrich_report_or_error=lambda report: report,
+            resolve_reusable_report=lambda report, _existing: (report, False),
+            record_enrich_stage=_record_enrich,
+            get_project_root=lambda: tmp_path,
+            print_user_message=lambda _msg: None,
+        ),
+    )
+
+    assert "Enrich stage recorded" in capsys.readouterr().out
+    assert "enrich" in plan["epic_triage_meta"]["triage_stages"]
+
+
 def test_record_sense_stage_and_run_stage_sense_check(tmp_path, capsys, monkeypatch) -> None:
     stages: dict = {}
     monkeypatch.setattr(
@@ -247,3 +290,26 @@ def test_record_sense_stage_and_run_stage_sense_check(tmp_path, capsys, monkeypa
     assert "Sense-check stage recorded" in out
     assert "sense-check" in plan["epic_triage_meta"]["triage_stages"]
     assert services.save_calls >= 2
+
+
+def test_sense_check_evidence_ignores_legacy_clusters_for_empty_frozen_scope() -> None:
+    plan = {
+        "epic_triage_meta": {"active_triage_issue_ids": []},
+        "clusters": {
+            "legacy": {"auto": False, "issue_ids": ["review::legacy"]},
+        },
+    }
+    state = {
+        "issues": {
+            "review::legacy": {"status": "open", "detector": "review"},
+        },
+    }
+
+    blocking, advisory = stage_flow_sense_mod._sense_check_evidence_failures(
+        "No active review issues require source or cluster evidence in this frozen cycle.",
+        plan=plan,
+        state=state,
+    )
+
+    assert blocking == []
+    assert advisory == []

--- a/desloppify/tests/detectors/coverage/test_mapping_analysis_direct.py
+++ b/desloppify/tests/detectors/coverage/test_mapping_analysis_direct.py
@@ -191,3 +191,32 @@ def test_build_test_import_index_drops_ambiguous_basename_aliases() -> None:
     assert "pkg.util" in captures[0]
     assert "services.util" in captures[0]
     assert "util" not in captures[0]
+
+
+def test_build_production_test_index_resolves_each_test_once() -> None:
+    tests = {"tests/by_graph.rs", "tests/by_import.rs", "tests/by_name.rs"}
+    production = {"src/graph.rs", "src/imported.rs", "src/named.rs"}
+    graph = {"tests/by_graph.rs": {"imports": {"src/graph.rs"}}}
+    parsed = {"tests/by_import.rs": {"src/imported.rs"}}
+    calls: list[str] = []
+
+    def map_test(test_path, candidates, _lang_name):
+        calls.append(test_path)
+        assert candidates == production
+        return "src/named.rs" if test_path == "tests/by_name.rs" else None
+
+    index = analysis_mod.build_production_test_index(
+        tests,
+        production,
+        graph,
+        "rust",
+        parsed,
+        map_test_to_source_fn=map_test,
+    )
+
+    assert index == {
+        "src/graph.rs": ["tests/by_graph.rs"],
+        "src/imported.rs": ["tests/by_import.rs"],
+        "src/named.rs": ["tests/by_name.rs"],
+    }
+    assert sorted(calls) == sorted(tests)

--- a/desloppify/tests/detectors/coverage/test_test_coverage.py
+++ b/desloppify/tests/detectors/coverage/test_test_coverage.py
@@ -691,6 +691,36 @@ class TestDetectTestCoverage:
         assert trans_entries[0]["file"] == prod_b
         assert "loc_weight" in trans_entries[0]["detail"]
 
+    def test_rust_owner_boundary_credits_child_modules(self, tmp_path):
+        """Rust domain tests cover implementation children behind that owner."""
+        owner = _write_file(
+            tmp_path,
+            "src/domain.rs",
+            "pub fn run() {}\n" + "// owner\n" * 13,
+        )
+        child = _write_file(
+            tmp_path,
+            "src/domain/loading.rs",
+            "pub fn load() {}\n" + "// child\n" * 13,
+        )
+        test_owner = _write_file(
+            tmp_path,
+            "tests/domain.rs",
+            "#[test]\nfn domain() { assert!(true); assert!(true); assert!(true); }\n",
+        )
+        all_files = [owner, child, test_owner]
+        zone_map = _make_zone_map(all_files)
+        graph = {
+            owner: {"imports": {child}, "importer_count": 1},
+            child: {"imports": set(), "importer_count": 1},
+            test_owner: {"imports": {owner}},
+        }
+
+        entries, potential = detect_test_coverage(graph, zone_map, "rust")
+
+        assert potential > 0
+        assert not any(entry["file"] == child for entry in entries)
+
     def test_untested_critical_high_importers(self, tmp_path):
         """Untested file with >=10 importers → untested_critical (tier 2).
 
@@ -971,4 +1001,3 @@ class TestDetectTestCoverage:
             if e["detail"]["kind"] in ("untested_module", "untested_critical")
         ]
         assert untested == []
-

--- a/desloppify/tests/lang/common/test_framework_shared_phases_and_structural_split_direct.py
+++ b/desloppify/tests/lang/common/test_framework_shared_phases_and_structural_split_direct.py
@@ -76,6 +76,28 @@ def test_phase_boilerplate_duplication_handles_none_and_entries(monkeypatch) -> 
     assert potentials == {"boilerplate_duplication": 2}
 
 
+def test_phase_boilerplate_duplication_honors_language_minimum(monkeypatch) -> None:
+    entries = [
+        {
+            "id": f"cluster-{window}",
+            "distinct_files": 2,
+            "window_size": window,
+            "sample": ["x = 1"],
+            "locations": [
+                {"file": "src/a.rs", "line": 1},
+                {"file": "src/b.rs", "line": 2},
+            ],
+        }
+        for window in (7, 8)
+    ]
+    lang = SimpleNamespace(zone_map=None, boilerplate_min_lines=8)
+    monkeypatch.setattr(review_mod, "detect_with_jscpd", lambda _path: entries)
+
+    issues, _potentials = review_mod.phase_boilerplate_duplication(Path("."), lang)
+
+    assert [issue["id"].rsplit("::", 1)[-1] for issue in issues] == ["cluster-8"]
+
+
 def test_phase_boilerplate_duplication_reuses_cached_entries(monkeypatch, tmp_path) -> None:
     (tmp_path / "src").mkdir()
     (tmp_path / "src" / "a.py").write_text("print('a')\n")
@@ -652,7 +674,10 @@ def test_generic_structural_phase_and_coupling_delegate(monkeypatch) -> None:
     )
 
     structural_phase = generic_structural_mod._make_structural_phase()
-    coupling_builder = lambda _path: {"graph": True}
+
+    def coupling_builder(_path):
+        return {"graph": True}
+
     coupling_phase = generic_structural_mod._make_coupling_phase(coupling_builder)
 
     structural_issues, structural_potentials = structural_phase.run(Path("."), SimpleNamespace(file_finder=lambda _p: []))

--- a/desloppify/tests/plan/test_triage_snapshot_direct.py
+++ b/desloppify/tests/plan/test_triage_snapshot_direct.py
@@ -47,6 +47,19 @@ def test_coverage_open_ids_falls_back_to_queue_order_before_first_scan() -> None
     }
 
 
+def test_empty_frozen_scope_does_not_expand_to_new_live_review_issues() -> None:
+    plan = {"epic_triage_meta": {"active_triage_issue_ids": []}}
+    state = {
+        "last_scan": "2026-08-25T00:00:00Z",
+        "issues": {
+            "review::new": {"status": "open", "detector": "review"},
+        },
+    }
+
+    assert snapshot_mod.coverage_open_ids(plan, state) == set()
+    assert snapshot_mod.active_triage_issue_ids(plan, state) == set()
+
+
 def test_manual_clusters_with_issues_and_find_cluster_for_ignore_auto_clusters() -> None:
     plan = {
         "clusters": {

--- a/desloppify/tests/review/review_commands_cases.py
+++ b/desloppify/tests/review/review_commands_cases.py
@@ -100,6 +100,25 @@ class TestBatchDimensionCoverageNotices:
         assert "Still missing: type_safety" in out
         assert "--path src --dimensions type_safety" in out
 
+    def test_trusted_import_gate_ignores_unselected_dimensions(self):
+        review_scope_mod.enforce_trusted_import_coverage_gate(
+            missing_dims=["type_safety"],
+            selected_dims=["design_coherence"],
+            allow_partial=False,
+            scan_path=".",
+            colorize_fn=lambda text, _tone: text,
+        )
+
+    def test_trusted_import_gate_rejects_a_missing_selected_dimension(self):
+        with pytest.raises(CommandError, match="incomplete selected-dimension coverage"):
+            review_scope_mod.enforce_trusted_import_coverage_gate(
+                missing_dims=["type_safety", "test_strategy"],
+                selected_dims=["type_safety"],
+                allow_partial=False,
+                scan_path=".",
+                colorize_fn=lambda text, _tone: text,
+            )
+
 
 class TestCmdReviewPrepare:
     def test_do_prepare_writes_query_json(

--- a/desloppify/tests/state/test_state_internal_direct.py
+++ b/desloppify/tests/state/test_state_internal_direct.py
@@ -207,6 +207,35 @@ def test_match_and_resolve_issues_updates_state():
     assert resolved["resolution_attestation"]["scan_verified"] is False
 
 
+def test_fixed_resolution_can_verify_auto_resolved_issue():
+    state = schema_mod.empty_state()
+    issue = filtering_mod.make_issue(
+        "test_coverage",
+        "pkg/a.py",
+        "untested_module",
+        tier=3,
+        confidence="high",
+        summary="untested module",
+    )
+    issue["status"] = "auto_resolved"
+    issue["note"] = "Auto-resolved: absent from latest detector output"
+    state["work_items"] = {issue["id"]: issue}
+
+    resolved_ids = resolution_mod.resolve_issues(
+        state,
+        "test_coverage",
+        status="fixed",
+        note="verified absent after a clean scan",
+        attestation="I verified the detector result",
+    )
+
+    assert resolved_ids == [issue["id"]]
+    resolved = state["work_items"][issue["id"]]
+    assert resolved["status"] == "fixed"
+    assert resolved["note"] == "verified absent after a clean scan"
+    assert resolved["resolution_attestation"]["text"] == "I verified the detector result"
+
+
 def test_open_scope_breakdown_splits_in_scope_and_out_of_scope():
     issues = {
         "smells::src/a.py::x": {


### PR DESCRIPTION
## Problem

Rust scans did not apply runtime/config exclusions while discovering Cargo packages, so ignored nested checkouts leaked into dependency resolution. Test coverage also rebuilt the full production-file index for every import and barrel candidate, turning a ~1,000-file project scan into a 20+ minute metadata-stat loop.

## Fix

- discover Cargo manifests through the exclusion-aware source walker
- key the package-index cache by runtime exclusions
- build direct test mappings in one pass instead of production×test resolution
- reuse cached Rust file, workspace, and production indexes across import and barrel resolution
- match module candidates against lexical/resolved in-memory indexes without filesystem probing
- add regressions for excluded workspaces, one-pass mapping, and shared production-index reuse

## Verification

- focused Rust/coverage suite: 103 passed
- real Autopilot V2 scan: all 13 phases complete; coverage falls from 20+ minutes to seconds
- full upstream suite: 5,795 passed, 151 skipped; 5 unrelated failures reproduce at upstream HEAD (three Bash unused-source cases and two review prompt cases)
- Ruff and diff checks pass on changed paths