### PR TITLE
Fix catastrophic backtracking in C++ review regex

### DIFF
--- a/desloppify/languages/cxx/review.py
+++ b/desloppify/languages/cxx/review.py
@@ -37,13 +37,23 @@ _PUBLIC_SECTION_RE = re.compile(
 )
 _FUNCTION_RE = re.compile(
     r"(?m)^\s*(?:inline\s+|static\s+|virtual\s+|constexpr\s+|friend\s+|extern\s+)*"
-    r"(?:[A-Za-z_~]\w*(?:::[A-Za-z_~]\w*)*(?:<[^;{}()]+>)?[\s*&:]+)+"
+    r"(?>(?:[A-Za-z_~]\w*(?:::[A-Za-z_~]\w*)*(?:<[^;{}()]+>)?[\s*&:]+)+)"
     r"([A-Za-z_~]\w*)\s*\([^;{}]*\)\s*(?:const\s*)?(?:;|\{)"
 )
 _CONTROL_KEYWORDS = {"if", "for", "while", "switch", "catch", "return"}
 
 
-_HEADER_LIKE_EXTENSIONS = (".h", ".hh", ".hpp", ".hxx", ".ipp", ".inl", ".tpp", ".txx", ".tcc")
+_HEADER_LIKE_EXTENSIONS = (
+    ".h",
+    ".hh",
+    ".hpp",
+    ".hxx",
+    ".ipp",
+    ".inl",
+    ".tpp",
+    ".txx",
+    ".tcc",
+)
 
 
 def _public_function_names(content: str) -> list[str]:

--- a/desloppify/languages/cxx/tests/test_review.py
+++ b/desloppify/languages/cxx/tests/test_review.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import time
 
 import desloppify.languages.cxx.review as cxx_review_mod
 
@@ -25,6 +26,7 @@ int BuildWidget();
     assert surface["public_types"] == ["Widget"]
     assert "BuildWidget" in surface["public_functions"]
     assert "Run" in surface["public_functions"]
+
 
 def test_api_surface_ignores_cpp_implementation_symbols():
     header = """
@@ -53,3 +55,14 @@ static int helper() { return 1; }
 
     assert surface["public_types"] == ["Widget"]
     assert surface["public_functions"] == ["BuildWidget", "Run"]
+
+
+def test_function_detection_bounds_qualified_name_backtracking():
+    content = "::".join(["Type"] * 21) + " value = source;"
+
+    started = time.perf_counter()
+    patterns = cxx_review_mod.module_patterns(content)
+    elapsed = time.perf_counter() - started
+
+    assert patterns == []
+    assert elapsed < 0.25


### PR DESCRIPTION
## Summary
- make the repeated C++ return-type prefix atomic so qualified-name non-matches cannot trigger catastrophic regex backtracking
- add a regression test for the pathological qualified-name assignment shape

## Reproduction
For a synthetic non-match shaped as repeated qualified names followed by an assignment, the prior regex grew from 0.04 s at 16 segments to 2.9 s at 22 segments. Five real C++ files in a 447-file project failed to finish within a two-second per-file probe.

## Validation
- `python -m pytest desloppify/languages/cxx/tests/test_review.py -q`: 3 passed
- Ruff check and format check pass for both changed files
- patched parser processed all 447 project C++ files in 1.203 s, with no file above 0.05 s
- the previously stalled project `review --prepare --dimensions design_coherence` completed and generated its packet

The broader `desloppify/tests` run completed locally with 52 failures outside the modified C++ language module; the focused modified-module suite is clean.