### PR TITLE
fix: stop reporting Nuxt/Nitro convention files and auto-imported Vue components as orphaned

### DIFF
--- a/desloppify/engine/detectors/_orphaned/nuxt.py
+++ b/desloppify/engine/detectors/_orphaned/nuxt.py
@@ -1,0 +1,347 @@
+"""Nuxt / Nitro convention entry points and auto-import usage resolution.
+
+Nuxt registers whole directory trees by convention: ``pages/`` is the router,
+``server/api/`` is the HTTP surface, ``plugins/`` boot on their own. Nothing
+imports those files, so an import-graph orphan check reports every one of them.
+
+Nuxt also auto-imports ``components/``, ``composables/``, ``utils/`` and
+``shared/``: consumers write ``<GameOutcomeDrawer />`` in a template or a bare
+``useUser()`` call with no import statement, which the graph cannot see either.
+Those are resolved by name rather than exempted wholesale, so a component that
+genuinely nobody references is still reported.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from desloppify.base.discovery.paths import get_project_root
+from desloppify.base.discovery.source import find_source_files, read_file_text
+
+# ---------------------------------------------------------------------------
+# Project detection
+# ---------------------------------------------------------------------------
+
+_NUXT_CONFIG_NAMES: frozenset[str] = frozenset(
+    {
+        "nuxt.config.ts",
+        "nuxt.config.js",
+        "nuxt.config.mjs",
+        "nuxt.config.cjs",
+        "nuxt.config.mts",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Convention directories and files
+# ---------------------------------------------------------------------------
+
+# Auto-registered directories under the Nuxt srcDir (``app/`` in Nuxt 4,
+# the project root in Nuxt 3).
+_NUXT_APP_DIRS: frozenset[str] = frozenset(
+    {
+        "pages",
+        "layouts",
+        "middleware",
+        "plugins",
+        "modules",
+    }
+)
+
+# File-routed or auto-registered directories under the Nitro ``server/`` dir.
+_NUXT_SERVER_DIRS: frozenset[str] = frozenset(
+    {
+        "api",
+        "routes",
+        "middleware",
+        "plugins",
+        "tasks",
+    }
+)
+
+# Root-level convention files, by stem.
+_NUXT_ROOT_CONVENTIONS: frozenset[str] = frozenset(
+    {
+        "nuxt.config",
+        "capacitor.config",
+        "app.config",
+        "app",
+        "error",
+    }
+)
+
+# Segments a source path may start with before the conventions begin.
+_NUXT_SRC_DIRS: frozenset[str] = frozenset({"app", "src"})
+
+# ---------------------------------------------------------------------------
+# Auto-import surfaces
+# ---------------------------------------------------------------------------
+
+# Directories whose files are registered globally by name. Values say how the
+# registered name is derived: component naming, or the module's exports.
+_COMPONENT_SURFACE = "component"
+_EXPORT_SURFACE = "export"
+
+_NUXT_APP_AUTO_IMPORTS: dict[str, str] = {
+    "components": _COMPONENT_SURFACE,
+    "composables": _EXPORT_SURFACE,
+    "utils": _EXPORT_SURFACE,
+}
+
+_NUXT_SERVER_AUTO_IMPORTS: dict[str, str] = {
+    "utils": _EXPORT_SURFACE,
+}
+
+_NUXT_SHARED_DIR = "shared"
+
+_NUXT_SOURCE_EXTENSIONS: tuple[str, ...] = (
+    ".vue",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".mts",
+)
+
+_MODE_SUFFIX_RE = re.compile(r"\.(?:client|server|global)$")
+_WORD_SPLIT_RE = re.compile(r"[^A-Za-z0-9]+")
+_CASE_SPLIT_RE = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
+
+_IDENTIFIER_RE = re.compile(r"[A-Za-z_$][A-Za-z0-9_$]*")
+_TAG_RE = re.compile(r"<\s*/?\s*([A-Za-z][A-Za-z0-9]*(?:-[A-Za-z0-9]+)+)")
+
+_EXPORT_DECL_RE = re.compile(
+    r"\bexport\s+(?:declare\s+)?(?:default\s+)?(?:async\s+)?"
+    r"(?:abstract\s+)?(?:function\s*\*?|const|let|var|class|interface|enum|type)\s+"
+    r"([A-Za-z_$][A-Za-z0-9_$]*)"
+)
+_EXPORT_LIST_RE = re.compile(r"\bexport\s*\{([^}]*)\}")
+
+
+def detect_nuxt_project(path: Path) -> bool:
+    """Return True if the scan root looks like a Nuxt project."""
+    for name in _NUXT_CONFIG_NAMES:
+        if (path / name).exists():
+            return True
+    return _package_json_declares_nuxt(path / "package.json")
+
+
+def _package_json_declares_nuxt(manifest: Path) -> bool:
+    """Return True if *manifest* lists ``nuxt`` as a dependency."""
+    try:
+        payload = json.loads(manifest.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, ValueError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    for key in ("dependencies", "devDependencies"):
+        section = payload.get(key)
+        if isinstance(section, dict) and "nuxt" in section:
+            return True
+    return False
+
+
+def _strip_src_prefix(parts: tuple[str, ...]) -> tuple[str, ...]:
+    """Drop a leading ``app/`` or ``src/`` srcDir segment."""
+    if len(parts) > 1 and parts[0] in _NUXT_SRC_DIRS:
+        return parts[1:]
+    return parts
+
+
+def is_nuxt_convention_entry(rel_path: str) -> bool:
+    """Return True if *rel_path* is a Nuxt or Nitro convention entry point.
+
+    Covers file-routed and auto-registered trees (``pages/``, ``layouts/``,
+    ``server/api/``, ``server/plugins/`` and friends) plus the root config
+    files, under both the Nuxt 3 root layout and the Nuxt 4 ``app/`` srcDir.
+    """
+    parts = Path(rel_path).parts
+    if not parts:
+        return False
+
+    inner = _strip_src_prefix(parts)
+
+    # ``nuxt.config.ts`` at the root, ``app.vue`` at the root or in the srcDir.
+    if len(inner) == 1:
+        return _MODE_SUFFIX_RE.sub("", Path(inner[0]).stem) in _NUXT_ROOT_CONVENTIONS
+
+    if inner[0] == "server":
+        return len(inner) > 2 and inner[1] in _NUXT_SERVER_DIRS
+
+    return inner[0] in _NUXT_APP_DIRS
+
+
+def _auto_import_surface(rel_path: str) -> tuple[str, tuple[str, ...]] | None:
+    """Return ``(surface, dir_parts)`` when *rel_path* is auto-imported."""
+    parts = Path(rel_path).parts
+    if len(parts) < 2:
+        return None
+
+    if parts[0] == _NUXT_SHARED_DIR:
+        return _EXPORT_SURFACE, parts[1:-1]
+
+    inner = _strip_src_prefix(parts)
+    if len(inner) < 2:
+        return None
+
+    if inner[0] == "server":
+        if len(inner) < 3:
+            return None
+        surface = _NUXT_SERVER_AUTO_IMPORTS.get(inner[1])
+        return (surface, inner[2:-1]) if surface else None
+
+    surface = _NUXT_APP_AUTO_IMPORTS.get(inner[0])
+    return (surface, inner[1:-1]) if surface else None
+
+
+def path_within_root(filepath: str, root: Path, fallback: str) -> str:
+    """Return *filepath* relative to the scan *root*.
+
+    Convention matching is anchored on the scan root, not on the working
+    directory: ``rel()`` resolves against the project root, which yields a
+    ``../..`` prefix when the tool is invoked from outside the project.
+    """
+    try:
+        return str(Path(filepath).resolve().relative_to(root))
+    except ValueError:
+        return fallback
+
+
+def _absolute(filepath: str) -> str:
+    """Resolve a discovery-relative path against the project root."""
+    if os.path.isabs(filepath):
+        return filepath
+    return str(get_project_root() / filepath)
+
+
+def _split_by_case(value: str) -> list[str]:
+    """Split an identifier into its case/separator-delimited words."""
+    words: list[str] = []
+    for chunk in _WORD_SPLIT_RE.split(value):
+        words.extend(_CASE_SPLIT_RE.findall(chunk))
+    return words
+
+
+def _pascal(words: list[str]) -> str:
+    return "".join(word[:1].upper() + word[1:] for word in words)
+
+
+def _component_names(dir_parts: tuple[str, ...], stem: str) -> set[str]:
+    """Return the names a Nuxt component file can be referenced by.
+
+    Nuxt joins the directory path to the filename and drops the directory
+    segments the filename already repeats, so ``game/GameOutcomeDrawer.vue``
+    registers as ``GameOutcomeDrawer`` while ``account/ThemeSwitcher.vue``
+    registers as ``AccountThemeSwitcher``. The undeduplicated join comes back
+    alongside it, and so does the bare filename: ``components.dirs`` with
+    ``pathPrefix: false`` registers under that, and it is also the local name a
+    consumer that imports the file by path writes in its template.
+    """
+    prefix_words: list[str] = []
+    for segment in dir_parts:
+        prefix_words.extend(_split_by_case(segment))
+
+    file_words = [] if stem.lower() == "index" else _split_by_case(stem)
+
+    remaining = list(prefix_words)
+    leading: list[str] = []
+    while remaining and (not file_words or remaining[0].lower() != file_words[0].lower()):
+        leading.append(remaining.pop(0))
+
+    names = {
+        _pascal(leading + file_words),
+        _pascal(prefix_words + file_words),
+        _pascal(file_words),
+    }
+    return {name for name in names if name}
+
+
+def _exported_names(filepath: str, stem: str) -> set[str]:
+    """Return the identifiers a composable/util module publishes."""
+    names = {stem}
+    text = read_file_text(_absolute(filepath))
+    if text is None:
+        return names
+    names.update(_EXPORT_DECL_RE.findall(text))
+    for group in _EXPORT_LIST_RE.findall(text):
+        for item in group.split(","):
+            token = item.strip().split(" as ")[-1].strip()
+            if token and _IDENTIFIER_RE.fullmatch(token):
+                names.add(token)
+    return names
+
+
+def nuxt_auto_import_names(rel_path: str, filepath: str) -> set[str] | None:
+    """Return the names *rel_path* is auto-imported under, or None.
+
+    None means the file is not on an auto-import surface, so the ordinary
+    import-graph verdict stands.
+    """
+    surface = _auto_import_surface(rel_path)
+    if surface is None:
+        return None
+
+    kind, dir_parts = surface
+    stem = _MODE_SUFFIX_RE.sub("", Path(rel_path).stem)
+    if kind == _COMPONENT_SURFACE:
+        return _component_names(dir_parts, stem)
+    return _exported_names(filepath, stem)
+
+
+@dataclass
+class NuxtUsageIndex:
+    """Where each referenced identifier was seen, across the project."""
+
+    hits: dict[str, tuple[int, str]] = field(default_factory=dict)
+
+    def record(self, name: str, filepath: str) -> None:
+        seen = self.hits.get(name)
+        if seen is None:
+            self.hits[name] = (1, filepath)
+        elif seen[1] != filepath:
+            self.hits[name] = (seen[0] + 1, seen[1])
+
+    def is_used_outside(self, names: set[str], filepath: str) -> bool:
+        """Return True if any of *names* is referenced by another file."""
+        for name in names:
+            seen = self.hits.get(name)
+            if seen is None:
+                continue
+            if seen[0] > 1 or seen[1] != filepath:
+                return True
+        return False
+
+
+def build_nuxt_usage_index(path: Path) -> NuxtUsageIndex:
+    """Index every identifier and component tag referenced under *path*.
+
+    Template tags are normalized to PascalCase so ``<game-outcome-drawer />``
+    and ``<GameOutcomeDrawer />`` resolve to the one registered name.
+    """
+    index = NuxtUsageIndex()
+    for filepath in find_source_files(path, list(_NUXT_SOURCE_EXTENSIONS)):
+        abs_path = _absolute(filepath)
+        text = read_file_text(abs_path)
+        if text is None:
+            continue
+        resolved = str(Path(abs_path).resolve())
+        for name in _IDENTIFIER_RE.findall(text):
+            index.record(name, resolved)
+        for tag in _TAG_RE.findall(text):
+            index.record(_pascal(_split_by_case(tag)), resolved)
+    return index
+
+
+__all__ = [
+    "NuxtUsageIndex",
+    "build_nuxt_usage_index",
+    "detect_nuxt_project",
+    "is_nuxt_convention_entry",
+    "nuxt_auto_import_names",
+    "path_within_root",
+]

--- a/desloppify/engine/detectors/orphaned.py
+++ b/desloppify/engine/detectors/orphaned.py
@@ -10,6 +10,15 @@ from pathlib import Path
 from desloppify.base.discovery.file_paths import rel
 from desloppify.base.discovery.file_paths import count_lines
 
+from ._orphaned.nuxt import (
+    NuxtUsageIndex,
+    build_nuxt_usage_index,
+    detect_nuxt_project,
+    is_nuxt_convention_entry,
+    nuxt_auto_import_names,
+    path_within_root,
+)
+
 _DUNDER_ALL_RE = re.compile(r"^__all__\s*[:=]", re.MULTILINE)
 
 # ---------------------------------------------------------------------------
@@ -140,9 +149,11 @@ def detect_orphaned_files(
     alias_resolver = resolved_options.alias_resolver
 
     # Framework convention detection
-    is_nextjs = (
-        resolved_options.detect_frameworks and _detect_nextjs_project(path)
-    )
+    detect_frameworks = resolved_options.detect_frameworks
+    is_nextjs = detect_frameworks and _detect_nextjs_project(path)
+    is_nuxt = detect_frameworks and detect_nuxt_project(path)
+    nuxt_usage: NuxtUsageIndex | None = None
+    scan_root = path.resolve()
 
     dynamic_targets = (
         dynamic_import_finder(path, extensions) if dynamic_import_finder else set()
@@ -165,6 +176,18 @@ def detect_orphaned_files(
 
         if is_nextjs and _is_nextjs_convention_entry(r):
             continue
+
+        if is_nuxt:
+            nuxt_rel = path_within_root(filepath, scan_root, r)
+            if is_nuxt_convention_entry(nuxt_rel):
+                continue
+            auto_import_names = nuxt_auto_import_names(nuxt_rel, filepath)
+            if auto_import_names is not None:
+                if nuxt_usage is None:
+                    nuxt_usage = build_nuxt_usage_index(path)
+                resolved_path = str(Path(filepath).resolve())
+                if nuxt_usage.is_used_outside(auto_import_names, resolved_path):
+                    continue
 
         if dynamic_targets and _is_dynamically_imported(
             filepath, dynamic_targets, alias_resolver

--- a/desloppify/tests/detectors/test_orphaned_nuxt.py
+++ b/desloppify/tests/detectors/test_orphaned_nuxt.py
@@ -1,0 +1,353 @@
+"""Tests for Nuxt/Nitro conventions and auto-imports in orphaned detection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from desloppify.engine.detectors._orphaned.nuxt import (
+    _component_names,
+    build_nuxt_usage_index,
+    detect_nuxt_project,
+    is_nuxt_convention_entry,
+    nuxt_auto_import_names,
+)
+from desloppify.engine.detectors.orphaned import (
+    OrphanedDetectionOptions,
+    detect_orphaned_files,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _graph_entry(*, importer_count: int = 0) -> dict:
+    """Build a minimal graph node dict."""
+    return {"imports": set(), "importer_count": importer_count, "importers": []}
+
+
+def _write(path: Path, body: str = "", lines: int = 20) -> Path:
+    """Write a file padded to *lines* so it clears the size floor."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    padding = "\n".join(f"// line {i}" for i in range(lines))
+    path.write_text(f"{body}\n{padding}\n")
+    return path
+
+
+def _nuxt_root(root: Path) -> Path:
+    """Make *root* look like a Nuxt project."""
+    (root / "nuxt.config.ts").write_text("export default defineNuxtConfig({})")
+    return root
+
+
+# ===================================================================
+# detect_nuxt_project
+# ===================================================================
+
+
+class TestDetectNuxtProject:
+    """A project counts as Nuxt via its config file or its manifest."""
+
+    def test_nuxt_config_ts_detected(self, tmp_path):
+        (tmp_path / "nuxt.config.ts").write_text("export default {}")
+        assert detect_nuxt_project(tmp_path) is True
+
+    def test_nuxt_config_mjs_detected(self, tmp_path):
+        (tmp_path / "nuxt.config.mjs").write_text("export default {}")
+        assert detect_nuxt_project(tmp_path) is True
+
+    def test_package_json_dependency_detected(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"dependencies": {"nuxt": "^4.0.0"}}')
+        assert detect_nuxt_project(tmp_path) is True
+
+    def test_dev_dependency_detected(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"devDependencies": {"nuxt": "^3.0.0"}}')
+        assert detect_nuxt_project(tmp_path) is True
+
+    def test_plain_project_not_detected(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"dependencies": {"react": "^18.0.0"}}')
+        assert detect_nuxt_project(tmp_path) is False
+
+    def test_unreadable_manifest_not_detected(self, tmp_path):
+        (tmp_path / "package.json").write_text("not json at all")
+        assert detect_nuxt_project(tmp_path) is False
+
+
+# ===================================================================
+# is_nuxt_convention_entry
+# ===================================================================
+
+
+class TestNuxtConventionEntry:
+    """File-routed and auto-registered trees are entry points."""
+
+    def test_nitro_api_route(self):
+        assert is_nuxt_convention_entry("server/api/puzzle/today.get.ts") is True
+
+    def test_nitro_non_api_route(self):
+        assert is_nuxt_convention_entry("server/routes/pricing.get.ts") is True
+
+    def test_nitro_middleware(self):
+        assert is_nuxt_convention_entry("server/middleware/auth.ts") is True
+
+    def test_nitro_plugin(self):
+        assert is_nuxt_convention_entry("server/plugins/pack-sync.ts") is True
+
+    def test_nitro_scheduled_task(self):
+        assert is_nuxt_convention_entry("server/tasks/daily/generate.ts") is True
+
+    def test_server_lib_is_not_an_entry(self):
+        """server/lib holds ordinary modules, so it keeps its orphan verdict."""
+        assert is_nuxt_convention_entry("server/lib/entitlement.ts") is False
+
+    def test_nuxt4_pages_under_srcdir(self):
+        assert is_nuxt_convention_entry("app/pages/index.vue") is True
+
+    def test_nuxt3_pages_at_root(self):
+        assert is_nuxt_convention_entry("pages/index.vue") is True
+
+    def test_layouts_middleware_and_plugins(self):
+        assert is_nuxt_convention_entry("app/layouts/default.vue") is True
+        assert is_nuxt_convention_entry("app/middleware/admin.ts") is True
+        assert is_nuxt_convention_entry("app/plugins/posthog.client.ts") is True
+
+    def test_root_configs(self):
+        assert is_nuxt_convention_entry("nuxt.config.ts") is True
+        assert is_nuxt_convention_entry("capacitor.config.ts") is True
+
+    def test_root_app_and_error_shells(self):
+        assert is_nuxt_convention_entry("app/app.vue") is True
+        assert is_nuxt_convention_entry("app.vue") is True
+        assert is_nuxt_convention_entry("app/error.vue") is True
+
+    def test_unrelated_root_config_is_not_an_entry(self):
+        assert is_nuxt_convention_entry("vitest.config.ts") is False
+
+    def test_components_are_not_convention_entries(self):
+        """Components are resolved by usage, not exempted by location."""
+        assert is_nuxt_convention_entry("app/components/game/GameOutcome.vue") is False
+
+
+# ===================================================================
+# Auto-import naming
+# ===================================================================
+
+
+class TestComponentNames:
+    """Nuxt derives a component's name from its path plus its filename."""
+
+    def test_directory_prefix_deduplicated(self):
+        assert "GameOutcomeDrawer" in _component_names(("game",), "GameOutcomeDrawer")
+
+    def test_directory_prefix_applied_when_not_repeated(self):
+        assert "AccountThemeSwitcher" in _component_names(("account",), "ThemeSwitcher")
+
+    def test_nested_directories_join(self):
+        assert "UiButton" in _component_names(("ui", "button"), "Button")
+
+    def test_index_takes_its_directory_name(self):
+        assert "Roster" in _component_names(("roster",), "index")
+
+    def test_flat_component_keeps_its_stem(self):
+        assert _component_names((), "Board") == {"Board"}
+
+    def test_bare_filename_is_always_a_candidate(self):
+        """pathPrefix: false, and path imports, both register the bare stem."""
+        assert "ThemeSwitcher" in _component_names(("account",), "ThemeSwitcher")
+
+
+class TestAutoImportSurface:
+    """Only auto-imported directories resolve by name."""
+
+    def test_component_resolves_to_registered_name(self, tmp_path):
+        path = _write(tmp_path / "app/components/game/GameOutcomeDrawer.vue")
+        names = nuxt_auto_import_names("app/components/game/GameOutcomeDrawer.vue", str(path))
+        assert names is not None
+        assert "GameOutcomeDrawer" in names
+
+    def test_mode_suffix_stripped(self, tmp_path):
+        path = _write(tmp_path / "app/components/badge/BadgeIcon.client.vue")
+        names = nuxt_auto_import_names("app/components/badge/BadgeIcon.client.vue", str(path))
+        assert names is not None
+        assert "BadgeIcon" in names
+
+    def test_composable_resolves_to_its_exports(self, tmp_path):
+        path = _write(
+            tmp_path / "app/composables/useUser.ts",
+            body="export function useUser() { return null }",
+        )
+        names = nuxt_auto_import_names("app/composables/useUser.ts", str(path))
+        assert names is not None
+        assert "useUser" in names
+
+    def test_shared_module_resolves_to_its_exports(self, tmp_path):
+        path = _write(
+            tmp_path / "shared/types/crossword.ts",
+            body="export interface CrosswordPublic { id: string }",
+        )
+        names = nuxt_auto_import_names("shared/types/crossword.ts", str(path))
+        assert names is not None
+        assert "CrosswordPublic" in names
+
+    def test_export_list_names_collected(self, tmp_path):
+        path = _write(
+            tmp_path / "shared/utils/ban.ts",
+            body="const isScoreBanActive = () => true\nexport { isScoreBanActive }",
+        )
+        names = nuxt_auto_import_names("shared/utils/ban.ts", str(path))
+        assert names is not None
+        assert "isScoreBanActive" in names
+
+    def test_non_auto_imported_directory_returns_none(self, tmp_path):
+        path = _write(tmp_path / "server/lib/entitlement.ts")
+        assert nuxt_auto_import_names("server/lib/entitlement.ts", str(path)) is None
+
+
+# ===================================================================
+# Usage index
+# ===================================================================
+
+
+class TestUsageIndex:
+    """Template tags and bare identifiers both count as references."""
+
+    def test_pascal_case_tag_is_a_reference(self, set_project_root):
+        root = set_project_root
+        _write(root / "app/pages/index.vue", body="<template><GameOutcome /></template>")
+        index = build_nuxt_usage_index(root)
+        assert index.is_used_outside({"GameOutcome"}, "/elsewhere/GameOutcome.vue") is True
+
+    def test_kebab_case_tag_resolves_to_the_registered_name(self, set_project_root):
+        root = set_project_root
+        _write(
+            root / "app/pages/index.vue",
+            body="<template><game-outcome-drawer /></template>",
+        )
+        index = build_nuxt_usage_index(root)
+        assert index.is_used_outside({"GameOutcomeDrawer"}, "/elsewhere/x.vue") is True
+
+    def test_a_files_own_mention_is_not_a_reference(self, set_project_root):
+        root = set_project_root
+        lonely = _write(root / "app/composables/useLonely.ts", body="export function useLonely() {}")
+        index = build_nuxt_usage_index(root)
+        assert index.is_used_outside({"useLonely"}, str(lonely.resolve())) is False
+
+    def test_unreferenced_name_is_not_used(self, set_project_root):
+        root = set_project_root
+        _write(root / "app/pages/index.vue", body="<template><div /></template>")
+        index = build_nuxt_usage_index(root)
+        assert index.is_used_outside({"NeverMentioned"}, "/elsewhere/x.vue") is False
+
+
+# ===================================================================
+# detect_orphaned_files integration
+# ===================================================================
+
+
+class TestNuxtIntegration:
+    """End-to-end orphan verdicts on a Nuxt-shaped tree."""
+
+    def test_convention_files_are_not_orphaned(self, set_project_root):
+        root = _nuxt_root(set_project_root)
+        route = _write(root / "server/api/puzzle/today.get.ts")
+        task = _write(root / "server/tasks/daily/generate.ts")
+        page = _write(root / "app/pages/index.vue")
+        plugin = _write(root / "app/plugins/posthog.client.ts")
+        stray = _write(root / "server/lib/unused-helper.ts")
+
+        graph = {
+            str(p): _graph_entry() for p in (route, task, page, plugin, stray)
+        }
+        entries, total = detect_orphaned_files(root, graph, [".ts", ".vue"])
+
+        assert total == 5
+        assert [e["file"] for e in entries] == [str(stray)]
+
+    def test_component_used_in_a_template_is_not_orphaned(self, set_project_root):
+        root = _nuxt_root(set_project_root)
+        used = _write(root / "app/components/game/GameOutcomeDrawer.vue")
+        unused = _write(root / "app/components/game/GameGhostPanel.vue")
+        _write(
+            root / "app/pages/index.vue",
+            body="<template><GameOutcomeDrawer /></template>",
+        )
+
+        graph = {str(used): _graph_entry(), str(unused): _graph_entry()}
+        entries, _total = detect_orphaned_files(root, graph, [".ts", ".vue"])
+
+        assert [e["file"] for e in entries] == [str(unused)]
+
+    def test_prefixed_component_resolves_through_its_registered_name(self, set_project_root):
+        root = _nuxt_root(set_project_root)
+        switcher = _write(root / "app/components/account/ThemeSwitcher.vue")
+        _write(
+            root / "app/pages/account.vue",
+            body="<template><AccountThemeSwitcher /></template>",
+        )
+
+        graph = {str(switcher): _graph_entry()}
+        entries, _total = detect_orphaned_files(root, graph, [".ts", ".vue"])
+
+        assert entries == []
+
+    def test_component_referenced_by_its_bare_filename_is_not_orphaned(self, set_project_root):
+        """A path import gives the consumer the bare stem as its local tag."""
+        root = _nuxt_root(set_project_root)
+        premium = _write(root / "app/components/layout/PremiumBanner.vue")
+        _write(root / "app/layouts/default.vue", body="<template><PremiumBanner /></template>")
+
+        graph = {str(premium): _graph_entry()}
+        entries, _total = detect_orphaned_files(root, graph, [".ts", ".vue"])
+
+        assert entries == []
+
+    def test_composable_called_without_an_import_is_not_orphaned(self, set_project_root):
+        root = _nuxt_root(set_project_root)
+        composable = _write(
+            root / "app/composables/useUser.ts",
+            body="export function useUser() { return null }",
+        )
+        _write(
+            root / "app/pages/index.vue",
+            body="<script setup>const user = useUser()</script>",
+        )
+
+        graph = {str(composable): _graph_entry()}
+        entries, _total = detect_orphaned_files(root, graph, [".ts", ".vue"])
+
+        assert entries == []
+
+    def test_unreferenced_composable_is_still_orphaned(self, set_project_root):
+        root = _nuxt_root(set_project_root)
+        composable = _write(
+            root / "app/composables/useForgotten.ts",
+            body="export function useForgotten() { return null }",
+        )
+
+        graph = {str(composable): _graph_entry()}
+        entries, _total = detect_orphaned_files(root, graph, [".ts", ".vue"])
+
+        assert [e["file"] for e in entries] == [str(composable)]
+
+    def test_non_nuxt_project_keeps_reporting_those_paths(self, set_project_root):
+        root = set_project_root
+        route = _write(root / "server/api/puzzle/today.get.ts")
+
+        graph = {str(route): _graph_entry()}
+        entries, _total = detect_orphaned_files(root, graph, [".ts"])
+
+        assert [e["file"] for e in entries] == [str(route)]
+
+    def test_detect_frameworks_false_disables_nuxt_rules(self, set_project_root):
+        root = _nuxt_root(set_project_root)
+        page = _write(root / "app/pages/index.vue")
+
+        graph = {str(page): _graph_entry()}
+        entries, _total = detect_orphaned_files(
+            root,
+            graph,
+            [".vue"],
+            options=OrphanedDetectionOptions(detect_frameworks=False),
+        )
+
+        assert [e["file"] for e in entries] == [str(page)]


### PR DESCRIPTION
## Problem

The `orphaned` detector has full support for Next.js App Router conventions (`_NEXTJS_APP_DIR_CONVENTIONS`, `_detect_nextjs_project`, `_is_nextjs_convention_entry`) but nothing equivalent for Nuxt. On a Nuxt project, almost every finding it produces is a false positive, for two separate reasons.

First, Nuxt and Nitro register entire directory trees by convention. Nothing imports `server/api/**`, `server/middleware/**`, `server/plugins/**`, `server/tasks/**`, `pages/**`, `layouts/**`, `middleware/**` or `plugins/**`, because the framework picks them up from the filesystem. Every one of those files has zero importers by design.

Second, Nuxt auto-imports `components/`, `composables/`, `utils/` and `shared/`. Consumers write `<GameOutcomeDrawer />` in a template, or call `useUser()` as a bare identifier, with no `import` statement anywhere. Those references are invisible to an import graph, so the components and composables that are used most heavily are exactly the ones reported as dead.

I measured this against a real Nuxt 4 codebase (roughly 1,700 files, Nuxt 4 with `app/` as srcDir plus a Nitro `server/` tree). Running `detect orphaned` and filtering to that project's own scan exclusions and the TypeScript entry patterns, the detector reported 429 orphans. Broken down by directory:

| Surface | Findings before |
| --- | --- |
| `server/api/` | 178 |
| `app/components/` | 103 |
| `app/composables/` | 29 |
| `shared/` | 13 |
| `server/plugins/` | 11 |
| `app/{layouts,middleware,plugins}/` | 10 |
| `app/utils/` | 8 |
| `server/middleware/` | 4 |
| `server/tasks/` | 2 |
| `server/routes/` | 1 |
| Everything else | 70 |

All 359 findings on Nuxt-owned surfaces were false positives. I checked the 103 component findings by hand: every one is referenced as a PascalCase tag in some `.vue` template. Nothing in that project was actually dead code.

## Fix

The detector now recognises a Nuxt project the way it recognises a Next.js one: a `nuxt.config.{ts,js,mjs,cjs,mts}` at the scan root, or a `nuxt` dependency in `package.json`. Everything below is gated on that detection, so Next.js projects and the existing `app/` handling are untouched, and `detect_frameworks=False` still disables the whole thing.

Convention entry points are exempted by location, mirroring `_is_nextjs_convention_entry`. That covers the Nitro trees (`server/api`, `server/routes`, `server/middleware`, `server/plugins`, `server/tasks`), the app trees (`pages`, `layouts`, `middleware`, `plugins`, `modules`), and the root config and shell files (`nuxt.config`, `app.config`, `capacitor.config`, `app`, `error`). Nuxt 3 keeps these at the project root and Nuxt 4 puts them under `app/`, so an optional leading `app/` or `src/` srcDir segment is stripped before matching. `server/lib/**` and similar ordinary module directories keep their orphan verdict.

Auto-import surfaces are handled differently, because blanket-exempting `components/` would hide genuinely dead components and cost the detector most of its value on a Nuxt codebase. Instead the file's registered name is computed and then looked up in a project-wide usage index:

- Component names follow Nuxt's own derivation, which joins the directory path to the filename and drops the directory segments the filename already repeats. `app/components/game/GameOutcomeDrawer.vue` registers as `GameOutcomeDrawer`; `app/components/account/ThemeSwitcher.vue` registers as `AccountThemeSwitcher`. `.client`, `.server` and `.global` suffixes are stripped, and an `index` file takes its directory's name. The undeduplicated join and the bare filename are accepted too, since `components.dirs` with `pathPrefix: false` registers under the bare stem and so does a consumer that imports the file by path.
- Composables, utils and `shared/` modules resolve through the identifiers they export, parsed from `export` declarations and `export { … }` lists, plus the filename stem.
- The usage index scans every `.vue`, `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs` and `.mts` file under the scan root for identifiers and for component tags. Kebab-case tags are normalised to PascalCase, so `<game-outcome-drawer />` and `<GameOutcomeDrawer />` both resolve to the one registered name. The index records which file each name was seen in, so a module's own mention of itself does not count as a reference and an unused composable is still reported.

The index is built lazily, only when the first auto-import candidate is reached, so nothing changes for projects that are not Nuxt. On the 1,700-file codebase above the whole run takes about five seconds, unchanged from before.

Convention matching is anchored on the scan root rather than on `rel()`, which resolves against the project root and yields a `../..` prefix when the tool is invoked from outside the project being scanned.

After the fix, the same run on the same codebase reports 67 orphans instead of 429. All 359 Nuxt-surface false positives are gone, and the 67 that remain are outside Nuxt's conventions: CLI scripts under `scripts/` invoked through npm scripts, tooling configs, a worker bundled by a build step, and a directory the project imports through a `~/` alias the graph does not resolve. None of them is a Nuxt or Nitro convention file, and none of them is an auto-imported component or composable.

Implementation lives in a new `desloppify/engine/detectors/_orphaned/nuxt.py`, following the `_flat_dirs` precedent of keeping the public detector module small, and `orphaned.py` wires it in beside the Next.js checks. Tests are in `desloppify/tests/detectors/test_orphaned_nuxt.py`: 43 cases covering project detection, convention paths, Nuxt's component-name derivation, export parsing, the usage index, and end-to-end orphan verdicts on a Nuxt-shaped tree, including the negative cases (an unreferenced composable is still reported, a non-Nuxt project still reports `server/api/**`, `detect_frameworks=False` disables all of it).

`python -m pytest desloppify/tests/ -q` passes: 5,695 passed, 152 skipped. Three failures in `desloppify/tests/lang/common/test_bash_unused_imports.py` are present on `main` before this change and are unrelated.

https://claude.ai/code/session_01D5dUe5YLshYGAFwwxf1JJx
