### PR TITLE
Fix Codex batch config quoting on Windows

### DIFF
--- a/desloppify/app/commands/runner/codex_batch.py
+++ b/desloppify/app/commands/runner/codex_batch.py
@@ -16,7 +16,9 @@ from desloppify.app.commands.review.runner_process_impl.attempts import (
     resolve_retry_config,
     run_batch_attempt,
 )
-from desloppify.app.commands.review.runner_process_impl.io import extract_payload_from_log
+from desloppify.app.commands.review.runner_process_impl.io import (
+    extract_payload_from_log,
+)
 from desloppify.app.commands.review.runner_process_impl.types import (
     CodexBatchRunnerDeps,
     FollowupScanDeps,
@@ -100,9 +102,9 @@ def codex_batch_command(*, prompt: str, repo_root: Path, output_file: Path) -> l
         "-s",
         sandbox,
         "-c",
-        'approval_policy="never"',
+        "approval_policy=never",
         "-c",
-        f'model_reasoning_effort="{effort}"',
+        f"model_reasoning_effort={effort}",
         "-o",
         str(output_file),
         "-" if _prompt_via_stdin(prompt) else prompt,

--- a/desloppify/tests/commands/test_runner_modules_direct.py
+++ b/desloppify/tests/commands/test_runner_modules_direct.py
@@ -59,6 +59,9 @@ def test_codex_batch_command_on_windows_collapses_cmd_c(monkeypatch, tmp_path: P
     assert "exec" in inner
     assert "--ephemeral" in inner
     assert "review prompt" not in inner
+    assert "approval_policy=never" in inner
+    assert "model_reasoning_effort=low" in inner
+    assert '\\"never\\"' not in inner
     assert inner.endswith(" -")
 
 
@@ -172,10 +175,11 @@ def test_codex_batch_command_uses_sanitized_reasoning_effort(monkeypatch, tmp_pa
 
     # On Windows with .cmd wrappers, prefix may be ["cmd", "/c", "...codex.cmd"]
     assert any(c.endswith("codex") or "codex" in c for c in command[:3])
-    assert "exec" in command
-    assert "--ephemeral" in command
-    assert f'model_reasoning_effort="high"' in command
-    assert str(tmp_path) in command
+    command_text = " ".join(command)
+    assert "exec" in command_text
+    assert "--ephemeral" in command_text
+    assert "model_reasoning_effort=high" in command_text
+    assert str(tmp_path) in command_text
 
     monkeypatch.setenv("DESLOPPIFY_CODEX_REASONING_EFFORT", "invalid")
     command = codex_batch_mod.codex_batch_command(
@@ -183,7 +187,7 @@ def test_codex_batch_command_uses_sanitized_reasoning_effort(monkeypatch, tmp_pa
         repo_root=tmp_path,
         output_file=tmp_path / "out.json",
     )
-    assert f'model_reasoning_effort="low"' in command
+    assert "model_reasoning_effort=low" in " ".join(command)
 
 
 def test_codex_batch_command_uses_sandbox_env_override(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- pass Codex configuration overrides without embedded TOML quotes
- verify the collapsed Windows cmd command contains parseable overrides and no backslash-escaped quote sequence
- make the existing reasoning-effort test work with the collapsed Windows command shape

## Problem
On Windows, subprocess.list2cmdline escaped the embedded quote characters before invoking an npm codex.cmd shim. cmd.exe passed those backslashes literally, and every Desloppify review batch failed immediately with an invalid approval_policy value.

## Validation
- the exact prior command failed with an unknown approval-policy variant containing a backslash and quote
- both unquoted override values are accepted by codex-cli 0.153.0 through cmd.exe
- `python -m pytest desloppify/tests/commands/test_runner_modules_direct.py -q`: 12 passed
- Ruff check passes for both changed files