### PR TITLE
fix: stop unreachable-code and unused-import false positives in C#

### DIFF
--- a/desloppify/languages/_framework/treesitter/analysis/smells.py
+++ b/desloppify/languages/_framework/treesitter/analysis/smells.py
@@ -125,7 +125,19 @@ _TERMINATOR_TYPES = frozenset({
     "continue_statement", "continue",
     "throw_statement", "throw_expression",
     "raise_statement",
-    "yield_statement",  # Not strictly terminating, but often last in generators
+})
+
+# Nodes emitted when the grammar loses sync with the source. Statement order
+# around them is not trustworthy, so no unreachable-code claim can be made.
+_PARSE_ERROR_NODE_TYPES = frozenset({"ERROR", "MISSING"})
+
+# Declarations that are hoisted, so position relative to a terminator says
+# nothing about reachability. C# local functions are routinely declared at the
+# bottom of a method, after its `return`; JavaScript function declarations are
+# likewise hoisted to the top of their scope.
+_HOISTED_DECLARATION_NODE_TYPES = frozenset({
+    "local_function_statement",  # C#
+    "function_declaration",      # JavaScript
 })
 
 # Node types whose children form a statement sequence.
@@ -180,6 +192,17 @@ def _check_sequence_for_unreachable(block_node, filepath: str, entries: list[dic
 
     for child in children:
         if child.type in _IGNORABLE_NODE_TYPES:
+            continue
+
+        if child.type in _HOISTED_DECLARATION_NODE_TYPES:
+            # Reachable wherever it sits, and it does not make later statements
+            # reachable either, so keep any pending terminator in play.
+            continue
+
+        if child.type in _PARSE_ERROR_NODE_TYPES:
+            # The parse is unreliable from here on, so drop any pending
+            # terminator rather than blaming the next node for being after it.
+            saw_terminator = False
             continue
 
         if saw_terminator:

--- a/desloppify/languages/_framework/treesitter/analysis/unused_imports.py
+++ b/desloppify/languages/_framework/treesitter/analysis/unused_imports.py
@@ -21,6 +21,12 @@ logger = logging.getLogger(__name__)
 
 _ECMASCRIPT_IMPORT_NODE_TYPE = "import_statement"
 
+# Grammars whose imports name a *namespace* rather than a local binding.
+# `using System;` introduces no name that call sites write: they say
+# `Math.Max(...)`, never `System`. Occurrence checking therefore reports every
+# such directive as unused, so it must not run for these languages at all.
+_NAMESPACE_IMPORT_GRAMMARS = frozenset({"csharp"})
+
 # Identifier-ish nodes that represent a reference to a binding in JavaScript/TypeScript.
 # JSX tag names are typically represented as `identifier` in tree-sitter-javascript/tsx,
 # but we include `jsx_identifier` as well for compatibility with grammar variants.
@@ -57,6 +63,9 @@ def detect_unused_imports(
     Returns list of {file, line, name} entries.
     """
     if not spec.import_query:
+        return []
+
+    if spec.grammar in _NAMESPACE_IMPORT_GRAMMARS:
         return []
 
     try:

--- a/desloppify/tests/lang/common/test_treesitter_analysis_direct.py
+++ b/desloppify/tests/lang/common/test_treesitter_analysis_direct.py
@@ -176,6 +176,75 @@ def test_smells_helpers_detect_empty_handlers_and_unreachable_code() -> None:
     assert entries == [{"file": "src/app.py", "line": 5, "after": "return_statement"}]
 
 
+def test_yield_does_not_make_the_rest_of_a_generator_unreachable() -> None:
+    """`yield return x;` / `yield x` resumes, so the next statement is reachable."""
+    entries: list[dict] = []
+    block = FakeNode(
+        "block",
+        children=[
+            FakeNode("yield_statement"),
+            FakeNode("yield_statement", start_point=(1, 0)),
+            FakeNode("expression_statement", start_point=(2, 0)),
+        ],
+    )
+    smells_mod._check_sequence_for_unreachable(block, "src/gen.cs", entries)
+    assert entries == []
+
+
+def test_hoisted_declarations_after_return_are_not_unreachable() -> None:
+    """C# local functions are routinely declared below a method's `return`."""
+    entries: list[dict] = []
+    block = FakeNode(
+        "block",
+        children=[
+            FakeNode("return_statement"),
+            FakeNode("local_function_statement", start_point=(2, 0)),
+            FakeNode("local_function_statement", start_point=(8, 0)),
+        ],
+    )
+    smells_mod._check_sequence_for_unreachable(block, "src/Contracts.cs", entries)
+    assert entries == []
+
+
+def test_statement_after_hoisted_declaration_is_still_unreachable() -> None:
+    """A hoisted declaration must not launder a real unreachable statement."""
+    entries: list[dict] = []
+    block = FakeNode(
+        "block",
+        children=[
+            FakeNode("return_statement"),
+            FakeNode("local_function_statement", start_point=(2, 0)),
+            FakeNode("expression_statement", start_point=(9, 0)),
+        ],
+    )
+    smells_mod._check_sequence_for_unreachable(block, "src/Contracts.cs", entries)
+    assert entries == [{"file": "src/Contracts.cs", "line": 10, "after": "return_statement"}]
+
+
+def test_parse_errors_do_not_produce_unreachable_findings() -> None:
+    """A grammar that loses sync must not blame the next node for being 'after' a return."""
+    entries: list[dict] = []
+    block = FakeNode(
+        "block",
+        children=[
+            FakeNode("return_statement"),
+            FakeNode("ERROR", start_point=(1, 0)),
+            FakeNode("local_function_statement", start_point=(2, 0)),
+        ],
+    )
+    smells_mod._check_sequence_for_unreachable(block, "src/unsafe.cs", entries)
+    assert entries == []
+
+
+def test_namespace_import_grammars_report_no_unused_imports() -> None:
+    """`using System;` names a namespace, so occurrence checking cannot judge it."""
+    spec = SimpleNamespace(
+        grammar="csharp",
+        import_query="(using_directive (identifier) @path) @import",
+    )
+    assert unused_imports_mod.detect_unused_imports(["src/Policy.cs"], spec) == []
+
+
 def test_unused_import_helpers_and_detection(monkeypatch) -> None:
     as_alias = FakeNode(
         "import_statement",


### PR DESCRIPTION
## Problem

Scanning a 199k-LOC / 156-file C# repo (WinUI 3, .NET 8) produced **13 `unreachable_code` findings and 31 `unused` import findings — 100% of them false positives.** I verified every one against the real tree-sitter AST before touching anything. Four distinct causes.

### 1. `yield_statement` was treated as a control-flow terminator

```python
_TERMINATOR_TYPES = frozenset({
    ...
    "yield_statement",  # Not strictly terminating, but often last in generators
})
```

The comment concedes the point. `yield return x;` resumes, so every statement after one in the same block gets reported:

```
$ desloppify --lang csharp scan --path .
smells::Sussudio/Services/Runtime/FfmpegRuntimeLocator.cs::unreachable_code::118
smells::tools/Common/PresentMon/PresentMonProbe.cs::unreachable_code::270
smells::tools/Common/PresentMon/PresentMonProbe.cs::unreachable_code::271
```

`FfmpegRuntimeLocator.cs:110-135` is a plain `IEnumerable<string>` iterator:

```csharp
private static IEnumerable<string> EnumerateCandidateDirectories(string? preferredBaseDirectory)
{
    ...
    yield return Path.Combine(assemblyDir, "ffmpeg");
    yield return assemblyDir;      // <- reported as unreachable
```

### 2. C# local functions declared after a method's `return`

This is a standard C# idiom — helpers at the bottom, below the return:

```csharp
        return Task.CompletedTask;

        static object[] GetHandlerEntries(Type dispatcherType, string fieldName)   // <- reported
        {
```

A `local_function_statement` is a declaration, not an executed statement, so its position relative to a terminator says nothing about reachability. JavaScript `function_declaration` is hoisted for the same reason. 7 findings.

### 3. A parse failure reported as unreachable code

`tree-sitter-c-sharp` loses sync on `unsafe` pointer code. In `WasapiAudioCapture.cs`:

```csharp
long value = format.ContainerBitsPerSample switch
{
    16 => *(short*)samplePtr,
    ...
};
value >>= format.PcmPaddingBits;
return (float)(value * format.PcmInverseScale);
}                                                  // <- reported, line 907
```

Dumping the block's children shows why:

```
('return_statement', 906), ('ERROR', 907), ('local_function_statement', 909),
('local_function_statement', 917), ... ('}', 1128)
```

The grammar emitted an `ERROR` at the closing brace and reparsed the next 14 methods as `local_function_statement` siblings of the same block. The walker then blamed the `ERROR` node for following a `return`. When the parse is unreliable, no reachability claim can be made.

### 4. Unused-import detection cannot work on namespace imports

`detect_unused_imports` asks whether the imported name appears in the file body. For C# that name is a *namespace*, and namespaces never appear at call sites:

```csharp
using System;                      // reported as unused
...
width = Math.Max(2, width);        // this is the usage
```

`Sussudio.csproj` has no `<ImplicitUsings>`, so that directive is load-bearing — removing it breaks the build. The C# import query is `(using_directive (identifier) @path)`, which only matches single-segment usings, so in practice the detector reported nothing but `using System;` and `using Xunit;` — 31 findings, every one required. (`using Xunit;` is needed for `[Fact]`/`Assert`, and `ImplicitUsings` never includes `Xunit`.)

## Fix

1. Removed `yield_statement` from `_TERMINATOR_TYPES`.
2. Added `_HOISTED_DECLARATION_NODE_TYPES` (`local_function_statement`, `function_declaration`) — skipped **without** clearing a pending terminator, so a genuinely unreachable statement after one is still reported.
3. Added `_PARSE_ERROR_NODE_TYPES` (`ERROR`, `MISSING`) — these drop the pending terminator rather than being reported.
4. Added `_NAMESPACE_IMPORT_GRAMMARS` (`csharp`) — `detect_unused_imports` returns early. Nothing of value is lost: the existing query never matched `using static` or alias directives, which are the only C# usings that introduce a checkable name.

## Verification

Re-running the patched detector over the eight affected files: **13 findings → 0.**

Five new tests, including one asserting the hoisted-declaration skip does not launder a real unreachable statement.

Full suite on this machine: `34 failed, 5781 passed` with the change, against a `34 failed, 5776 passed` baseline on the same tree with the change stashed — no new failures, +5 tests. (The 34 pre-existing failures look like Windows path-separator assertions, e.g. `_c0\src\ui/index.js`, and are unrelated.)

## Not fixed here

Two other false-positive classes in the same scan trace back to `expand_namespace_matches` treating C# namespace co-membership as a directed import edge. That behaviour is deliberate and has a test asserting parent/child expansion, so it needs a design decision rather than a patch — filing it as an issue with the repro instead of changing it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
