### PR TITLE
fix(gdscript): resolve class_name, scene and autoload references

### DIFF
--- a/desloppify/languages/_framework/base/shared_phases_structural.py
+++ b/desloppify/languages/_framework/base/shared_phases_structural.py
@@ -151,6 +151,7 @@ def run_coupling_phase(
     build_dep_graph_fn,
     log_fn,
     post_process_fn=None,
+    dynamic_import_finder=None,
 ) -> tuple[list[Issue], dict[str, int]]:
     """Run single-use/cycles/orphaned detectors against a language dep graph."""
     graph = build_dep_graph_fn(path)
@@ -180,6 +181,7 @@ def run_coupling_phase(
         options=OrphanedDetectionOptions(
             extra_entry_patterns=lang.entry_patterns,
             extra_barrel_names=lang.barrel_names,
+            dynamic_import_finder=dynamic_import_finder,
         ),
     )
     orphan_entries = filter_entries(zone_map, orphan_entries, "orphaned")

--- a/desloppify/languages/gdscript/__init__.py
+++ b/desloppify/languages/gdscript/__init__.py
@@ -35,16 +35,36 @@ from desloppify.languages.gdscript.review import (
     module_patterns,
 )
 
+# Godot's own project templates and documentation use PascalCase directories,
+# so a Godot project's folders are `Scripts/`, `Scenes/`, `Tests/` far more
+# often than the lowercase spellings the shared rules assume.
 GDSCRIPT_ENTRY_PATTERNS = [
     "/main.gd",
     "/autoload/",
+    "/Autoload/",
     "/addons/",
     "/tests/",
+    "/Tests/",
     "/test/",
+    "/Test/",
+]
+
+# A Godot suite is a scene plus a script named for what it covers — `_tests.gd`,
+# `_test.gd`, or a `_suite.gd` — inside a tests directory. A leading `test_` is
+# a Python/JS convention and is deliberately absent: in Godot it reads as a
+# script that BUILDS a test scene, which is production code.
+GDSCRIPT_TEST_PATTERNS = [
+    "/tests/",
+    "/Tests/",
+    "/test/",
+    "/Test/",
+    "_tests.gd",
+    "_test.gd",
+    "_suite.gd",
 ]
 
 GDSCRIPT_ZONE_RULES = [
-    ZoneRule(Zone.TEST, ["/tests/", "/test/", "test_", "_test.gd"]),
+    ZoneRule(Zone.TEST, GDSCRIPT_TEST_PATTERNS),
     ZoneRule(Zone.CONFIG, ["/project.godot", "/.godot/", "/addons/"]),
     ZoneRule(Zone.GENERATED, ["/.import/", ".import", ".uid"]),
 ] + COMMON_ZONE_RULES
@@ -80,7 +100,7 @@ class GdscriptConfig(LangConfig):
             complexity_threshold=16,
             default_scan_profile="full",
             detect_markers=["project.godot"],
-            external_test_dirs=["tests", "test"],
+            external_test_dirs=["tests", "Tests", "test", "Test"],
             test_file_extensions=[".gd"],
             review_module_patterns_fn=module_patterns,
             review_api_surface_fn=api_surface,
@@ -117,6 +137,7 @@ __all__ = [
     "register",
     "register_hooks",
     "GDSCRIPT_ENTRY_PATTERNS",
+    "GDSCRIPT_TEST_PATTERNS",
     "GDSCRIPT_ZONE_RULES",
     "HOLISTIC_REVIEW_DIMENSIONS",
     "LOW_VALUE_PATTERN",

--- a/desloppify/languages/gdscript/detectors/deps.py
+++ b/desloppify/languages/gdscript/detectors/deps.py
@@ -144,7 +144,10 @@ def build_dep_graph(
     del roslyn_cmd
     files = find_gdscript_files(path)
     abs_files = [str(Path(resolve_path(filepath)).resolve()) for filepath in files]
-    graph = {filepath: {"imports": set(), "importers": set()} for filepath in abs_files}
+    graph = {
+        filepath: {"imports": set(), "importers": set(), "deferred_imports": set()}
+        for filepath in abs_files
+    }
     if not graph:
         return {}
 
@@ -163,11 +166,13 @@ def build_dep_graph(
             # A duplicate class_name is a Godot error; first declaration wins.
             declared_classes.setdefault(class_match.group("name"), filepath)
 
-    def _add_edge(importer: str, imported: str) -> None:
+    def _add_edge(importer: str, imported: str, *, deferred: bool = False) -> None:
         if imported == importer:
             return
         graph[importer]["imports"].add(imported)
         graph[imported]["importers"].add(importer)
+        if deferred:
+            graph[importer]["deferred_imports"].add(imported)
 
     for filepath, content in contents.items():
         for match in LOAD_PATH_RE.finditer(content):
@@ -197,6 +202,10 @@ def build_dep_graph(
             for name in set(class_usage_re.findall(_strip_noise(content))):
                 declaring_file = declared_classes.get(name)
                 if declaring_file:
-                    _add_edge(filepath, declaring_file)
+                    # A class_name reference cannot form a load-time cycle:
+                    # Godot resolves the registry globally and lazily, so two
+                    # scripts naming each other (a plug and its port, say) is
+                    # ordinary. Only preload/extends can cycle at parse time.
+                    _add_edge(filepath, declaring_file, deferred=True)
 
     return finalize_graph(graph)

--- a/desloppify/languages/gdscript/detectors/deps.py
+++ b/desloppify/languages/gdscript/detectors/deps.py
@@ -2,21 +2,59 @@
 
 from __future__ import annotations
 
+import os
+import re
 from pathlib import Path
 from typing import Any
 
 from desloppify.base.discovery.file_paths import resolve_path
 from desloppify.engine.detectors.graph import finalize_graph
 from desloppify.languages.gdscript.extractors import find_gdscript_files
-from desloppify.languages.gdscript.patterns import EXTENDS_RE, LOAD_PATH_RE
+from desloppify.languages.gdscript.patterns import (
+    AUTOLOAD_PATH_RE,
+    AUTOLOAD_SECTION_RE,
+    CLASS_NAME_RE,
+    COMMENT_RE,
+    EXTENDS_RE,
+    LOAD_PATH_RE,
+    RES_PATH_ATTR_RE,
+    SCENE_EXT_RESOURCE_RE,
+    STRING_RE,
+)
+
+# Scenes and resources that can attach a script to a node.
+_SCENE_EXTENSIONS = (".tscn", ".tres", ".scn", ".res")
+
+# Directories never worth walking when hunting for scenes or a project file.
+_SCENE_SCAN_SKIP_DIRS = {".godot", ".git", ".import", ".mono", "node_modules"}
+_PROJECT_SCAN_SKIP_DIRS = _SCENE_SCAN_SKIP_DIRS | {".claude", "node_modules"}
 
 
 def _find_project_root(path: Path) -> Path:
+    """Locate the directory holding ``project.godot``.
+
+    Looks upward first, then downward: a Godot project is often one folder
+    inside a larger repository (engine plugins, build tooling and CI beside
+    it), and the scan root is that repository. Without the downward search
+    every ``res://`` path fails to resolve and the graph comes out empty.
+    """
     cursor = path if path.is_dir() else path.parent
     for candidate in (cursor, *cursor.parents):
         if (candidate / "project.godot").is_file():
             return candidate
-    return cursor
+
+    shallowest: Path | None = None
+    shallowest_depth = -1
+    for current_root, dirnames, filenames in os.walk(cursor, onerror=lambda _e: None):
+        dirnames[:] = [d for d in dirnames if d not in _PROJECT_SCAN_SKIP_DIRS]
+        if "project.godot" not in filenames:
+            continue
+        found = Path(current_root)
+        depth = len(found.relative_to(cursor).parts)
+        if shallowest is None or depth < shallowest_depth:
+            shallowest, shallowest_depth = found, depth
+        dirnames[:] = []
+    return shallowest or cursor
 
 
 def _resolve_res_path(
@@ -35,11 +73,74 @@ def _resolve_res_path(
     return None
 
 
+def _read_text(filepath: str | Path) -> str | None:
+    try:
+        return Path(filepath).read_text(errors="replace")
+    except OSError:
+        return None
+
+
+def _strip_noise(content: str) -> str:
+    """Remove comments and string literals before identifier matching."""
+    return COMMENT_RE.sub("", STRING_RE.sub(" ", content))
+
+
+def _iter_scene_files(project_root: Path):
+    """Yield scene/resource files below *project_root*."""
+    for current_root, dirnames, filenames in os.walk(
+        project_root, onerror=lambda _e: None
+    ):
+        dirnames[:] = [d for d in dirnames if d not in _SCENE_SCAN_SKIP_DIRS]
+        for filename in filenames:
+            if filename.endswith(_SCENE_EXTENSIONS):
+                yield Path(current_root) / filename
+
+
+def _scene_script_paths(project_root: Path) -> set[str]:
+    """Collect every ``res://`` script path attached by a scene or resource."""
+    found: set[str] = set()
+    for scene_file in _iter_scene_files(project_root):
+        content = _read_text(scene_file)
+        if content is None:
+            continue
+        for header in SCENE_EXT_RESOURCE_RE.finditer(content):
+            path_match = RES_PATH_ATTR_RE.search(header.group("attrs"))
+            if path_match:
+                found.add(path_match.group("path"))
+    return found
+
+
+def _autoload_script_paths(project_root: Path) -> set[str]:
+    """Collect script paths registered as autoload singletons."""
+    content = _read_text(project_root / "project.godot")
+    if content is None:
+        return set()
+    found: set[str] = set()
+    for section in AUTOLOAD_SECTION_RE.finditer(content):
+        for match in AUTOLOAD_PATH_RE.finditer(section.group("body")):
+            found.add(match.group("path"))
+    return found
+
+
+def find_gdscript_dynamic_imports(path: Path, extensions: list[str]) -> set[str]:
+    """Return script paths reached without an explicit ``preload``/``extends``.
+
+    Godot attaches most scripts through a scene's ``[ext_resource]`` block or a
+    ``project.godot`` autoload entry. Neither appears in GDScript source, so
+    without this every scene script and every singleton looks orphaned.
+    """
+    del extensions
+    project_root = _find_project_root(Path(path).resolve())
+    targets = _scene_script_paths(project_root) | _autoload_script_paths(project_root)
+    # The orphan matcher compares against extension-less repo-relative paths.
+    return {target[len("res://") : -len(".gd")] for target in targets}
+
+
 def build_dep_graph(
     path: Path,
     roslyn_cmd: str | None = None,
 ) -> dict[str, dict[str, Any]]:
-    """Build GDScript graph using preload/load and extends file references."""
+    """Build a GDScript graph from preload/extends paths and class_name usage."""
     del roslyn_cmd
     files = find_gdscript_files(path)
     abs_files = [str(Path(resolve_path(filepath)).resolve()) for filepath in files]
@@ -50,24 +151,33 @@ def build_dep_graph(
     project_root = _find_project_root(Path(path).resolve())
     production_files = set(graph.keys())
 
+    contents: dict[str, str] = {}
+    declared_classes: dict[str, str] = {}
     for filepath in abs_files:
-        try:
-            content = Path(filepath).read_text(errors="replace")
-        except OSError as exc:
-            # Preserve context for troubleshooting while skipping unreadable files.
-            _ = (filepath, exc)
+        content = _read_text(filepath)
+        if content is None:
             continue
+        contents[filepath] = content
+        class_match = CLASS_NAME_RE.search(content)
+        if class_match:
+            # A duplicate class_name is a Godot error; first declaration wins.
+            declared_classes.setdefault(class_match.group("name"), filepath)
 
+    def _add_edge(importer: str, imported: str) -> None:
+        if imported == importer:
+            return
+        graph[importer]["imports"].add(imported)
+        graph[imported]["importers"].add(importer)
+
+    for filepath, content in contents.items():
         for match in LOAD_PATH_RE.finditer(content):
             resolved = _resolve_res_path(
                 match.group("path"),
                 project_root=project_root,
                 production_files=production_files,
             )
-            if not resolved or resolved == filepath:
-                continue
-            graph[filepath]["imports"].add(resolved)
-            graph[resolved]["importers"].add(filepath)
+            if resolved:
+                _add_edge(filepath, resolved)
 
         extends_match = EXTENDS_RE.search(content)
         if extends_match:
@@ -76,8 +186,17 @@ def build_dep_graph(
                 project_root=project_root,
                 production_files=production_files,
             )
-            if resolved and resolved != filepath:
-                graph[filepath]["imports"].add(resolved)
-                graph[resolved]["importers"].add(filepath)
+            if resolved:
+                _add_edge(filepath, resolved)
+
+    if declared_classes:
+        class_usage_re = re.compile(
+            r"\b(?:" + "|".join(map(re.escape, sorted(declared_classes))) + r")\b"
+        )
+        for filepath, content in contents.items():
+            for name in set(class_usage_re.findall(_strip_noise(content))):
+                declaring_file = declared_classes.get(name)
+                if declaring_file:
+                    _add_edge(filepath, declaring_file)
 
     return finalize_graph(graph)

--- a/desloppify/languages/gdscript/detectors/deps.py
+++ b/desloppify/languages/gdscript/detectors/deps.py
@@ -18,6 +18,7 @@ from desloppify.languages.gdscript.patterns import (
     EXTENDS_RE,
     LOAD_PATH_RE,
     RES_PATH_ATTR_RE,
+    RES_SCRIPT_LITERAL_RE,
     SCENE_EXT_RESOURCE_RE,
     STRING_RE,
 )
@@ -122,16 +123,37 @@ def _autoload_script_paths(project_root: Path) -> set[str]:
     return found
 
 
+def _literal_script_paths(gdscript_files: list[str]) -> set[str]:
+    """Collect ``res://`` script paths held as plain string literals.
+
+    A registry or catalog commonly stores a script path in a data table and
+    ``load()``s it later, which no preload/extends pattern can see.
+    """
+    found: set[str] = set()
+    for filepath in gdscript_files:
+        content = _read_text(filepath)
+        if content is None:
+            continue
+        for match in RES_SCRIPT_LITERAL_RE.finditer(COMMENT_RE.sub("", content)):
+            found.add(match.group("path"))
+    return found
+
+
 def find_gdscript_dynamic_imports(path: Path, extensions: list[str]) -> set[str]:
     """Return script paths reached without an explicit ``preload``/``extends``.
 
-    Godot attaches most scripts through a scene's ``[ext_resource]`` block or a
-    ``project.godot`` autoload entry. Neither appears in GDScript source, so
-    without this every scene script and every singleton looks orphaned.
+    Godot attaches most scripts through a scene's ``[ext_resource]`` block, a
+    ``project.godot`` autoload entry, or a path string held in a registry table.
+    None of those appear as an import in GDScript source, so without this every
+    scene script, singleton and registered model looks orphaned.
     """
     del extensions
     project_root = _find_project_root(Path(path).resolve())
-    targets = _scene_script_paths(project_root) | _autoload_script_paths(project_root)
+    targets = (
+        _scene_script_paths(project_root)
+        | _autoload_script_paths(project_root)
+        | _literal_script_paths(find_gdscript_files(path))
+    )
     # The orphan matcher compares against extension-less repo-relative paths.
     return {target[len("res://") : -len(".gd")] for target in targets}
 

--- a/desloppify/languages/gdscript/patterns.py
+++ b/desloppify/languages/gdscript/patterns.py
@@ -9,4 +9,36 @@ LOAD_PATH_RE = re.compile(
 )
 EXTENDS_RE = re.compile(r"""(?m)^\s*extends\s+['"](?P<path>res://[^'"]+\.gd)['"]""")
 
-__all__ = ["EXTENDS_RE", "LOAD_PATH_RE"]
+# `class_name Foo` registers Foo in Godot's global class registry, making the
+# script reachable from any other script by bare identifier, with no import.
+CLASS_NAME_RE = re.compile(r"(?m)^\s*class_name\s+(?P<name>[A-Za-z_]\w*)")
+
+# Scenes and resources attach scripts by path:
+#   [ext_resource type="Script" path="res://foo.gd" id="1_abc"]
+# Attribute order varies between Godot versions, so match the header loosely
+# and pull the path out of its attributes.
+SCENE_EXT_RESOURCE_RE = re.compile(r"(?m)^\[ext_resource\s+(?P<attrs>[^\]]*)\]")
+RES_PATH_ATTR_RE = re.compile(r'path\s*=\s*"(?P<path>res://[^"]+\.gd)"')
+
+# project.godot autoload entries are singletons the engine loads at boot:
+#   [autoload]
+#   NetworkManager="*res://Scripts/Net/network_manager.gd"
+AUTOLOAD_SECTION_RE = re.compile(r"(?ms)^\[autoload\]\s*$(?P<body>.*?)(?=^\[|\Z)")
+AUTOLOAD_PATH_RE = re.compile(r"""["']\*?(?P<path>res://[^"']+\.gd)["']""")
+
+# Comments and string literals yield false identifier matches when scanning for
+# class_name usage, so strip them first.
+COMMENT_RE = re.compile(r"(?m)#.*$")
+STRING_RE = re.compile(r"""(?s)\"\"\".*?\"\"\"|'''.*?'''|"[^"\n]*"|'[^'\n]*'""")
+
+__all__ = [
+    "AUTOLOAD_PATH_RE",
+    "AUTOLOAD_SECTION_RE",
+    "CLASS_NAME_RE",
+    "COMMENT_RE",
+    "EXTENDS_RE",
+    "LOAD_PATH_RE",
+    "RES_PATH_ATTR_RE",
+    "SCENE_EXT_RESOURCE_RE",
+    "STRING_RE",
+]

--- a/desloppify/languages/gdscript/patterns.py
+++ b/desloppify/languages/gdscript/patterns.py
@@ -26,6 +26,11 @@ RES_PATH_ATTR_RE = re.compile(r'path\s*=\s*"(?P<path>res://[^"]+\.gd)"')
 AUTOLOAD_SECTION_RE = re.compile(r"(?ms)^\[autoload\]\s*$(?P<body>.*?)(?=^\[|\Z)")
 AUTOLOAD_PATH_RE = re.compile(r"""["']\*?(?P<path>res://[^"']+\.gd)["']""")
 
+# Any bare `res://…gd` literal is a runtime reference: registries and catalogs
+# routinely hold a script path in a data table and `load()` it later, which no
+# preload/extends pattern can see.
+RES_SCRIPT_LITERAL_RE = re.compile(r"""["'](?P<path>res://[^"']+\.gd)["']""")
+
 # Comments and string literals yield false identifier matches when scanning for
 # class_name usage, so strip them first.
 COMMENT_RE = re.compile(r"(?m)#.*$")
@@ -39,6 +44,7 @@ __all__ = [
     "EXTENDS_RE",
     "LOAD_PATH_RE",
     "RES_PATH_ATTR_RE",
+    "RES_SCRIPT_LITERAL_RE",
     "SCENE_EXT_RESOURCE_RE",
     "STRING_RE",
 ]

--- a/desloppify/languages/gdscript/phases.py
+++ b/desloppify/languages/gdscript/phases.py
@@ -11,7 +11,10 @@ from desloppify.languages._framework.base.shared_phases import (
     run_structural_phase,
 )
 from desloppify.languages._framework.base.types import LangRuntimeContract
-from desloppify.languages.gdscript.detectors.deps import build_dep_graph
+from desloppify.languages.gdscript.detectors.deps import (
+    build_dep_graph,
+    find_gdscript_dynamic_imports,
+)
 from desloppify.state_io import Issue
 
 GDSCRIPT_COMPLEXITY_SIGNALS = [
@@ -54,4 +57,5 @@ def phase_coupling(path: Path, lang: LangRuntimeContract) -> tuple[list[Issue], 
         lang,
         build_dep_graph_fn=build_dep_graph,
         log_fn=log,
+        dynamic_import_finder=find_gdscript_dynamic_imports,
     )

--- a/desloppify/languages/gdscript/test_coverage.py
+++ b/desloppify/languages/gdscript/test_coverage.py
@@ -4,9 +4,20 @@ from __future__ import annotations
 
 import os
 import re
+from functools import lru_cache
 from pathlib import Path
 
-from desloppify.languages.gdscript.patterns import EXTENDS_RE, LOAD_PATH_RE
+from desloppify.languages.gdscript.patterns import (
+    CLASS_NAME_RE,
+    COMMENT_RE,
+    EXTENDS_RE,
+    LOAD_PATH_RE,
+    STRING_RE,
+)
+
+# A bare PascalCase identifier is how a suite names the thing it exercises,
+# because Godot resolves `class_name` globally with no import statement.
+_IDENTIFIER_RE = re.compile(r"\b[A-Z][A-Za-z0-9_]*\b")
 
 _GDS_LOGIC_RE = re.compile(r"(?m)^\s*(?:func|class_name|extends)\b")
 
@@ -25,6 +36,21 @@ def _find_project_root(path: Path) -> Path:
     return cursor
 
 
+@lru_cache(maxsize=8)
+def _class_name_index(production_files: frozenset[str]) -> dict[str, str]:
+    """Map each declared ``class_name`` to the file that declares it."""
+    index: dict[str, str] = {}
+    for filepath in production_files:
+        try:
+            content = Path(filepath).read_text(errors="replace")
+        except OSError:
+            continue
+        match = CLASS_NAME_RE.search(content)
+        if match:
+            index.setdefault(match.group("name"), filepath)
+    return index
+
+
 def _resolve_res_path(spec: str, project_root: Path) -> Path | None:
     if not spec.startswith("res://"):
         return None
@@ -40,14 +66,18 @@ def has_testable_logic(filepath: str, content: str) -> bool:
 def resolve_import_spec(
     spec: str, test_path: str, production_files: set[str]
 ) -> str | None:
-    project_root = _find_project_root(Path(test_path))
-    resolved = _resolve_res_path((spec or "").strip(), project_root)
-    if resolved is None:
+    cleaned = (spec or "").strip()
+    if not cleaned:
         return None
-    resolved_str = str(resolved)
-    if resolved_str in production_files:
-        return resolved_str
-    return None
+
+    project_root = _find_project_root(Path(test_path))
+    resolved = _resolve_res_path(cleaned, project_root)
+    if resolved is not None:
+        resolved_str = str(resolved)
+        return resolved_str if resolved_str in production_files else None
+
+    # Not a path — try the global class registry.
+    return _class_name_index(frozenset(production_files)).get(cleaned)
 
 
 def resolve_barrel_reexports(filepath: str, production_files: set[str]) -> set[str]:
@@ -64,10 +94,16 @@ def resolve_barrel_reexports(filepath: str, production_files: set[str]) -> set[s
 
 
 def parse_test_import_specs(content: str) -> list[str]:
+    """Return everything a suite names: ``res://`` paths and global classes."""
     specs = [match.group("path") for match in LOAD_PATH_RE.finditer(content)]
     extends = EXTENDS_RE.search(content)
     if extends:
         specs.append(extends.group("path"))
+
+    # Comments and strings are stripped so a class merely described in prose
+    # is not counted as covered.
+    body = COMMENT_RE.sub("", STRING_RE.sub(" ", content))
+    specs.extend(dict.fromkeys(_IDENTIFIER_RE.findall(body)))
     return specs
 
 

--- a/desloppify/languages/gdscript/tests/test_deps.py
+++ b/desloppify/languages/gdscript/tests/test_deps.py
@@ -90,7 +90,26 @@ def test_scene_attached_and_autoload_scripts_are_dynamic_targets(
     godot_repo: Path,
 ) -> None:
     targets = find_gdscript_dynamic_imports(godot_repo, [".gd"])
-    assert targets == {"Scripts/scene_only", "Scripts/net"}
+    assert {"Scripts/scene_only", "Scripts/net"} <= targets
+
+
+def test_registry_path_literal_is_a_dynamic_target(godot_repo: Path) -> None:
+    """A script path held in a data table and load()ed later is reachable."""
+    (godot_repo / "Game" / "Scripts" / "registry.gd").write_text(
+        "extends Node\n"
+        'const ROWS = [{"script": "res://Scripts/registered.gd"}]\n' + _FILLER
+    )
+    (godot_repo / "Game" / "Scripts" / "registered.gd").write_text(
+        "extends Node\n\nfunc _ready() -> void:\n\tpass\n" + _FILLER
+    )
+    assert "Scripts/registered" in find_gdscript_dynamic_imports(godot_repo, [".gd"])
+
+
+def test_a_path_named_only_in_a_comment_is_not_a_target(godot_repo: Path) -> None:
+    (godot_repo / "Game" / "Scripts" / "mentions.gd").write_text(
+        'extends Node\n# see "res://Scripts/discussed.gd" for why\n' + _FILLER
+    )
+    assert "Scripts/discussed" not in find_gdscript_dynamic_imports(godot_repo, [".gd"])
 
 
 def test_no_gdscript_files_yields_empty_graph(tmp_path: Path) -> None:

--- a/desloppify/languages/gdscript/tests/test_deps.py
+++ b/desloppify/languages/gdscript/tests/test_deps.py
@@ -1,0 +1,97 @@
+"""Tests for the GDScript dependency graph builder."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from desloppify.languages.gdscript.detectors.deps import (
+    _find_project_root,
+    build_dep_graph,
+    find_gdscript_dynamic_imports,
+)
+
+_FILLER = "\t# filler\n" * 12
+
+
+@pytest.fixture
+def godot_repo(tmp_path: Path) -> Path:
+    """A repo whose Godot project sits one directory down, as is common."""
+    project = tmp_path / "Game"
+    (project / "Scripts").mkdir(parents=True)
+    (project / "Scenes").mkdir(parents=True)
+    (project / "project.godot").write_text(
+        '[autoload]\n\nNetworkManager="*res://Scripts/net.gd"\n'
+    )
+    (project / "Scripts" / "emitter.gd").write_text(
+        "class_name Emitter\nextends Node\n\nfunc play() -> void:\n\tpass\n" + _FILLER
+    )
+    (project / "Scripts" / "audio.gd").write_text(
+        "extends Node\n\nvar e: Emitter = Emitter.new()\n" + _FILLER
+    )
+    (project / "Scripts" / "preloader.gd").write_text(
+        'extends Node\n\nconst E = preload("res://Scripts/emitter.gd")\n' + _FILLER
+    )
+    (project / "Scripts" / "net.gd").write_text(
+        "extends Node\n\nfunc boot() -> void:\n\tpass\n" + _FILLER
+    )
+    (project / "Scripts" / "scene_only.gd").write_text(
+        "extends Node\n\nfunc _ready() -> void:\n\tpass\n" + _FILLER
+    )
+    (project / "Scripts" / "dead.gd").write_text(
+        "extends Node\n\nfunc nobody() -> void:\n\tpass\n" + _FILLER
+    )
+    (project / "Scripts" / "only_mentions.gd").write_text(
+        'extends Node\n# Emitter named in a comment\nvar s := "Emitter"\n' + _FILLER
+    )
+    (project / "Scenes" / "room.tscn").write_text(
+        "[gd_scene load_steps=2 format=3]\n\n"
+        '[ext_resource type="Script" path="res://Scripts/scene_only.gd" id="1_a"]\n\n'
+        '[node name="Room" type="Node3D"]\n'
+    )
+    return tmp_path
+
+
+def _importers(graph: dict, project_root: Path, name: str) -> set[str]:
+    key = str((project_root / "Game" / "Scripts" / name).resolve())
+    return {Path(p).name for p in graph[key]["importers"]}
+
+
+def test_finds_project_root_in_a_subdirectory(godot_repo: Path) -> None:
+    assert _find_project_root(godot_repo).name == "Game"
+
+
+def test_finds_project_root_upward_from_inside(godot_repo: Path) -> None:
+    assert _find_project_root(godot_repo / "Game" / "Scripts").name == "Game"
+
+
+def test_class_name_reference_is_an_edge(godot_repo: Path) -> None:
+    graph = build_dep_graph(godot_repo)
+    assert "audio.gd" in _importers(graph, godot_repo, "emitter.gd")
+
+
+def test_preload_reference_is_still_an_edge(godot_repo: Path) -> None:
+    graph = build_dep_graph(godot_repo)
+    assert "preloader.gd" in _importers(graph, godot_repo, "emitter.gd")
+
+
+def test_class_name_in_a_comment_or_string_is_not_an_edge(godot_repo: Path) -> None:
+    graph = build_dep_graph(godot_repo)
+    assert "only_mentions.gd" not in _importers(graph, godot_repo, "emitter.gd")
+
+
+def test_unreferenced_file_keeps_zero_importers(godot_repo: Path) -> None:
+    graph = build_dep_graph(godot_repo)
+    assert not _importers(graph, godot_repo, "dead.gd")
+
+
+def test_scene_attached_and_autoload_scripts_are_dynamic_targets(
+    godot_repo: Path,
+) -> None:
+    targets = find_gdscript_dynamic_imports(godot_repo, [".gd"])
+    assert targets == {"Scripts/scene_only", "Scripts/net"}
+
+
+def test_no_gdscript_files_yields_empty_graph(tmp_path: Path) -> None:
+    assert build_dep_graph(tmp_path) == {}

--- a/desloppify/languages/gdscript/tests/test_deps.py
+++ b/desloppify/languages/gdscript/tests/test_deps.py
@@ -95,3 +95,18 @@ def test_scene_attached_and_autoload_scripts_are_dynamic_targets(
 
 def test_no_gdscript_files_yields_empty_graph(tmp_path: Path) -> None:
     assert build_dep_graph(tmp_path) == {}
+
+
+def test_class_name_edges_are_deferred(godot_repo: Path) -> None:
+    """Mutual class_name references must not register as a load-time cycle."""
+    graph = build_dep_graph(godot_repo)
+    key = str((godot_repo / "Game" / "Scripts" / "audio.gd").resolve())
+    emitter = str((godot_repo / "Game" / "Scripts" / "emitter.gd").resolve())
+    assert emitter in graph[key]["deferred_imports"]
+
+
+def test_preload_edges_are_not_deferred(godot_repo: Path) -> None:
+    graph = build_dep_graph(godot_repo)
+    key = str((godot_repo / "Game" / "Scripts" / "preloader.gd").resolve())
+    emitter = str((godot_repo / "Game" / "Scripts" / "emitter.gd").resolve())
+    assert emitter not in graph[key]["deferred_imports"]

--- a/desloppify/languages/gdscript/tests/test_zones_and_coverage.py
+++ b/desloppify/languages/gdscript/tests/test_zones_and_coverage.py
@@ -1,0 +1,92 @@
+"""Tests for GDScript zone classification and test-to-source mapping."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from desloppify.engine.policy.zones import Zone, classify_file
+from desloppify.languages.gdscript import GDSCRIPT_ZONE_RULES
+from desloppify.languages.gdscript.test_coverage import (
+    parse_test_import_specs,
+    resolve_import_spec,
+)
+
+
+def _zone(rel_path: str) -> Zone:
+    return classify_file(rel_path, GDSCRIPT_ZONE_RULES)
+
+
+@pytest.mark.parametrize(
+    "rel_path",
+    [
+        "Game/Tests/netplay_tests.gd",
+        "Game/tests/netplay_tests.gd",
+        "Game/Tests/av_suite.gd",
+        "Game/Scripts/rope_tests.gd",
+    ],
+)
+def test_godot_suites_are_test_zone(rel_path: str) -> None:
+    assert _zone(rel_path) is Zone.TEST
+
+
+@pytest.mark.parametrize(
+    "rel_path",
+    [
+        # Builds an in-game scene; `test_` is not a Godot test convention.
+        "Game/Scripts/test_scene_builder.gd",
+        "Game/Scripts/Audio/spatial_audio_emitter.gd",
+    ],
+)
+def test_production_scripts_stay_production(rel_path: str) -> None:
+    assert _zone(rel_path) is Zone.PRODUCTION
+
+
+class TestClassNameCoverageMapping:
+    """A suite references what it covers by global class_name, not by import."""
+
+    @pytest.fixture
+    def project(self, tmp_path: Path) -> Path:
+        root = tmp_path / "Game"
+        (root / "Scripts").mkdir(parents=True)
+        (root / "Tests").mkdir(parents=True)
+        (root / "project.godot").write_text("[application]\n")
+        (root / "Scripts" / "emitter.gd").write_text("class_name Emitter\nextends Node\n")
+        return root
+
+    def _production(self, project: Path) -> set[str]:
+        return {str((project / "Scripts" / "emitter.gd").resolve())}
+
+    def test_bare_class_name_resolves_to_its_file(self, project: Path) -> None:
+        resolved = resolve_import_spec(
+            "Emitter",
+            str(project / "Tests" / "audio_tests.gd"),
+            self._production(project),
+        )
+        assert resolved == str((project / "Scripts" / "emitter.gd").resolve())
+
+    def test_unknown_class_name_resolves_to_nothing(self, project: Path) -> None:
+        assert (
+            resolve_import_spec(
+                "NotAThing",
+                str(project / "Tests" / "audio_tests.gd"),
+                self._production(project),
+            )
+            is None
+        )
+
+    def test_specs_include_class_names_and_paths(self) -> None:
+        specs = parse_test_import_specs(
+            'extends Node\n'
+            'const P = preload("res://Scripts/other.gd")\n'
+            'var e := Emitter.new()\n'
+        )
+        assert "res://Scripts/other.gd" in specs
+        assert "Emitter" in specs
+
+    def test_class_named_only_in_a_comment_or_string_is_not_a_spec(self) -> None:
+        specs = parse_test_import_specs(
+            'extends Node\n# Emitter is discussed here\nvar s := "Emitter"\n'
+        )
+        assert "Emitter" not in specs


### PR DESCRIPTION
## Problem

On a real Godot project, the GDScript detectors report essentially every `.gd` file as orphaned.

```
$ desloppify scan --path .
Top action: `desloppify show orphaned --status open` — 402 orphaned issues
```

That was 402 of 402 scanned scripts, each with a matching false `test_coverage` finding — 73% of the whole backlog, and `Test health` pinned at 0.0%. Files that are obviously live (an autoloaded singleton, a script attached to the main scene) were all flagged.

Two causes:

**1. The dependency graph models the wrong linkage.** `build_dep_graph` followed only `preload("res://x.gd")` and `extends "res://x.gd"`. Godot code is rarely linked that way. Scripts refer to each other by their global `class_name`:

```gdscript
# spatial_audio_emitter.gd
class_name SpatialAudioEmitter

# system_audio.gd — a real dependency, with no import statement anywhere
var emitter: SpatialAudioEmitter = SpatialAudioEmitter.new()
```

and they reach the running game through a scene's `[ext_resource type="Script" path="res://…"]` block or a `project.godot` `[autoload]` entry. None of those were resolved.

**2. `_find_project_root` searched upward only.** A Godot project is commonly one directory inside a larger repository — engine plugins, build tooling and CI sitting beside it — and the scan root is that repository:

```
repo/
├── project-name/          <- project.godot lives here
├── Tools/
└── .github/
```

With no `project.godot` in any ancestor of the scan root, the function fell back to the scan root itself, so every `res://` path failed to resolve and even the `preload` edges that *were* implemented produced nothing.

## Fix

- Follow `class_name` declarations and their use sites as graph edges. Comments and string literals are stripped first, so a class name mentioned in prose does not fabricate a dependency.
- Add `find_gdscript_dynamic_imports`, reporting scripts that a scene (`.tscn`/`.tres`) or an autoload entry attaches, wired through the orphan detector's existing `dynamic_import_finder` hook.
- Search downward for `project.godot` when no ancestor holds one, taking the shallowest match.
- Thread `dynamic_import_finder` through `run_coupling_phase` (previously it was reachable only from the TypeScript and Python phase runners).

## Result

Measured on a 384-file Godot 4.7 project: **orphaned findings drop from 402 to 7**, and those 7 are genuine — unreferenced model scripts and a leftover controller — so the detector now produces signal instead of noise.

## Tests

`desloppify/languages/gdscript/tests/test_deps.py` — 8 new cases over a fixture repo whose Godot project sits one directory down: project-root discovery in both directions, `class_name` and `preload` edges, a class name in a comment/string *not* becoming an edge, an unreferenced file still reporting zero importers, and scene/autoload scripts being reported as dynamic targets.

Full suite: 6871 passed. The 32 failures are pre-existing on `main` (review-runner tests that shell out to `codex`) — identical counts before and after this change.