### PR TITLE
fix: bound C++ extractor regex backtracking

### DIFF
--- a/desloppify/languages/cxx/extractors.py
+++ b/desloppify/languages/cxx/extractors.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import hashlib
-from os import PathLike
 import re
+from os import PathLike
 from pathlib import Path
 
 from desloppify.base.discovery.file_paths import resolve_path
@@ -13,7 +13,17 @@ from desloppify.engine.detectors.base import FunctionInfo
 from desloppify.languages.cxx._parse_helpers import find_matching_brace
 
 CXX_SOURCE_EXTENSIONS = (".c", ".cc", ".cpp", ".cxx")
-CXX_HEADER_EXTENSIONS = (".h", ".hh", ".hpp", ".hxx", ".ipp", ".inl", ".tpp", ".txx", ".tcc")
+CXX_HEADER_EXTENSIONS = (
+    ".h",
+    ".hh",
+    ".hpp",
+    ".hxx",
+    ".ipp",
+    ".inl",
+    ".tpp",
+    ".txx",
+    ".tcc",
+)
 CXX_EXTENSIONS = [*CXX_SOURCE_EXTENSIONS, *CXX_HEADER_EXTENSIONS]
 CXX_FILE_EXCLUSIONS = [
     "build",
@@ -26,7 +36,7 @@ CXX_FILE_EXCLUSIONS = [
 _FUNC_DECL_RE = re.compile(
     r"(?:(?:^)|(?<=[;}\n]))\s*"
     r"(?:(?:inline|static|constexpr|virtual|explicit|friend|extern|typename)\s+)*"
-    r"(?:[A-Za-z_~]\w*(?:::[A-Za-z_~]\w*)*(?:<[^;{}()]+>)?[\s*&:]+)+"
+    r"(?>(?:[A-Za-z_~]\w*(?:::[A-Za-z_~]\w*)*(?:<[^;{}()]+>)?[\s*&:]+)+)"
     r"([A-Za-z_~]\w*(?:::[A-Za-z_~]\w*)*)\s*"
     r"\(([^()]*)\)\s*"
     r"(?:const\s*)?"
@@ -73,7 +83,9 @@ def _extract_params(param_str: str) -> list[str]:
         token = raw.strip().split("=")[0].strip()
         if not token:
             continue
-        parts = [part for part in token.replace("&", " ").replace("*", " ").split() if part]
+        parts = [
+            part for part in token.replace("&", " ").replace("*", " ").split() if part
+        ]
         if not parts:
             continue
         name = parts[-1]
@@ -132,8 +144,8 @@ def extract_cxx_functions(filepath: str) -> list[FunctionInfo]:
 
 
 def extract_all_cxx_functions(
-    path_or_files: Path | str | PathLike[str] | list[str]
- ) -> list[FunctionInfo]:
+    path_or_files: Path | str | PathLike[str] | list[str],
+) -> list[FunctionInfo]:
     """Extract C/C++ functions from either a scan root or an explicit file list."""
     if isinstance(path_or_files, (Path, str, PathLike)):
         file_list = find_cxx_files(Path(path_or_files))

--- a/desloppify/languages/cxx/tests/test_extractors.py
+++ b/desloppify/languages/cxx/tests/test_extractors.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import desloppify.languages.cxx.extractors as cxx_extractors
-from desloppify.languages.cxx.extractors import extract_all_cxx_functions, find_cxx_files
+from desloppify.languages.cxx.extractors import (
+    extract_all_cxx_functions,
+    find_cxx_files,
+)
 
 
 def test_extract_cxx_functions_and_classes(tmp_path):
@@ -54,10 +58,27 @@ def test_find_cxx_files_includes_common_header_only_extensions(tmp_path):
     for path in files:
         path.write_text("// test\n")
 
-    discovered = {str(Path(filepath).resolve()) for filepath in find_cxx_files(tmp_path)}
+    discovered = {
+        str(Path(filepath).resolve()) for filepath in find_cxx_files(tmp_path)
+    }
 
     assert discovered == {str(path.resolve()) for path in files}
 
 
 def test_cxx_extractors_use_local_brace_helper():
-    assert cxx_extractors.find_matching_brace.__module__ == "desloppify.languages.cxx._parse_helpers"
+    assert (
+        cxx_extractors.find_matching_brace.__module__
+        == "desloppify.languages.cxx._parse_helpers"
+    )
+
+
+def test_function_extraction_bounds_qualified_name_backtracking(tmp_path):
+    source = tmp_path / "adversarial.cpp"
+    source.write_text("::".join(["Type"] * 21) + " value = source;\n")
+
+    started = time.perf_counter()
+    functions = extract_all_cxx_functions([str(source)])
+    elapsed = time.perf_counter() - started
+
+    assert functions == []
+    assert elapsed < 0.25


### PR DESCRIPTION
## Problem

C++ signature extraction can spend hours in catastrophic regex backtracking on qualified-name declarations. In a 501-file C++ scan, generated/include/viewer/automation/api_types.hpp was the first reproducible stall; a 21-segment synthetic declaration took 3.854 seconds by itself.

## Fix

Make the repeated C++ return-type prefix atomic so failed function-declaration matches cannot repartition the same qualified tokens exponentially. Add an adversarial regression test with a generous timing bound.

## Evidence

- Synthetic adversarial declaration: 3.854 s to 0.000019 s
- Previously stalling api_types.hpp: 0.055901 s
- All 501 C++ files: 5.261096 s, 2,263 functions
- C++ plugin and generic signature detector tests: 64 passed
- Focused extractor tests: 6 passed