### PR TITLE
Fix C++ static test coverage mapping

### DIFF
--- a/desloppify/languages/cxx/test_coverage.py
+++ b/desloppify/languages/cxx/test_coverage.py
@@ -4,27 +4,72 @@ from __future__ import annotations
 
 import os
 import re
+from functools import cache
 from pathlib import Path
 
 from desloppify.base.text_utils import strip_c_style_comments
 
-ASSERT_PATTERNS = [re.compile(r"\bASSERT_[A-Z_]+\b"), re.compile(r"\bEXPECT_[A-Z_]+\b")]
+ASSERT_PATTERNS = [
+    re.compile(r"\bASSERT_[A-Z_]+\b"),
+    re.compile(r"\bEXPECT_[A-Z_]+\b"),
+    re.compile(r"\b(?:STATIC_)?(?:REQUIRE|CHECK)(?:_[A-Z_]+)?\s*\("),
+    re.compile(r"\b(?:SUCCEED|FAIL|FAIL_CHECK)\s*\("),
+]
 MOCK_PATTERNS = [re.compile(r"\bMOCK_METHOD\b"), re.compile(r"\bFakeIt\b")]
 SNAPSHOT_PATTERNS: list[re.Pattern[str]] = []
-TEST_FUNCTION_RE = re.compile(r"\bTEST(?:_F|_P)?\s*\(")
+TEST_FUNCTION_RE = re.compile(
+    r"\b(?:TEST(?:_F|_P)?|"
+    r"(?:TEMPLATE_(?:PRODUCT_)?|TEMPLATE_LIST_)?TEST_CASE(?:_METHOD|_SIG)?|"
+    r"SCENARIO(?:_METHOD)?)\s*\("
+)
 BARREL_BASENAMES: set[str] = set()
 _INCLUDE_RE = re.compile(r'(?m)^\s*#include\s*[<"]([^>"]+)[>"]')
 _SOURCE_EXTENSIONS = (".c", ".cc", ".cpp", ".cxx")
 _HEADER_EXTENSIONS = (".h", ".hh", ".hpp")
 _CMAKE_COMMENT_RE = re.compile(r"(?m)#.*$")
-_CMAKE_COMMAND_RE = re.compile(r"\b(?:add_executable|add_library|target_sources)\s*\(", re.IGNORECASE)
+_CMAKE_COMMAND_RE = re.compile(
+    r"\b(?:(?:qt6?_)?add_executable|(?:qt6?_)?add_library|target_sources)\s*\(",
+    re.IGNORECASE,
+)
 _CMAKE_SOURCE_SPEC_RE = re.compile(
     r'"([^"\n]+\.(?:cpp|cxx|cc|c|hpp|hh|h))"|([^\s()"]+\.(?:cpp|cxx|cc|c|hpp|hh|h))',
     re.IGNORECASE,
 )
-_TESTABLE_LOGIC_RE = re.compile(
-    r"\b(?:class|struct|enum|namespace)\b|^\s*(?:inline\s+|static\s+)?[A-Za-z_]\w*(?:[\s*&:<>]+[A-Za-z_]\w*)*\s+\w+\s*\(",
-    re.MULTILINE,
+_TYPE_DECLARATION_RE = re.compile(
+    r"\b(?:class|struct|union|enum(?:\s+class)?)\s+([A-Za-z_]\w*)"
+)
+_CALLABLE_IDENTIFIER_RE = re.compile(r"\b([A-Za-z_]\w*)\s*\(")
+_IDENTIFIER_RE = re.compile(r"\b[A-Za-z_]\w*\b")
+_NON_SYMBOL_CALLABLES = frozenset(
+    {
+        "alignof",
+        "catch",
+        "decltype",
+        "for",
+        "if",
+        "noexcept",
+        "requires",
+        "sizeof",
+        "static_assert",
+        "switch",
+        "while",
+    }
+)
+_TYPE_OR_NAMESPACE_RE = re.compile(r"\b(?:class|struct|enum|namespace)\b")
+_FUNCTION_NAME_AT_END_RE = re.compile(
+    r"(?:operator\s*[^\s]+|~?[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)$"
+)
+_NON_FUNCTION_PREFIXES = (
+    "#",
+    "case ",
+    "co_return ",
+    "for ",
+    "if ",
+    "return ",
+    "static_assert ",
+    "switch ",
+    "throw ",
+    "while ",
 )
 
 
@@ -35,17 +80,91 @@ def has_testable_logic(filepath: str, content: str) -> bool:
         return False
     if basename.startswith("test_") and basename.endswith(_SOURCE_EXTENSIONS):
         return False
-    return bool(_TESTABLE_LOGIC_RE.search(content))
-
+    if _TYPE_OR_NAMESPACE_RE.search(content):
+        return True
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if "(" not in line or line.startswith(_NON_FUNCTION_PREFIXES):
+            continue
+        prefix = line.partition("(")[0].rstrip()
+        if _FUNCTION_NAME_AT_END_RE.search(prefix) and (
+            "::" in prefix or any(character.isspace() for character in prefix)
+        ):
+            return True
+    return False
 
 
 def _match_candidate(candidate: Path, production_files: set[str]) -> str | None:
-    resolved = str(candidate.resolve())
-    normalized = {str(Path(path).resolve()): path for path in production_files}
-    if resolved in normalized:
-        return normalized[resolved]
+    absolute = os.path.abspath(candidate)
+    if absolute in production_files:
+        return absolute
+
+    normalized_candidate = os.path.normcase(absolute)
+    matches = [
+        production
+        for production in production_files
+        if os.path.normcase(os.path.abspath(production)) == normalized_candidate
+    ]
+    if len(matches) == 1:
+        return matches[0]
     return None
 
+
+def _unique_suffix_match(spec: str, production_files: set[str]) -> str | None:
+    normalized_spec = spec.replace("\\", "/").lstrip("./")
+    matches = [
+        production
+        for production in production_files
+        if production.replace("\\", "/") == normalized_spec
+        or production.replace("\\", "/").endswith(f"/{normalized_spec}")
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+@cache
+def _declared_header_symbols(header_path: str) -> frozenset[str]:
+    try:
+        header = strip_c_style_comments(Path(header_path).read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError):
+        return frozenset()
+
+    symbols = set(_TYPE_DECLARATION_RE.findall(header))
+    symbols.update(_CALLABLE_IDENTIFIER_RE.findall(header))
+    return frozenset(symbols - _NON_SYMBOL_CALLABLES)
+
+
+@cache
+def _test_body_identifiers(test_path: str) -> frozenset[str]:
+    try:
+        test = strip_c_style_comments(Path(test_path).read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError):
+        return frozenset()
+    return frozenset(_IDENTIFIER_RE.findall(_INCLUDE_RE.sub("", test)))
+
+
+def _test_references_declared_symbol(header_path: str, test_path: str) -> bool:
+    return bool(
+        _declared_header_symbols(header_path) & _test_body_identifiers(test_path)
+    )
+
+
+def _unique_source_companion(
+    header_path: str,
+    test_path: str,
+    production_files: set[str],
+) -> str | None:
+    header = Path(header_path)
+    if header.suffix.lower() not in _HEADER_EXTENSIONS:
+        return None
+    if not _test_references_declared_symbol(header_path, test_path):
+        return None
+    matches = [
+        production
+        for production in production_files
+        if Path(production).suffix.lower() in _SOURCE_EXTENSIONS
+        and Path(production).stem == header.stem
+    ]
+    return matches[0] if len(matches) == 1 else None
 
 
 def resolve_import_spec(
@@ -58,30 +177,22 @@ def resolve_import_spec(
     if not cleaned:
         return None
 
-    test_file = Path(test_path).resolve()
-    candidates: list[Path] = []
-    if cleaned.startswith("./") or cleaned.startswith("../"):
-        candidates.append((test_file.parent / cleaned).resolve())
-    else:
-        candidates.append((test_file.parent / cleaned).resolve())
-        leaf = Path(cleaned).name
-        for production in production_files:
-            if Path(production).name == leaf:
-                return production
+    test_file = Path(os.path.abspath(test_path))
+    candidate = test_file.parent / cleaned
+    matched = _match_candidate(candidate, production_files)
+    if matched:
+        return _unique_source_companion(matched, test_path, production_files) or matched
 
-    for candidate in candidates:
-        matched = _match_candidate(candidate, production_files)
-        if matched:
-            return matched
+    matched = _unique_suffix_match(cleaned, production_files)
+    if matched:
+        return _unique_source_companion(matched, test_path, production_files) or matched
     return None
-
 
 
 def resolve_barrel_reexports(filepath: str, production_files: set[str]) -> set[str]:
     """C/C++ has no barrel-file re-export expansion."""
     del filepath, production_files
     return set()
-
 
 
 def _unique_preserving_order(specs: list[str]) -> list[str]:
@@ -96,7 +207,6 @@ def _unique_preserving_order(specs: list[str]) -> list[str]:
     return ordered
 
 
-
 def _parse_cmake_source_specs(content: str) -> list[str]:
     if not _CMAKE_COMMAND_RE.search(content):
         return []
@@ -109,13 +219,11 @@ def _parse_cmake_source_specs(content: str) -> list[str]:
     return _unique_preserving_order(specs)
 
 
-
 def parse_test_import_specs(content: str) -> list[str]:
     """Return include-like specs from test content and test build files."""
     include_specs = [match.group(1).strip() for match in _INCLUDE_RE.finditer(content)]
     cmake_specs = _parse_cmake_source_specs(content)
     return _unique_preserving_order(include_specs + cmake_specs)
-
 
 
 def _iter_test_tree_ancestors(test_file: Path) -> list[Path]:
@@ -130,8 +238,9 @@ def _iter_test_tree_ancestors(test_file: Path) -> list[Path]:
     return ancestors[: stop_at + 1]
 
 
-
-def discover_test_mapping_files(test_files: set[str], production_files: set[str]) -> set[str]:
+def discover_test_mapping_files(
+    test_files: set[str], production_files: set[str]
+) -> set[str]:
     """Find CMake/Make build files that define test target sources within test trees."""
     del production_files
     discovered: set[str] = set()
@@ -143,7 +252,6 @@ def discover_test_mapping_files(test_files: set[str], production_files: set[str]
                 if candidate.is_file():
                     discovered.add(str(candidate.resolve()))
     return discovered
-
 
 
 def map_test_to_source(test_path: str, production_set: set[str]) -> str | None:
@@ -167,10 +275,11 @@ def map_test_to_source(test_path: str, production_set: set[str]) -> str | None:
             return matched
 
     for production in production_set:
-        if Path(production).name == src_name and not re.search(r"(?:^|[\\/])tests?(?:[\\/]|$)", production):
+        if Path(production).name == src_name and not re.search(
+            r"(?:^|[\\/])tests?(?:[\\/]|$)", production
+        ):
             return production
     return None
-
 
 
 def strip_test_markers(basename: str) -> str | None:
@@ -187,7 +296,6 @@ def strip_test_markers(basename: str) -> str | None:
     if stem.endswith("Test"):
         return f"{stem[:-4]}{ext}"
     return None
-
 
 
 def strip_comments(content: str) -> str:

--- a/desloppify/languages/cxx/tests/test_coverage.py
+++ b/desloppify/languages/cxx/tests/test_coverage.py
@@ -9,7 +9,18 @@ from desloppify.engine.policy.zones import FileZoneMap, Zone, ZoneRule
 
 def _make_zone_map(file_list: list[str]) -> FileZoneMap:
     rules = [
-        ZoneRule(Zone.TEST, ["test_", ".test.", ".spec.", "/tests/", "\\tests\\", "/__tests__/", "\\__tests__\\"]),
+        ZoneRule(
+            Zone.TEST,
+            [
+                "test_",
+                ".test.",
+                ".spec.",
+                "/tests/",
+                "\\tests\\",
+                "/__tests__/",
+                "\\__tests__\\",
+            ],
+        ),
     ]
     return FileZoneMap(file_list, rules)
 
@@ -47,13 +58,61 @@ add_executable(WidgetBehaviorTest
     ]
 
 
+def test_parse_test_import_specs_extracts_qt_cmake_sources():
+    content = """
+qt_add_executable(WidgetBehaviorTest
+    widget_behavior.cpp
+    ../src/widget.cpp
+)
+qt6_add_library(WidgetFixture STATIC ../src/widget_fixture.cpp)
+"""
+    assert cxx_cov.parse_test_import_specs(content) == [
+        "widget_behavior.cpp",
+        "../src/widget.cpp",
+        "../src/widget_fixture.cpp",
+    ]
+
+
+def test_catch2_test_and_assertion_patterns():
+    content = """
+TEST_CASE("widget value", "[widget]") {
+    REQUIRE(widget() == 1);
+    CHECK_FALSE(widget() == 2);
+}
+"""
+
+    assert len(cxx_cov.TEST_FUNCTION_RE.findall(content)) == 1
+    assert (
+        sum(
+            1
+            for line in content.splitlines()
+            if any(pattern.search(line) for pattern in cxx_cov.ASSERT_PATTERNS)
+        )
+        == 2
+    )
+
+
 def test_has_testable_logic_accepts_function_definitions_without_regex_crash():
-    assert cxx_cov.has_testable_logic("widget.cpp", "int widget() { return 1; }\n") is True
-    assert cxx_cov.has_testable_logic("widget_test.cpp", "int widget() { return 1; }\n") is False
+    assert (
+        cxx_cov.has_testable_logic("widget.cpp", "int widget() { return 1; }\n") is True
+    )
+    assert (
+        cxx_cov.has_testable_logic("widget_test.cpp", "int widget() { return 1; }\n")
+        is False
+    )
+
+
+def test_has_testable_logic_rejects_long_non_function_token_sequence():
+    content = ("TypeName " * 10_000) + "value;\n"
+
+    assert cxx_cov.has_testable_logic("widget.cpp", content) is False
 
 
 def test_has_testable_logic_excludes_test_prefix_files():
-    assert cxx_cov.has_testable_logic("test_widget.cpp", "int widget() { return 1; }\n") is False
+    assert (
+        cxx_cov.has_testable_logic("test_widget.cpp", "int widget() { return 1; }\n")
+        is False
+    )
 
 
 def test_map_test_to_source_and_resolve_import_spec(tmp_path):
@@ -65,15 +124,61 @@ def test_map_test_to_source_and_resolve_import_spec(tmp_path):
     test_file.parent.mkdir(parents=True)
     source.write_text("int widget() { return 1; }\n", encoding="utf-8")
     header.write_text("int widget();\n", encoding="utf-8")
-    test_file.write_text('#include "../src/widget.hpp"\n', encoding="utf-8")
+    test_file.write_text(
+        '#include "../src/widget.hpp"\nint use_widget() { return widget(); }\n',
+        encoding="utf-8",
+    )
 
     production = {str(source.resolve()), str(header.resolve())}
 
-    assert cxx_cov.map_test_to_source(str(test_file), production) == str(source.resolve())
-    assert (
-        cxx_cov.resolve_import_spec("../src/widget.hpp", str(test_file), production)
-        == str(header.resolve())
+    assert cxx_cov.map_test_to_source(str(test_file), production) == str(
+        source.resolve()
     )
+    assert cxx_cov.resolve_import_spec(
+        "../src/widget.hpp", str(test_file), production
+    ) == str(source.resolve())
+
+
+def test_match_candidate_uses_case_normalized_lexical_paths(tmp_path, monkeypatch):
+    expected = _write(tmp_path, "include/widget.hpp", "int widget();\n")
+    monkeypatch.setattr(cxx_cov.os.path, "normcase", lambda value: value.lower())
+
+    resolved = cxx_cov._match_candidate(Path(expected.upper()), {expected})
+
+    assert resolved == expected
+
+
+def test_resolve_import_spec_does_not_guess_between_same_stem_sources(tmp_path):
+    header = _write(tmp_path, "include/widget.hpp", "int widget();\n")
+    source_a = _write(tmp_path, "src/a/widget.cpp", "int widget() { return 1; }\n")
+    source_b = _write(tmp_path, "src/b/widget.cpp", "int widget() { return 2; }\n")
+    test_file = _write(
+        tmp_path,
+        "tests/widget_behavior.cpp",
+        "#include <widget.hpp>\nint value = widget();\n",
+    )
+
+    resolved = cxx_cov.resolve_import_spec(
+        "widget.hpp",
+        test_file,
+        {header, source_a, source_b},
+    )
+
+    assert resolved == header
+
+
+def test_resolve_import_spec_keeps_unused_header_as_header(tmp_path):
+    header = _write(tmp_path, "include/widget.hpp", "int widget();\n")
+    source = _write(tmp_path, "src/widget.cpp", "int widget() { return 1; }\n")
+    test_file = _write(tmp_path, "tests/other_behavior.cpp", "#include <widget.hpp>\n")
+
+    resolved = cxx_cov.resolve_import_spec(
+        "widget.hpp",
+        test_file,
+        {header, source},
+    )
+
+    assert resolved == header
 
 
 def test_discover_test_mapping_files_finds_cmakelists_within_test_tree(tmp_path):
@@ -82,8 +187,13 @@ def test_discover_test_mapping_files_finds_cmakelists_within_test_tree(tmp_path)
     nested_cmake = tmp_path / "tests" / "kernel_parity" / "CMakeLists.txt"
     test_file.parent.mkdir(parents=True)
     test_file.write_text("// test\n", encoding="utf-8")
-    cmake_file.write_text("add_executable(WidgetBehaviorTest widget_behavior.cpp ../src/widget.cpp)\n", encoding="utf-8")
-    nested_cmake.write_text("add_library(ParityHelpers ../src/widget.hpp)\n", encoding="utf-8")
+    cmake_file.write_text(
+        "add_executable(WidgetBehaviorTest widget_behavior.cpp ../src/widget.cpp)\n",
+        encoding="utf-8",
+    )
+    nested_cmake.write_text(
+        "add_library(ParityHelpers ../src/widget.hpp)\n", encoding="utf-8"
+    )
 
     discovered = cxx_cov.discover_test_mapping_files({str(test_file.resolve())}, set())
 
@@ -95,7 +205,7 @@ def test_detect_test_coverage_uses_cmake_test_sources_for_direct_mapping(tmp_pat
     test_file = _write(
         tmp_path,
         "tests/widget_behavior.cpp",
-        '#include <gtest/gtest.h>\n\nTEST(WidgetBehavior, Smoke) {\n    EXPECT_EQ(1, 1);\n}\n',
+        "#include <gtest/gtest.h>\n\nTEST(WidgetBehavior, Smoke) {\n    EXPECT_EQ(1, 1);\n}\n",
     )
     _write(
         tmp_path,
@@ -118,6 +228,48 @@ def test_detect_test_coverage_uses_cmake_test_sources_for_direct_mapping(tmp_pat
     untested = [
         entry
         for entry in entries
-        if entry["file"] == prod and entry["detail"]["kind"] in {"untested_module", "untested_critical"}
+        if entry["file"] == prod
+        and entry["detail"]["kind"] in {"untested_module", "untested_critical"}
     ]
     assert untested == []
+
+
+def test_detect_test_coverage_maps_public_header_to_implementation_and_internal_header(
+    tmp_path,
+):
+    public_header = _write(tmp_path, "include/widget.hpp", "int widget();\n")
+    internal_header = _write(
+        tmp_path, "src/widget_internal.hpp", "int widget_value();\n"
+    )
+    source = _write(
+        tmp_path,
+        "src/widget.cpp",
+        '#include "../include/widget.hpp"\n#include "widget_internal.hpp"\n'
+        "int widget() { return widget_value(); }\n" * 12,
+    )
+    test_file = _write(
+        tmp_path,
+        "tests/widget_behavior.cpp",
+        '#include <widget.hpp>\n\nTEST_CASE("widget value") {\n    REQUIRE(widget() == 1);\n}\n',
+    )
+
+    files = [public_header, internal_header, source, test_file]
+    zone_map = _make_zone_map(files)
+    graph = {
+        public_header: {"imports": set(), "importer_count": 2},
+        internal_header: {"imports": set(), "importer_count": 1},
+        source: {"imports": {public_header, internal_header}, "importer_count": 0},
+        test_file: {"imports": {public_header}, "importer_count": 0},
+    }
+
+    entries, potential = detect_test_coverage(graph, zone_map, "cxx")
+
+    assert potential > 0
+    uncovered = {
+        entry["file"]
+        for entry in entries
+        if entry["detail"]["kind"] in {"untested_module", "untested_critical"}
+    }
+    assert source not in uncovered
+    assert public_header not in uncovered
+    assert internal_header not in uncovered


### PR DESCRIPTION
## Summary
- map exercised public headers to a unique same-stem C/C++ implementation while retaining ambiguity and unused-include guards
- recognize Catch2 tests/assertions and Qt CMake target commands
- remove repeated filesystem path resolution and replace the catastrophic C++ testability regex with bounded lexical checks

## Verification
- `python -m ruff check desloppify/languages/cxx/test_coverage.py desloppify/languages/cxx/tests/test_coverage.py`
- `python -m pytest desloppify/languages/cxx/tests -q` (53 passed)
- read-only calibration against dicom_viewer: 478-file graph completes; representative `beam_geometry.cpp`, `rt_plan_reader.cpp`, and `rt_dose_command_service.cpp` false gaps are removed

The broader shared coverage suite currently has unrelated Windows path-normalization failures in existing Python/TypeScript tests; this change does not touch those paths.